### PR TITLE
Fix retrace-server-worker --restart backtrace due to unwriteable retr…

### DIFF
--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -24,16 +24,16 @@ if __name__ == "__main__":
         sys.stderr.write("Task '%d' does not exist\n" % cmdline.task_id)
         exit(1)
 
-    worker = task.create_worker()
-    worker.begin_logging()
-
     if task.has_status():
         if not cmdline.restart:
-            log_error("%s has already been executed for task %d" % (sys.argv[0], cmdline.task_id))
-            log_info("You can use --restart option if you really want to restart the task")
-            worker._fail()
+            sys.stderr.write("%s has already been executed for task %d\n" % (sys.argv[0], cmdline.task_id))
+            sys.stdout.write("You can use --restart option if you really want to restart the task\n")
+            exit(1)
 
         task.reset()
+
+    worker = task.create_worker()
+    worker.begin_logging()
 
     if not cmdline.foreground:
         try:


### PR DESCRIPTION
…ace_log

After refactor of RetraceWorker we're trying to call 'begin_logging' a little
too early.  This results in a backtrace as follows since retrace_log is not
writeable.

$ retrace-server-worker --restart 984648283
Traceback (most recent call last):
  File "/usr/bin/retrace-server-worker", line 28, in <module>
    worker.begin_logging()
  File "/usr/lib/python2.6/site-packages/retrace/retrace_worker.py", line 17, in begin_logging
    self.task._get_file_path(RetraceTask.LOG_FILE))
  File "/usr/lib64/python2.6/logging/__init__.py", line 827, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib64/python2.6/logging/__init__.py", line 846, in _open
    stream = open(self.baseFilename, self.mode)
IOError: [Errno 13] Permission denied: '/retrace/tasks/984648283/retrace_log'
$ ls -l /retrace/tasks/984648283/retrace_log
-rw-r--r--. 1 retrace retrace-group 2860 Dec 15 16:09 /retrace/tasks/984648283/retrace_log

Fix this by moving the call to begin_logging just below the point at which
we call task.reset().  Inside task.reset() we clear all files which are associated
with the task state, and so we can easily open the retrace_log file again.
This restores the original behavior of --restart.

After the refactor we do add a check to see if --restart was on the commandline or not.
If the status file is present for the task, but the user did not specify --restart,
it makes more sense to send the messages to stdout / stderr than the log file.

Also it's important to note after this patch we don't create the worker until after
the task has been reset.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>