### PR TITLE
Rhbz1340158 email notifications

### DIFF
--- a/src/lib/retrace_worker.py
+++ b/src/lib/retrace_worker.py
@@ -516,8 +516,7 @@ class RetraceWorker(object):
         else:
             kernelver = get_kernel_release(vmcore, task.get_crash_cmd().split())
             if not kernelver:
-                log_error("Unable to determine kernel version")
-                self._fail()
+                raise Exception("Unable to determine kernel version")
 
             log_debug("Determined kernel version: %s" % kernelver)
 

--- a/src/lib/retrace_worker.py
+++ b/src/lib/retrace_worker.py
@@ -121,7 +121,7 @@ class RetraceWorker(object):
 
                     message += "Remote file(s): %s\n" % files
 
-                if taks.has_log():
+                if task.has_log():
                     message += "\nError log:\n%s\n" % task.get_log()
 
                 send_email("Retrace Server <%s>" % CONFIG["EmailNotifyFrom"],
@@ -830,7 +830,7 @@ class RetraceWorker(object):
 
                     message += "Remote file(s): %s\n" % files
 
-                if taks.has_log():
+                if task.has_log():
                     message += "\nLog:\n%s\n" % task.get_log()
 
                 send_email("Retrace Server <%s>" % CONFIG["EmailNotifyFrom"],


### PR DESCRIPTION
These minor fixup patches resolves issues with email notifications as described in https://bugzilla.redhat.com/show_bug.cgi?id=1340158

1. Typo causes email notifications to not get sent
2. After fixing typo, duplicate emails get sent for tasks that fail due to unable to determine kernel version

Tested these on a development server with these two patches added on top of retrace-server-1.15-1.el6.noarch