### PR TITLE
manager.wsgi: Move the FTP query operation to an AJAX operation - Resolves rhbz1124462

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ interface_PYTHON = backtrace.wsgi \
                    index.wsgi \
                    log.wsgi \
                    manager.wsgi \
+                   ftp.wsgi \
                    settings.wsgi \
                    start.wsgi \
                    stats.wsgi \

--- a/src/config/retrace-server-httpd.conf
+++ b/src/config/retrace-server-httpd.conf
@@ -3,6 +3,7 @@ WSGIDaemonProcess retrace user=retrace group=retrace processes=5 threads=3
 WSGIProcessGroup retrace
 
 WSGIScriptAliasMatch ^/manager(/.*)?$ /usr/share/retrace-server/manager.wsgi
+WSGIScriptAliasMatch ^/ftp(/.*)?$ /usr/share/retrace-server/ftp.wsgi
 WSGIScriptAliasMatch ^/settings$ /usr/share/retrace-server/settings.wsgi
 WSGIScriptAliasMatch ^/create$ /usr/share/retrace-server/create.wsgi
 WSGIScriptAliasMatch ^/stats$ /usr/share/retrace-server/stats.wsgi
@@ -29,7 +30,7 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
     </IfModule>
 </Directory>
 
-<LocationMatch "^/(manager(/.*)?|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete))?)?$">
+<LocationMatch "^/(manager(/.*)?|ftp|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete))?)?$">
     Options -Indexes -FollowSymLinks
     <IfModule mod_authz_core.c>
         # Apache 2.4

--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+import fnmatch
+import re
+import urllib
+import urlparse
+from retrace import *
+
+MANAGER_URL_PARSER = re.compile("^(.*/manager)(/(([^/]+)(/(__custom__|start|backtrace|savenotes|caseno|notify|delete(/(sure/?)?)?|misc/([^/]+)/?)?)?)?)?$")
+tableheader = """
+          <table>
+            <tr>
+              <th class="tablename">FTP files</th>
+            </tr>
+"""
+tablefooter = """
+          </table>
+"""
+
+def async_ftp_list_dir(filterexp):
+    available = []
+    rawtasklist = ftp_list_dir(CONFIG["FTPDir"])
+
+    if filterexp:
+        tasklist = sorted(fnmatch.filter(rawtasklist, filterexp))
+    else:
+        tasklist = sorted(rawtasklist, cmp=cmp_vmcores_first)
+
+    for fname in tasklist:
+        available.append("<tr><td><a href=\"manager/%s\">%s</a></td></tr>" \
+                         % (urllib.quote(fname), fname))
+
+    available.append(tablefooter)
+    return "\n            ".join(available)
+
+def application(environ, start_response):
+    request = Request(environ)
+
+    _ = parse_http_gettext("%s" % request.accept_language,
+                           "%s" % request.accept_charset)
+
+    get = urlparse.parse_qs(request.query_string)
+    filterexp = None
+    if "filterexp" in get:
+        filterexp = get["filterexp"][0]
+
+    output = ""
+    output += tableheader
+    output += async_ftp_list_dir(filterexp)
+    output += tablefooter
+
+    return response(start_response, "200 OK", output, [("Content-Type", "text/html")])

--- a/src/manager.xhtml
+++ b/src/manager.xhtml
@@ -177,6 +177,8 @@
     </style>
   </head>
   <body>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    {ftpscript}
     <h1>{sitename}</h1>
     <form method="get" id="filter">
       <input type="text" name="filter" />
@@ -191,7 +193,6 @@
             <tr>
               <th class="tablename">{available_str}</th>
             </tr>
-            {available}
           </table>
         </div>
       </div>


### PR DESCRIPTION
In the event that UseFTPTasks is enabled, and the backing FTP server
contains an exceptional number of files in it, the resulting query
can take an extreme amount of time to return. In the meantime, the
manager UI is unavailable for use to access existing tasks.

This patch implements an AJAX call to a new "ftp" interface. It will
return the remainder of the "FTP files" table by default, but will
also adhere to the "filter=" variable passing to limit the resulting
table.

Signed-off-by: Kyle Walker <walker.kyle.t@gmail.com>