### PR TITLE
Rhbz1440383 improve email notifications

### DIFF
--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -121,6 +121,12 @@ class RetraceWorker(object):
             if task.has_finished_time():
                 message += "Finished: %s\n" % datetime.datetime.fromtimestamp(task.get_finished_time())
 
+            if task.has_md5sum():
+                message += "MD5sum: %s" % task.get_md5sum()
+
+            if task.has_kernelver():
+                message += "Kernelver: %s\n" % task.get_kernelver()
+
             if task.has_remote() or task.has_downloaded():
                 files = ""
                 if task.has_remote():
@@ -131,6 +137,10 @@ class RetraceWorker(object):
                     files = ", ".join(filter(None, [task.get_downloaded(), files]))
 
                 message += "Remote file(s): %s\n" % files
+
+            if task.get_type() in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE] and task.get_status() == STATUS_FAIL:
+                message += "\nIf kernel version detection failed (the log shows 'Unable to determine kernel version'), and you know the kernel version, you may try re-starting the task with the 'retrace-server-worker --restart' command.  Please check the log below for more information on why the task failed.  The following example assumes the vmcore's kernel version is 2.6.32-358.el6 on x86_64 arch: \n$ retrace-server-worker --restart --kernelver 2.6.32-358.el6.x86_64 --arch x86_64 %d\n" % task.get_taskid()
+                message += "\nIf this is a test kernel with a non-errata kernel version, or for some reason the kernel-debuginfo repository is unavailable, you can place the kernel-debuginfo RPM at %s/download/ and restart the task with: \n$ retrace-server-worker --restart %d\n" % (CONFIG["RepoDir"], task.get_taskid())
 
             if task.has_log():
                 message += "\nLog:\n%s\n" % task.get_log()

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -96,91 +96,58 @@ class RetraceWorker(object):
         """After cleaning task"""
         self.hook_universal("post_clean_task")
 
-    def notify_email_success(self):
+    def notify_email(self):
         task = self.task
-        if CONFIG["EmailNotify"] and task.has_notify():
-            try:
-                log_info("Sending e-mail to %s" % ", ".join(task.get_notify()))
+        if not CONFIG["EmailNotify"] or not task.has_notify():
+            return
+        if task.get_status() == STATUS_SUCCESS:
+            disposition = "succeeded"
+        else:
+            disposition = "failed"
 
-                message = "The task #%d started on %s succeeded\n\n" % (task.get_taskid(), os.uname()[1])
+        try:
+            log_info("Sending e-mail to %s" % ", ".join(task.get_notify()))
 
-                if task.has_url():
-                    message += "URL: %s\n" % task.get_url()
+            message = "The task #%d started on %s %s\n\n" % (task.get_taskid(), os.uname()[1], disposition)
 
-                message += "Task directory: %s\n" % task.get_savedir()
+            if task.has_url():
+                message += "URL: %s\n" % task.get_url()
 
-                if task.has_started_time():
-                    message += "Started: %s\n" % datetime.datetime.fromtimestamp(task.get_started_time())
+            message += "Task directory: %s\n" % task.get_savedir()
 
-                if task.has_finished_time():
-                    message += "Finished: %s\n" % datetime.datetime.fromtimestamp(task.get_finished_time())
+            if task.has_started_time():
+                message += "Started: %s\n" % datetime.datetime.fromtimestamp(task.get_started_time())
 
-                if task.has_remote() or task.has_downloaded():
-                    files = ""
-                    if task.has_remote():
-                        remote = map(lambda x: x[4:] if x.startswith("FTP ") else x, task.get_remote())
-                        files = ", ".join(remote)
+            if task.has_finished_time():
+                message += "Finished: %s\n" % datetime.datetime.fromtimestamp(task.get_finished_time())
 
-                    if task.has_downloaded():
-                        files = ", ".join(filter(None, [task.get_downloaded(), files]))
+            if task.has_remote() or task.has_downloaded():
+                files = ""
+                if task.has_remote():
+                    remote = map(lambda x: x[4:] if x.startswith("FTP ") else x, task.get_remote())
+                    files = ", ".join(remote)
 
