### PR TITLE
status: use has_finished_time instead of has_log

### DIFF
--- a/src/status.wsgi
+++ b/src/status.wsgi
@@ -27,7 +27,7 @@ def application(environ, start_response):
                         _("Invalid password"))
 
     status = "PENDING"
-    if task.has_log():
+    if task.has_finished_time():
         if task.has_backtrace():
             status = "FINISHED_SUCCESS"
         else:


### PR DESCRIPTION
Task has log from the beginning.

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>