### PR TITLE
Correct eu-unstrip parser if FILE is -

### DIFF
--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -174,6 +174,10 @@ def process_unstrip_output():
         # try/except to handle malformed eu-unstrip output
         # e.g. for X.org cores
         try:
+            # if FILE (parts[2]) is not present on local filesystem
+            # eu-unstrip uses FILE as MODULENAME (parts[4])
+            if binobj_path == '-' and parts[4] != '[exe]':
+                binobj_path = parts[4]
             if binobj_path[0] != '/' and parts[4] != '[exe]':
                 continue
         except:


### PR DESCRIPTION
When 'eu-unstrip -n' can find the matching ELF and debug files on
disk given the build-ids it will display them, otherwise it won't.
If it can find the files then it "resolves" the module name on the end,
otherwise the name of the module is file path.

Example:
    0x7f248b+0x20d 96030f@0x7f248 - - /usr/lib64/gedit/plugins/libtime.so

If the FILE part does not begin with '/' and the MODULE part is not
'[exe]', coredump2packages silently skips these eu-unstrip output
lines ignoring the fact that such lines are completely valid.

This commit ensures that those lines will be processed too.

Signed-off-by: Jakub Filak <jfilak@redhat.com>