### PR TITLE
Set "crash" inside get_crash_cmd file if the file does not exist, fix…

### DIFF
--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -2160,7 +2160,11 @@ class RetraceTask:
 
     def get_crash_cmd(self):
         """Gets the contents of CRASH_CMD_FILE"""
-        return self.get(RetraceTask.CRASH_CMD_FILE, maxlen=1 << 22)
+        result = self.get(RetraceTask.CRASH_CMD_FILE, maxlen=1 << 22)
+        if result is None:
+            self.set_crash_cmd("crash")
+            return "crash"
+        return result
 
     def set_crash_cmd(self, data):
         """Writes data to CRASH_CMD_FILE"""

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -135,7 +135,7 @@ if __name__ == "__main__":
             os.execvp(cmdline[0], cmdline)
 
         if args.action == "shell":
-            if task.get_use_mock(kernelver):
+            if task.use_mock(kernelver):
                 cmdline = ["/usr/bin/mock", "--configdir",
                            os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid()), "shell"]
 


### PR DESCRIPTION
… get_use_mock typeo.

This patch fixes a couple oversights in the previous patcheset to introduce crash_cmd and use_mock.

First, for older tasks which do not have a 'crash_cmd' file, we need to create one by
default.  Otherwise, any retrace-server-worker or retrace-server-interact command may
fail as follows:
Traceback (most recent call last):
  File "/usr/bin/retrace-server-interact", line 117, in <module>
    crash_cmd = task.get_crash_cmd().split()
AttributeError: 'NoneType' object has no attribute 'split'

Second, retrace-server-interact contained a 'get_use_mock' function rather than 'use_mock'
This caused the following:
$ retrace-server-interact 757071668 shell
Traceback (most recent call last):
  File "/usr/bin/retrace-server-interact", line 138, in <module>
    if task.get_use_mock(kernelver):
AttributeError: RetraceTask instance has no attribute 'get_use_mock'

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>