### PR TITLE
Add VMCoreTask and UsrCoreTask to config

### DIFF
--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -157,6 +157,8 @@ CONFIG = {
   "AllowExternalDir": False,
   "AllowInteractive": False,
   "AllowTaskManager": False,
+  "AllowVMCoreTask" : False,
+  "AllowUsrCoreTask" : False,
   "TaskManagerAuthDelete": False,
   "TaskManagerDeleteUsers": [],
   "UseFTPTasks": False,


### PR DESCRIPTION
/manager page returned error 500 because VMCoreTask and UsrCoreTask missed in config variable

Signed-off-by: Patrik Helia <phelia@redhat.com>