### PR TITLE
Fix typo in exception handling of get_kernel_release

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -524,7 +524,7 @@ def get_kernel_release(vmcore, crash_cmd=["crash"]):
             fd.seek(0)
             blksize = 64000000
             b = os.read(fd.fileno(),blksize)
-        except IOerror as e:
+        except OSError as e:
             log_error("Failed to get kernel release - failed open/seek/read of file %s with errno(%d - '%s')" % (vmcore, e.errno, e.strerror()))
             if fd:
                 fd.close()


### PR DESCRIPTION
The previous commit 232ff36 introduced a minor bug when processing
a vmcore that failed a permission check or read error.  The retrace_log
will show a message indicating 'IOerror' not being defined.
For example:
 2018-02-28 15:17:51 prepare_debuginfo failed: global name 'IOerror' is not defined
 2018-02-28 15:17:51 File '/retrace/tasks/875129564/crash/vmcore' is not group readable and chmod failed. The process will continue but if it fails this is the likely cause.

While the overall error message is still accurate, there is a small bug
here.  Indeed "IOerror" is not defined and this is a simple typo and this
should be 'OSError'.

Fixing this shows a slightly more accurate retrace_log:
 2018-02-28 15:24:38 prepare_debuginfo failed: [Errno 13] Permission denied: '/retrace/tasks/722567843/crash/vmcore'
 2018-02-28 15:24:38 File '/retrace/tasks/722567843/crash/vmcore' is not group readable and chmod failed. The process will continue but if it fails this is the likely cause.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>