### PR TITLE
Explicitly state python version in shebangs

### DIFF
--- a/src/bt_filter
+++ b/src/bt_filter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # 
 #  Copyright (C) 2009 Flavio Leitner <fleitner@redhat.com>
 #  

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 # -*- coding:utf-8;mode:python -*-
 # Gets list of packages necessary for processing of a coredump.
 # Uses eu-unstrip and yum.

--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import fnmatch
 import re
 import urllib

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import datetime
 import fnmatch
 import re

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import os
 import sys
 from retrace import *

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import argparse
 import grp
 import os

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import argparse
 import errno
 import os

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import os
 import sys

--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import sys
 from retrace import *
 

--- a/src/retrace/argparser.py
+++ b/src/retrace/argparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Copyright (C) 2012 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/src/stats.wsgi
+++ b/src/stats.wsgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from retrace import *
 sys.path.insert(0, "/usr/share/retrace-server/")
 


### PR DESCRIPTION
Scripts should explicitly use /usr/bin/python[23] in shebangs.

See https://pagure.io/packaging-committee/issue/698
Also https://fedoraproject.org/wiki/Packaging:Python#Multiple_Python_Runtimes

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>