### PR TITLE
Enable creating repository from faf repository

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -123,6 +123,7 @@ fi
 %{_bindir}/%{name}-interact
 %{_bindir}/%{name}-cleanup
 %{_bindir}/%{name}-reposync
+%{_bindir}/%{name}-reposync-faf
 %{_bindir}/bt_filter
 %{_bindir}/coredump2packages
 %{python_site}/retrace/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ dist_bin_SCRIPTS = bt_filter \
                    coredump2packages \
                    retrace-server-cleanup \
                    retrace-server-reposync \
+                   retrace-server-reposync-faf \
                    retrace-server-worker \
                    retrace-server-interact
 

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -185,6 +185,25 @@ if __name__ == "__main__":
     version = args.version
     arch = get_canon_arch(args.architecture)
 
+
+    if CONFIG["UseFafPackages"]:
+        log_info("Creating repo from faf")
+        targetid = "%s-%s-%s" % (distribution, version, arch)
+        targetdir = os.path.join(CONFIG["RepoDir"], targetid)
+
+        if not os.path.isdir(targetdir):
+            os.makedirs(targetdir)
+
+        cmd_line = ["retrace-server-reposync-faf", distribution, version, arch,
+                    "--outputdir",  targetdir]
+        child = Popen(cmd_line, stdout=PIPE, stderr=PIPE)
+        stdout, stderr = child.communicate()
+        if child.returncode != 0:
+            log_error("Could not create faf repo")
+            sys.exit(child.returncode)
+        sys.exit(0)
+
+
     # drop privilegies if possible
     try:
         gr = grp.getgrnam(TARGET_GROUP)

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+import os
+import sys
+from argparse import ArgumentParser
+import yum.misc
+from createrepo import MetaDataGenerator, MetaDataConfig
+from pyfaf.storage import getDatabase
+from pyfaf.queries import get_packages_by_osrelease
+
+def get_pkglist(db, outputdir, opsys, release, arch):
+    q = get_packages_by_osrelease(db, opsys, release, arch)
+    for pkg in q:
+        if pkg.has_lob("package"):
+            print("Adding package: %s-%s-%s" % (pkg.name, pkg.build.version, pkg.build.release))
+            yield os.path.relpath(pkg.get_lob_path("package"), outputdir)
+
+def generate_yum_repo(db, outputdir, opsys, release):
+    if not os.path.exists(outputdir):
+        os.makedirs(outputdir)
+    conf = MetaDataConfig()
+    conf.quiet = False
+    conf.verbose = True
+    conf.update = False
+    conf.sumtype = yum.misc._default_checksums[0]
+    conf.outputdir = outputdir
+    conf.directory = conf.outputdir
+    conf.pkglist = get_pkglist(db, conf.directory, opsys, release)
+
+    mdgen = MetaDataGenerator(config_obj=conf)
+
+    if mdgen.checkTimeStamps():
+        print("%s repo is up to date" % (reponame))
+
+    mdgen.doPkgMetadata()
+    mdgen.doRepoMetadata()
+    mdgen.doFinalMove()
+    #mdgen.cleanup()
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Generates yum repo from FAF databse")
+    parser.add_argument("OPSYS")
+    parser.add_argument("RELEASE")
+    parser.add_argument("ARCHITECTURE")
+    parser.add_argument("--outputdir", default=os.getcwd())
+    args = parser.parse_args()
+
+    print("Creating repo in '%s'" % (args.outputdir))
+
+    generate_yum_repo(getDatabase(), args.outputdir, args.OPSYS, args.RELEASE, args.ARCHITECTURE)


### PR DESCRIPTION
In faf there was introduced a way of assigning operating system with release
to builds. That makes it possible to find all builds of specific operating
system and release. Then repository can be created by using packages from faf
repository.

Action of creating repository from faf was integrated into
retrace-server-reposync, so when this action is executed and UseFafPackages
in configuration file is enabled, repository is created/updated from faf.

This closes abrt/retrace-server#115.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>