### PR TITLE
Add aliases into FAF reposync

### DIFF
--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -8,9 +8,13 @@ from createrepo import MetaDataGenerator, MetaDataConfig
 from pyfaf.storage import getDatabase
 from pyfaf.queries import get_packages_by_osrelease
 
+faf_names = {'rhel' : "Red Hat Enterprise Linux",
+             'fedora': 'Fedora',
+             'centos': 'CentOS'}
+
 def get_pkglist(db, outputdir, opsys, release, arch):
-    if opsys == "rhel":
-        opsys = "Red Hat Enterprise Linux"
+    if opsys in faf_names.keys():
+        opsys = faf_names[opsys]
     q = get_packages_by_osrelease(db, opsys, release, arch)
     for pkg in q:
         if pkg.has_lob("package"):


### PR DESCRIPTION
Default names of releases differ between FAF and RetraceServer.
It means that running (with UseFafPackages = 1):
`retrace-server-reposync fedora 25 x86_64` will succeed in RS but fail in FAF
`retrace-server-reposync Fedora 25 x86_64` will succeed in FAF but fail in RS
After this patch the first version succeeds in both components.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>