### PR TITLE
Add dedup_vmcore to RetraceTask and call this from retrace-server-cle…

### DIFF
--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -97,6 +97,17 @@ if __name__ == "__main__":
                 task.create_worker().clean_task()
                 task.set_log("Task was killed due to running too long or taking too many resources.\n", True)
 
+        md5_tasks = {}
+        total_savings = 0
+        for task in get_md5_tasks():
+            md5 = str.split(task.get_md5sum())[0]
+            if md5 in md5_tasks:
+                total_savings += md5_tasks[md5].dedup_vmcore(task)
+            else:
+                md5_tasks[md5] = task
+
+        log.write("Total space savings from duplicate task hardlinking (md5sums equal, different inodes): %d MB\n" % (total_savings / 1024 / 1024))
+
         if CONFIG["ArchiveTaskAfter"] > 0:
             # archive old tasks
             try:


### PR DESCRIPTION
…anup

Today retrace-server allows the same ftp vmcore to be submitted multiple times.
This means disk space can be consumed for the same vmcore / multiple tasks.
In our production system, we have seen where this may take up around 10% of the
space, or 4TB so it is not insignificant.  To eliminate this overhead,
introduce dedup_vmcore method to RetraceTask.

The dedup_vmcore method takes advantage of the fact we usually have the
md5sum of a downloaded file prior to processing it.  While this md5sum
is not the same as the md5sum of the vmcore, the ending vmcore file after
all processing should always be the same if the same archive is submitted
twice (anything else is a pathalogical case we don't care about).  Also
we can do a simple 'size' check and if the md5sum is the same and the size
is the same we have enough certainty it is ok to deduplicate the vmcores.

Add a new section to retrace-server-cleanup where we first get a list of
tasks that have an md5sum file.  Then, go through these tasks building up
a dictionary based on each unique md5sum which is the first portion of the
md5sum file (Note that we actually store the output of 'md5sum' command
in the 'md5sum' file on the task).  While iteration of the tasks with
md5sums, if we look in the dictionary and one task is already there,
call the new dedup_vmcore method.  This method first does a couple checks
to make sure these two vmcores are the same and should be deduped:
- existence of each file (stat on the file)
- inodes are different
- sizes are the same
- md5sums (of the originally downloaded file) are the same

If all of the above checks out, then the dedup_vmcore proceeds with the
next steps:
- create a temporary hardlink name based on the second vmcore name
- create a hardlink from the second vmcore to the first using the temp name
- remove the second vmcore
- change the hardlink name to the name of the second vmcore that was removed

If all of the above works, then we have have safely deduplicated the
vmcore file for two tasks that are equal.  The return value of dedup_vmcore
is the number of bytes saved in the deplication, and in a successful
operation, the return will be non-zero, while in a failure it will be 0.

If something goes wrong in the process of deduplicating the vmcores, or
even if we successfully dedup the vmcores, we write a message into the
second task's retrace-log so we know what the cleanup job has done.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>