### PR TITLE
Allow package names with Epoch

### DIFF
--- a/src/lib/retrace.py
+++ b/src/lib/retrace.py
@@ -70,7 +70,7 @@ INPUT_CHARSET_PARSER = re.compile("^([a-zA-Z0-9\-]+)(,.*)?$")
 #en_GB, sk-SK, cs, fr etc.
 INPUT_LANG_PARSER = re.compile("^([a-z]{2}([_\-][A-Z]{2})?)(,.*)?$")
 #characters allowed by Fedora Naming Guidelines
-INPUT_PACKAGE_PARSER = re.compile("^[a-zA-Z0-9\-\.\_\+]+$")
+INPUT_PACKAGE_PARSER = re.compile("^([1-9][0-9]*:)?[a-zA-Z0-9\-\.\_\+]+$")
 #architecture (i386, x86_64, armv7hl, mips4kec)
 INPUT_ARCH_PARSER = re.compile("^[a-zA-Z0-9_]+$")
 #name-version-arch (fedora-16-x86_64, rhel-6.2-i386, opensuse-12.1-x86_64)


### PR DESCRIPTION
Epoch should be a number and 0 means it is not set.

https://fedoraproject.org/wiki/Packaging:Guidelines#Use_of_Epochs
https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s03.html