### PR TITLE
Fix unreadable crash subdirectory when tarball is submitted without g…

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1935,6 +1935,15 @@ class RetraceTask:
                         unpack_coredump(fullpath)
                     except Exception as ex:
                         errors.append((fullpath, str(ex)))
+                st = os.stat(crashdir)
+                if (st.st_mode & stat.S_IRGRP) == 0 or (st.st_mode & stat.S_IXGRP) == 0:
+                    try:
+                        os.chmod(crashdir, st.st_mode | stat.S_IRGRP | stat.S_IXGRP)
+                    except Exception as ex:
+                        log_warn("Crashdir '%s' is not group readable and chmod"
+                                 " failed. The process will continue but if"
+                                 " it fails this is the likely cause."
+                                 % crashdir)
 
         if self.get_type() in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE]:
             vmcore = os.path.join(crashdir, "vmcore")


### PR DESCRIPTION
…roup read permissions

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1481433#c0
by checking for the group read and execute permissions in the 'crashdir'
after unpacking.  This patch should handle both vmcores (kernel) and coredump
(user space) cores.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>