### PR TITLE
Fix typeo in manager.wsgi which creates a backtrace on non-ftp tasks.

### DIFF
--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -401,7 +401,7 @@ def application(environ, start_response):
             if task.has_started_time():
                 starttime = task.get_started_time()
             else:
-                startime = task.get_default_started_time()
+                starttime = task.get_default_started_time()
 
             starttime_str = "<tr><th>Started:</th><td>%s</td></tr>" % datetime.datetime.fromtimestamp(starttime)
 


### PR DESCRIPTION
Typo results in the following error in /var/log/httpd/error_log when
a non-ftp task is submitted through "Custom core location":

  mod_wsgi (pid=23919): Exception occurred processing WSGI script '/usr/share/retrace-server/manager.wsgi'.
  Traceback (most recent call last):
  File "/usr/share/retrace-server/manager.wsgi", line 406, in application
     starttime_str = "<tr><th>Started:</th><td>%s</td></tr>" % datetime.datetime.fromtimestamp(starttime)
  UnboundLocalError: local variable 'starttime' referenced before assignment

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>