### PR TITLE
Set kernelver and vmlinux as soon as possible

### DIFF
--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -109,6 +109,9 @@ if __name__ == "__main__":
             kernelver = KernelVer(task.get_kernelver())
         else:
             kernelver = get_kernel_release(vmcore, task.get_crash_cmd().split())
+            if kernelver is None:
+                raise Exception, "Unable to determine kernel version"
+            task.set_kernelver(str(kernelver))
 
         hostarch = os.uname()[4]
         if hostarch in ["i486", "i586", "i686"]:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1670,6 +1670,8 @@ class RetraceTask:
         if kernelver is None:
             raise Exception, "Unable to determine kernel version"
 
+        self.set_kernelver(str(kernelver))
+
         debugdir_base = os.path.join(CONFIG["RepoDir"], "kernel", kernelver.arch)
         if not os.path.isdir(debugdir_base):
             os.makedirs(debugdir_base)
@@ -1696,6 +1698,7 @@ class RetraceTask:
         if os.path.isfile(vmlinux_cache_path):
             log_info("Found cached vmlinux at path: " + vmlinux_cache_path)
             vmlinux = vmlinux_cache_path
+            self.set_vmlinux(vmlinux)
         else:
             log_info("Unable to find cached vmlinux at path: " + vmlinux_cache_path)
             vmlinux = None
@@ -1709,7 +1712,6 @@ class RetraceTask:
         debuginfo = find_kernel_debuginfo(kernelver)
         if not debuginfo:
             if vmlinux is not None:
-                self.set_vmlinux(vmlinux)
                 return vmlinux
             else:
                 raise Exception, "Unable to find debuginfo package and no cached vmlinux file"
@@ -1754,16 +1756,13 @@ class RetraceTask:
         # Note the dependency from this code on the debuginfo file list
         if vmlinux is None:
             vmlinux_debuginfo = os.path.join(debugdir_base, vmlinux_path.lstrip("/"))
+            cache_files_from_debuginfo(debuginfo, debugdir_base, [vmlinux_path])
             if os.path.isfile(vmlinux_debuginfo):
-                log_info("Found cached vmlinux at existing debuginfo location: " + vmlinux_debuginfo)
+                log_info("Found cached vmlinux at new debuginfo location: " + vmlinux_debuginfo)
                 vmlinux = vmlinux_debuginfo
+                self.set_vmlinux(vmlinux)
             else:
-                cache_files_from_debuginfo(debuginfo, debugdir_base, [vmlinux_path])
-                if os.path.isfile(vmlinux_debuginfo):
-                    log_info("Found cached vmlinux at new debuginfo location: " + vmlinux_debuginfo)
-                    vmlinux = vmlinux_debuginfo
-                else:
-                    raise Exception, "Failed vmlinux caching from debuginfo at location: " + vmlinux_debuginfo
+                raise Exception, "Failed vmlinux caching from debuginfo at location: " + vmlinux_debuginfo
 
         # Obtain the list of modules this vmcore requires
         if chroot:
@@ -1785,7 +1784,6 @@ class RetraceTask:
         # If we fail to get the list of modules, is the vmcore even usable?
         if child.returncode:
             log_warn("Unable to list modules: crash exited with %d:\n%s" % (child.returncode, stdout))
-            self.set_vmlinux(vmlinux)
             return vmlinux
 
         modules = []
@@ -1805,7 +1803,6 @@ class RetraceTask:
 
         cache_files_from_debuginfo(debuginfo, debugdir_base, todo)
 
-        self.set_vmlinux(vmlinux)
         return vmlinux
 
     def strip_vmcore(self, vmcore, kernelver=None, crash_cmd=["crash"]):

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -561,9 +561,8 @@ class RetraceWorker(object):
 
             log_debug("Determined kernel version: %s" % kernelver)
 
-        kernelver_str = kernelver.kernelver_str
-
         task.set_kernelver(str(kernelver))
+        kernelver_str = kernelver.kernelver_str
 
         self.stats["package"] = "kernel"
         self.stats["version"] = "%s-%s" % (kernelver.version, kernelver.release)


### PR DESCRIPTION
For larger vmcores it is possible that prepare_debuginfo may take a long time.
This is due to various factors such as makedumpfile, as well as how long crash
takes to load when detecting modules as well as running the early commands
such as 'sys'.  Today we are not setting kernelver or vmlinux as early as we
can and as a result, someone waiting to get access to the vmcore either has to
wait excessivly long or do some manual intervention like setting up vmlinux
manually.  Today if someone tries to run 'retrace-server-interact' before all
commands complete in the retrace, they will end up blocking waiting
for the re-detction of the kernelver which can take a very long time (since
it may run strings on the whole file).  This makes no sense since retrace
figures out the kernelver early on as well as the vmlinux file (assuming it
is in the cache).  This patch sets both the kernelver file and the vmlinux
file as early as reasonably possible, and thus allows much earlier access
to the vmcore through 'retrace-server-interact <task> crash'.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1516329

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>