### PR TITLE
Include md5sum of original archive in summary page

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -149,6 +149,8 @@ EmailNotify = 0
 # Who sends the e-mail notifications
 EmailNotifyFrom = retrace@localhost
 
+# Calculate md5sum for remote resources - changeable on manager page
+CalculateMd5 = 0
 
 [archhosts]
 i386 =

--- a/src/manager_usrcore_task_form.xhtml
+++ b/src/manager_usrcore_task_form.xhtml
@@ -13,5 +13,6 @@
         <input type="submit" value="Create coredump task" class="submit" />
         <div class="center">Any URL that <code>wget</code> can download or a local path (<code>file:///foo/bar</code> or just <code>/foo/bar</code>)</div>
       </div>
+      <input type="checkbox" {md5_enabled} name="md5sum" class="checkbox" /><span class="formsubhead"> Calculate md5 checksum for all downloaded resources</span>
     </form>
 

--- a/src/manager_vmcore_task_form.xhtml
+++ b/src/manager_vmcore_task_form.xhtml
@@ -10,4 +10,5 @@
         <input type="submit" value="Create vmcore task" class="submit" />
         <div class="center">Any URL that <code>wget</code> can download or a local path (<code>file:///foo/bar</code> or just <code>/foo/bar</code>)</div>
       </div>
+      <input type="checkbox" {md5_enabled} name="md5sum" class="checkbox" /><span class="formsubhead"> Calculate md5 checksum for all downloaded resources</span>
     </form>

--- a/src/managertask.xhtml
+++ b/src/managertask.xhtml
@@ -108,6 +108,7 @@
       {starttime}
       {finishtime}
       {downloaded}
+      {md5sum}
       {misc}
       {notify}
       {caseno}

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -73,6 +73,7 @@ class Config(object):
           "AuthGroup": "retrace",
           "EmailNotify": False,
           "EmailNotifyFrom": "retrace@localhost",
+          "CalculateMd5": True,
           "CaseNumberURL": "",
           "Crashi386": "",
         }


### PR DESCRIPTION
This commit adds option for users to see md5sum of original archive. User can
select before submitting task whether this information will be displayed or not.

If selected, this information is displayed on summary page as well as is written
into file. Format of this file is same as when md5sum command is run, so these
data can be compared easily (for example with diff).

Also into configuration file new item was added, to have this checkbox checked
by default.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>