### PR TITLE
Updating the stats handling and including a RHEL plugin

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -1,2 +1,2 @@
-plugins_PYTHON = __init__.py fedora.py
+plugins_PYTHON = __init__.py fedora.py rhel.py
 pluginsdir = $(datadir)/retrace-server/plugins

--- a/src/plugins/fedora.py
+++ b/src/plugins/fedora.py
@@ -3,6 +3,33 @@ import re
 distribution = "fedora"
 abrtparser = re.compile("^Fedora release ([0-9]+) \(([^\)]+)\)$")
 guessparser = re.compile("\.fc([0-9]+)")
+displayrelease = "Fedora release"
+versionlist = [
+  "fc1",
+  "fc2",
+  "fc3",
+  "fc4",
+  "fc5",
+  "fc6",
+  "fc7",
+  "fc8",
+  "fc9",
+  "fc10",
+  "fc11",
+  "fc12",
+  "fc13",
+  "fc14",
+  "fc15",
+  "fc16",
+  "fc17",
+  "fc18",
+  "fc19",
+  "fc20",
+  "fc21",
+  "fc22",
+  "fc23",
+  "fc24",
+]
 repos = [
   [
     "rsync://dl.fedoraproject.org/fedora-enchilada/linux/releases/$VER/Everything/$ARCH/os/Packages/*/*.rpm",

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -1,0 +1,16 @@
+import re
+
+distribution = "rhel"
+abrtparser = re.compile("^Red Hat Enterprise Linux release ([0-9]+) \(([^\)]+)\)$")
+guessparser = re.compile("\.el([0-9]+)")
+displayrelease = "Red Hat Enterprise Linux release"
+versionlist = [
+  "el1",
+  "el2",
+  "el3",
+  "el4",
+  "el5",
+  "el6",
+  "el7",
+]
+repos = [[]]

--- a/src/stats.xhtml
+++ b/src/stats.xhtml
@@ -86,18 +86,7 @@
               <th>{_Release}</th>
               <th>{_Count}</th>
             </tr>
-            <tr class="odd">
-              <td>Fedora 15</td>
-              <td>{f15}</td>
-            </tr>
-            <tr class="even">
-              <td>Fedora 16</td>
-              <td>{f16}</td>
-            </tr>
-            <tr class="odd">
-              <td>Fedora 17</td>
-              <td>{f17}</td>
-            </tr>
+            {release_rows}
           </table>
           <h3>{_Retraced_packages}</h3>
           <table>


### PR DESCRIPTION
Prior to the below commits, the release entries of the stats page were hard-coded to query and present the following releases.

   Fedora 15
   Fedora 16
   Fedora 17

The commits below alter this behaviour to allow the releases to be determined based off of the plugins present. For this process, The Fedora plugin has been refreshed to allow it to determine releases for all of the presently available Fedora releases. At the same time, a Red Hat Enterprise Linux plugin is also present to allow, though it currently does not include repository information to allow it to function with the retrace-server-reposync utility.