### PR TITLE
Add "exploitable" into LocationMatch in the httpd.conf

### DIFF
--- a/src/config/retrace-server-httpd.conf
+++ b/src/config/retrace-server-httpd.conf
@@ -30,7 +30,7 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
     </IfModule>
 </Directory>
 
-<LocationMatch "^/(manager(/.*)?|ftp|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete))?)?$">
+<LocationMatch "^/(manager(/.*)?|ftp|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete|exploitable))?)?$">
     Options -Indexes -FollowSymLinks
     <IfModule mod_authz_core.c>
         # Apache 2.4


### PR DESCRIPTION
Without this patch httpd refuses to download exploitable file.
On server the following message appears:
H01630: client denied by server configuration: /usr/share/retrace-server/exploitable.wsgi
And 403 is returned.
After creating this patch exploitable was returned correctly.