### PR TITLE
Rhbz1314973 refactor kernelver detection v3

### DIFF
--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -196,7 +196,7 @@ def application(environ, start_response):
                             _("Required file '%s' is missing") % required_file)
 
     if task.get_type() in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE]:
-        strip_vmcore(os.path.join(crashdir, "vmcore"))
+        task.strip_vmcore(os.path.join(crashdir, "vmcore"))
 
     task.start()
 

--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -1466,6 +1466,7 @@ class RetraceTask:
     STATUS_FILE = "status"
     TYPE_FILE = "type"
     URL_FILE = "url"
+    VMLINUX_FILE = "vmlinux"
     MOCK_DEFAULT_CFG = "default.cfg"
     MOCK_SITE_DEFAULTS_CFG = "site-defaults.cfg"
     MOCK_LOGGING_INI = "logging.ini"
@@ -1797,6 +1798,16 @@ class RetraceTask:
 
     def set_url(self, value):
         self.set(RetraceTask.URL_FILE, value)
+
+    def has_vmlinux(self):
+        return self.has(RetraceTask.VMLINUX_FILE)
+
+    def get_vmlinux(self):
+        """Gets the contents of VMLINUX_FILE"""
+        return self.get(RetraceTask.VMLINUX_FILE, maxlen=1 << 22)
+
+    def set_vmlinux(self, value):
+        self.set(RetraceTask.VMLINUX_FILE, value)
 
     def download_block(self, data):
         self._progress_write_func(data)
@@ -2254,7 +2265,7 @@ class RetraceTask:
               RetraceTask.STARTED_FILE, RetraceTask.STATUS_FILE,
               RetraceTask.TYPE_FILE, RetraceTask.MISC_DIR,
               RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
-              RetraceTask.URL_FILE ]:
+              RetraceTask.URL_FILE, RetraceTask.VMLINUX_FILE ]:
 
                 path = os.path.join(self._savedir, f)
                 try:
@@ -2274,7 +2285,7 @@ class RetraceTask:
                          RetraceTask.PROGRESS_FILE, RetraceTask.STARTED_FILE,
                          RetraceTask.STATUS_FILE, RetraceTask.MOCK_DEFAULT_CFG,
                          RetraceTask.MOCK_SITE_DEFAULTS_CFG, RetraceTask.MOCK_LOGGING_INI,
-                         RetraceTask.CRASH_CMD_FILE]:
+                         RetraceTask.CRASH_CMD_FILE, RetraceTask.VMLINUX_FILE]:
             try:
                 os.unlink(os.path.join(self._savedir, filename))
             except OSError as ex:

--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -1780,6 +1780,7 @@ class RetraceTask:
 
         if child.returncode:
             log_warn("Unable to list modules: crash exited with %d:\n%s" % (child.returncode, stdout))
+            self.set_vmlinux(vmlinux)
             return vmlinux
 
         modules = []
@@ -1799,6 +1800,7 @@ class RetraceTask:
 
         cache_files_from_debuginfo(debuginfo, debugdir_base, todo)
 
+        self.set_vmlinux(vmlinux)
         return vmlinux
 
     def strip_vmcore(self, vmcore, kernelver=None, crash_cmd=["crash"]):

--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -1805,7 +1805,7 @@ class RetraceTask:
 
     def strip_vmcore(self, vmcore, kernelver=None, crash_cmd=["crash"]):
         try:
-            vmlinux = self.prepare_debuginfo(self, vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
+            vmlinux = self.prepare_debuginfo(vmcore, chroot=None, kernelver=kernelver, crash_cmd=crash_cmd)
         except Exception as ex:
             log_warn("prepare_debuginfo failed: %s" % ex)
             return

--- a/src/lib/retrace_worker.py
+++ b/src/lib/retrace_worker.py
@@ -614,7 +614,7 @@ class RetraceWorker(object):
             # no locks required, mock locks itself
             try:
                 self.hook_pre_prepare_debuginfo()
-                vmlinux = prepare_debuginfo(vmcore, cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
+                vmlinux = task.prepare_debuginfo(vmcore, cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
                 self.hook_post_prepare_debuginfo()
 
                 self.hook_pre_retrace()
@@ -689,7 +689,7 @@ class RetraceWorker(object):
             try:
                 self.hook_pre_prepare_debuginfo()
                 crash_cmd = task.get_crash_cmd().split()
-                vmlinux = prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
+                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
                 task.set_crash_cmd(' '.join(crash_cmd))
                 self.hook_post_prepare_debuginfo()
             except Exception as ex:

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -115,15 +115,21 @@ if __name__ == "__main__":
         if args.action == "crash":
             if not task.use_mock(kernelver):
                 crash_cmd = task.get_crash_cmd().split()
-                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
-                task.set_crash_cmd(' '.join(crash_cmd))
+                if task.has_vmlinux():
+                    vmlinux = task.get_vmlinux()
+                else:
+                    vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
+                    task.set_crash_cmd(' '.join(crash_cmd))
                 if task.has_crashrc():
                     cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore, vmlinux]
                 else:
                     cmdline = task.get_crash_cmd().split() + [vmcore, vmlinux]
             else:
                 cfgdir = os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
-                vmlinux = task.prepare_debuginfo(vmcore, chroot=cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
+                if task.has_vmlinux():
+                    vmlinux = task.get_vmlinux()
+                else:
+                    vmlinux = task.prepare_debuginfo(vmcore, chroot=cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
                                "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore, vmlinux)]

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         if args.action == "crash":
             if not task.use_mock(kernelver):
                 crash_cmd = task.get_crash_cmd().split()
-                vmlinux = prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
+                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
                 task.set_crash_cmd(' '.join(crash_cmd))
                 if task.has_crashrc():
                     cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore, vmlinux]
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                     cmdline = task.get_crash_cmd().split() + [vmcore, vmlinux]
             else:
                 cfgdir = os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
-                vmlinux = prepare_debuginfo(vmcore, chroot=cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
+                vmlinux = task.prepare_debuginfo(vmcore, chroot=cfgdir, kernelver=kernelver, crash_cmd=task.get_crash_cmd().split())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
                                "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore, vmlinux)]


### PR DESCRIPTION
This is hopefully the last version of these patches.
Fixes
1. Problem with create.wsgi reported after testing by Patrik Helia
[Fri Mar 11 08:24:48 2016] [error] [client 10.34.24.100] mod_wsgi (pid=5396): Exception occurred processing WSGI script '/usr/share/retrace-server/create.wsgi'. [Fri Mar 11 08:24:48 2016] [error] [client 10.34.24.100] Traceback (most recent call last): 
[Fri Mar 11 08:24:48 2016] [error] [client 10.34.24.100] File "/usr/share/retrace-server/create.wsgi", line 199, in application 
[Fri Mar 11 08:24:48 2016] [error] [client 10.34.24.100] strip_vmcore(os.path.join(crashdir, "vmcore")) 
[Fri Mar 11 08:24:48 2016] [error] [client 10.34.24.100] NameError: global name 'strip_vmcore' is not defined

2. Small problem with strip_vmcore incorrectly calling prepare_debuginfo
    There was a small problem with strip_vmcore which incorrectly was calling prepare_debuginfo.
    This would result in the following error in the retrace_log:
     2016-03-11 06:03:59 prepare_debuginfo failed: execv() arg 2 must contain only strings
