### PR TITLE
Fix character escape typo

### DIFF
--- a/src/index.wsgi
+++ b/src/index.wsgi
@@ -17,7 +17,7 @@ def application(environ, start_response):
     about = "%s %s" % (_("Retrace Server is a service that provides the possibility to analyze "
                          "coredump and generate backtrace over network. "
                          "You can find further information at Retrace Server&apos;s github:"),
-                         "<a href=\"https://github.com/abrt/retrace-server">"
+                         "<a href=\"https://github.com/abrt/retrace-server\">"
                          "https://github.com/abrt/retrace-server</a>")
     if CONFIG["RequireHTTPS"]:
         https = _("Only the secure HTTPS connection is now allowed by the server. HTTP requests will be denied.")


### PR DESCRIPTION
In 99ad409 there was introduced a typo that caused index page of retrace-server
not working. This commit fixes the problem.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>