### PR TITLE
Change retrace-server httpd config

### DIFF
--- a/src/config/retrace-server-httpd.conf
+++ b/src/config/retrace-server-httpd.conf
@@ -1,6 +1,5 @@
 WSGISocketPrefix /var/run/retrace
 WSGIDaemonProcess retrace user=retrace group=retrace processes=5 threads=3
-WSGIProcessGroup retrace
 
 WSGIScriptAliasMatch ^/manager(/.*)?$ /usr/share/retrace-server/manager.wsgi
 WSGIScriptAliasMatch ^/ftp(/.*)?$ /usr/share/retrace-server/ftp.wsgi
@@ -31,6 +30,7 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
 </Directory>
 
 <LocationMatch "^/(manager(/.*)?|ftp|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete|exploitable))?)?$">
+    WSGIProcessGroup retrace
     Options -Indexes -FollowSymLinks
     <IfModule mod_authz_core.c>
         # Apache 2.4


### PR DESCRIPTION
Moving WSGIProcessGroup directive to LocationMatch will let retrace
process operate just within specified paths.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>