-                    message += "Remote file(s): %s\n" % files
+                if task.has_downloaded():
+                    files = ", ".join(filter(None, [task.get_downloaded(), files]))
 
-                if task.has_log():
-                    message += "\nLog:\n%s\n" % task.get_log()
+                message += "Remote file(s): %s\n" % files
 
-                send_email("Retrace Server <%s>" % CONFIG["EmailNotifyFrom"],
-                           task.get_notify(),
-                           "Retrace Task #%d on %s succeded" % (task.get_taskid(), os.uname()[1]),
-                           message)
+            if task.has_log():
+                message += "\nLog:\n%s\n" % task.get_log()
 
-            except Exception as ex:
-                log_error("Failed to send e-mail: %s" % ex)
+            send_email("Retrace Server <%s>" % CONFIG["EmailNotifyFrom"],
+                       task.get_notify(),
+                       "Retrace Task #%d on %s %s" % (task.get_taskid(), os.uname()[1], disposition),
+                       message)
 
-    def notify_email_fail(self):
-        task = self.task
-        if CONFIG["EmailNotify"] and task.has_notify():
-            try:
-                log_info("Sending e-mail to %s" % ", ".join(task.get_notify()))
-
-                message = "The task #%d on %s failed\n\n" % (task.get_taskid(), os.uname()[1])
-
-                if task.has_url():
-                    message += "URL: %s\n" % task.get_url()
-
-                message += "Task directory: %s\n" % task.get_savedir()
-
-                if task.has_started_time():
-                    message += "Started: %s\n" % datetime.datetime.fromtimestamp(task.get_started_time())
-
-                if task.has_remote() or task.has_downloaded():
-                    files = ""
-                    if task.has_remote():
-                        remote = map(lambda x: x[4:] if x.startswith("FTP ") else x, task.get_remote())
-                        files = ", ".join(remote)
-
-                    if task.has_downloaded():
-                        files = ", ".join(filter(None, [task.get_downloaded(), files]))
-
-                    message += "Remote file(s): %s\n" % files
-
-                if task.has_log():
-                    message += "\nError log:\n%s\n" % task.get_log()
-
-                send_email("Retrace Server <%s>" % CONFIG["EmailNotifyFrom"],
-                           task.get_notify(),
-                           "Retrace Task #%d on %s failed" % (task.get_taskid(), os.uname()[1]),
-                           message)
-
-            except Exception as ex:
-                log_error("Failed to send e-mail: %s" % ex)
+        except Exception as ex:
+            log_error("Failed to send e-mail: %s" % ex)
 
     def _fail(self, errorcode=1):
         task = self.task
         task.set_status(STATUS_FAIL)
-        self.notify_email_fail()
-
         task.set_finished_time(int(time.time()))
+        self.notify_email()
 
         self.stats["duration"] = int(time.time()) - self.stats["starttime"]
         try:
@@ -889,7 +856,6 @@ class RetraceWorker(object):
         if not task.get_type() in [TASK_VMCORE_INTERACTIVE]:
             self.clean_task()
 
-        self.notify_email_success()
         log_info("Retrace took %d seconds" % self.stats["duration"])
         log_info(STATUS[STATUS_SUCCESS])
 
@@ -900,6 +866,7 @@ class RetraceWorker(object):
                        os.path.join(task._get_file_path(RetraceTask.MISC_DIR), "retrace-log"))
 
         task.set_status(STATUS_SUCCESS)
+        self.notify_email()
         self.hook_success()
 
     def start(self, kernelver=None, arch=None):


### PR DESCRIPTION
This is an improved patchset based on Matej's review and my additional testing. Items fixed:

    first patch originally missed a 'self.' on the notify_email_X functions
    second patch checks the 'status' variable at the top and sets "succeeded" or "failed" to use later; this also addresses the reordering of STATUS_SUCCESS and STATUS_FAIL
    third patch fix help text to use CONFIG["RepoDir"] rather than hardcoded path

FWIW, I also noticed a separate bug when testing this patchset where RetraceWorker._fail method is called twice for failing tasks and so two email notifications are given. This bug has nothing to do with this patchset though and existed before it so I filed https://bugzilla.redhat.com/show_bug.cgi?id=1535485