### PR TITLE
Make the reposync tool more verbose if required

### DIFF
--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -175,11 +175,13 @@ if __name__ == "__main__":
     argparser.add_argument("distribution", type=str, help="Distribution name")
     argparser.add_argument("version", type=str, help="Release version")
     argparser.add_argument("architecture", type=str, help="CPU architecture")
-    argparser.add_argument("-v", "--verbose", action="store_const",
-                           default=logging.INFO, const=logging.DEBUG)
+    argparser.add_argument("-v", "--verbose", action="count", default=0)
     args = argparser.parse_args()
 
-    logging.basicConfig(level=args.verbose)
+    if args.verbose == 0:
+        logging.basicConfig(level=logging.INFO)
+    else:
+        logging.basicConfig(level=logging.DEBUG)
 
     distribution = args.distribution
     version = args.version
@@ -220,7 +222,9 @@ if __name__ == "__main__":
         log_error("Unable to set lock")
         sys.exit(3)
 
-    null = open(os.devnull, "w")
+    null = None
+    if args.verbose < 2:
+        null = open(os.devnull, "w")
 
     try:
         targetdir = os.path.join(CONFIG["RepoDir"], targetid)
@@ -309,7 +313,8 @@ if __name__ == "__main__":
 
         retcode = call(cmd, stdout=null, stderr=null)
     finally:
-        null.close()
+        if null:
+            null.close()
         unlock(lockfile)
 
     if retcode != 0:


### PR DESCRIPTION
Sometimes someone does something bad to repo files and directories and
rsync's output seems to be the best source for fixing such problems.

This commit adds possibility to pass more '-v' on command line. If there
are more 2 or more '-v's, then output of executed commands (rsync,
createrepo) is forwarded to stdout/stderr; otherwise the output goes to
/dev/null.

Signed-off-by: Jakub Filak jfilak@redhat.com
