### PR TITLE
Fix coredump2packages

### DIFF
--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -176,7 +176,7 @@ def process_unstrip_output():
         try:
             # if FILE (parts[2]) is not present on local filesystem
             # eu-unstrip uses FILE as MODULENAME (parts[4])
-            if binobj_path == '-' and parts[4] != '[exe]':
+            if (binobj_path == '-' or binobj_path == '.') and parts[4] != '[exe]':
                 binobj_path = parts[4]
             if binobj_path[0] != '/' and parts[4] != '[exe]':
                 continue

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -211,7 +211,7 @@ def find_duplicates(package_list):
         package1 = package_list[p1]
         for p2 in range(p1 + 1, len(package_list)):
             package2 = package_list[p2]
-            if package1.name == package2.name:
+            if package1.name == package2.name and package1.arch == package2.arch:
                 return package1, package2
     return None, None
 


### PR DESCRIPTION
While working with retrace-server I noticed, that sometimes coredump2packages returns less packages for very similar coredumps. Investigating this behaviour I found 2 problems.

1.  Packages with different architectures were marked as duplicity. Later one of them got deleted and often the one with architecture we wanted. Therefore it would be better to keep them both.

2. The eu-unstrip function returns different results based on ability to find ELF image. One of the cases is that FILE is set to '.' and MODULENAME is set to a file path. This case was ignored, even though that MODULNAME provides enough data.