### PR TITLE
Mock logging into retrace task's dir

### DIFF
--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -1457,6 +1457,7 @@ class RetraceTask:
     LOG_FILE = "retrace_log"
     MANAGED_FILE = "managed"
     MISC_DIR = "misc"
+    MOCK_LOG_DIR = "log"
     NOTES_FILE = "notes"
     NOTIFY_FILE = "notify"
     PASSWORD_FILE = "password"
@@ -2254,7 +2255,7 @@ class RetraceTask:
               RetraceTask.STARTED_FILE, RetraceTask.STATUS_FILE,
               RetraceTask.TYPE_FILE, RetraceTask.MISC_DIR,
               RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
-              RetraceTask.URL_FILE ]:
+              RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR ]:
 
                 path = os.path.join(self._savedir, f)
                 try:
@@ -2274,7 +2275,7 @@ class RetraceTask:
                          RetraceTask.PROGRESS_FILE, RetraceTask.STARTED_FILE,
                          RetraceTask.STATUS_FILE, RetraceTask.MOCK_DEFAULT_CFG,
                          RetraceTask.MOCK_SITE_DEFAULTS_CFG, RetraceTask.MOCK_LOGGING_INI,
-                         RetraceTask.CRASH_CMD_FILE]:
+                         RetraceTask.CRASH_CMD_FILE, RetraceTask.MOCK_LOG_DIR]:
             try:
                 os.unlink(os.path.join(self._savedir, filename))
             except OSError as ex:

--- a/src/lib/retrace_worker.py
+++ b/src/lib/retrace_worker.py
@@ -415,7 +415,7 @@ class RetraceWorker(object):
         task.set_status(STATUS_INIT)
         log_info(STATUS[STATUS_INIT])
 
-        self._retrace_run(25, ["/usr/bin/mock", "init", "--configdir", task.get_savedir()])
+        self._retrace_run(25, ["/usr/bin/mock", "init", "--resultdir", task.get_savedir() + "/log", "--configdir", task.get_savedir()])
 
         self.hook_post_prepare_mock()
         self.hook_pre_retrace()


### PR DESCRIPTION
Saving mock log into retrace directory and add mock log directory into retrace
directory whitelist because all other files and folders are deleted after task
end.

Signed-off-by: Patrik Helia <phelia@redhat.com>