### PR TITLE
Default to hex mode for crash commands involving backtraces.

### DIFF
--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -653,7 +653,7 @@ class RetraceWorker(object):
 
                     child = Popen(["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
                                    "crash -s %s %s" % (vmcore, vmlinux)], stdin=PIPE, stdout=PIPE, stderr=null)
-                    crash_bt_a = child.communicate("bt -a\nquit\n")[0]
+                    crash_bt_a = child.communicate("set hex\nbt -a\nquit\n")[0]
                     if child.wait():
                         log_warn("crash 'bt -a' exitted with %d" % child.returncode)
                         crash_bt_a = None
@@ -700,7 +700,7 @@ class RetraceWorker(object):
 
                     child = Popen(["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
                                    "crash -s %s %s" % (vmcore, vmlinux)], stdin=PIPE, stdout=PIPE, stderr=null)
-                    crash_foreach_bt = child.communicate("foreach bt\nquit\n")[0]
+                    crash_foreach_bt = child.communicate("set hex\nforeach bt\nquit\n")[0]
                     if child.wait():
                         log_warn("crash 'foreach bt' exitted with %d" % child.returncode)
                         crash_foreach_bt = None
@@ -730,7 +730,7 @@ class RetraceWorker(object):
                 log_warn("crash 'log' exited with %d" % child.returncode)
 
             child = Popen(task.get_crash_cmd().split() + ["-s", vmcore, vmlinux], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-            crash_bt_a = child.communicate("bt -a\nquit\n")[0]
+            crash_bt_a = child.communicate("set hex\nbt -a\nquit\n")[0]
             if child.wait():
                 log_warn("crash 'bt -a' exited with %d" % child.returncode)
                 crash_bt_a = None
@@ -771,7 +771,7 @@ class RetraceWorker(object):
                 crash_sys_c = None
 
             child = Popen(task.get_crash_cmd().split() + ["-s", vmcore, vmlinux], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-            crash_foreach_bt = child.communicate("foreach bt\nquit\n")[0]
+            crash_foreach_bt = child.communicate("set hex\nforeach bt\nquit\n")[0]
             if child.wait():
                 log_warn("crash 'foreach bt' exited with %d" % child.returncode)
                 crash_foreach_bt = None


### PR DESCRIPTION
The kernel log contains an oops message which is printed with hex offsets.
For consistency, output in hex when running crash commands involving backtraces.
Use the "set hex" command inside crash to ensure the best backward compatibility
with crash versions.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1416086

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>