### PR TITLE
Fix runaway crash processes due to either corrupted vmcore memory or …

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -152,6 +152,9 @@ EmailNotifyFrom = retrace@localhost
 # Calculate md5sum for remote resources - changeable on manager page
 CalculateMd5 = 0
 
+# Timeout (in seconds) for communication with any process
+ProcessCommunicateTimeout = 3600
+
 [archhosts]
 i386 =
 x86_64 =

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -75,6 +75,7 @@ class Config(object):
             "CalculateMd5": True,
             "CaseNumberURL": "",
             "Crashi386": "",
+            "ProcessCommunicateTimeout": 3600,
         }
 
         def __getitem__(self, key):

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1760,7 +1760,14 @@ class RetraceTask:
                               stdin=PIPE, stdout=PIPE, stderr=null)
         else:
             child = Popen(crash_cmd + ["-s", vmcore, vmlinux], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-        stdout = child.communicate("mod\nquit")[0]
+        try:
+            t = 3600
+            if CONFIG["ProcessCommunicateTimeout"]:
+                t = CONFIG["ProcessCommunicateTimeout"]
+            stdout = child.communicate("mod\nquit", timeout=t)[0]
+        except:
+            child.kill()
+            raise Exception, "WARNING: Possible vmcore memory corruption or damaged file - crash 'mod' command exceeded " + str(t) + " second timeout"
         if child.returncode == 1 and "el5" in kernelver.release:
             log_info("Unable to list modules but el5 detected, trying crash fixup for vmss files")
             crash_cmd.append("--machdep")


### PR DESCRIPTION
…files.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1208563#c0
Periodically we get vmcores that have either severely corrupted memory
or the vmcore files are corrupted themselves, and as a result, the first
attempt at running any crash command may hang with 100% CPU.  This
requires too much human intervention for little to no benefit.

Add a 'ProcessCommunicateTimeout' parameter and set it to 60 minutes
by default, then use this in the prepare_debuginfo() function which
is the first place where crash is called to load the vmcore.  If crash
is hung, the timeout on the Popen.communicate will trigger an exception.
This will fail the task and in the retrace_log (and possibly email
notification) you'll see a message like this:
 2017-10-13 18:16:49 prepare_debuginfo failed: WARNING: Possible vmcore memory corruption or damaged file - crash 'mod' command exceeded 3600 second timeout

The bug discusses an alternative approach of a external tool.  However,
an external tool would have its own downsides and in this case, we want
retrace-server to detect this error and cleanly error out, so I'm not
going that route.

It's possible we may want to expand usage of 'ProcessCommunicateTimeout'
to other areas since there's many calls to Popen.communicate, and assuming
a similar problem comes up elsewhere.  However, for this bug we're only
interested in detecting whether the vmcore can load via crash,
and adding the timeout everywhere seemed excessive for now.  Finally,
note we cannot just hardcode a value here due to variations in vmcore
storage performance, so we need some parameter.

Note that retrace-server-cleanup does have a clause that will kill
tasks running > 1 hour.  But this code skips over 'managed' tasks,
which are ftp tasks and most of our vmcores due to the fact that a
very large vmcore (not uncommon) may take hours to download.  So
we can neither use this code nor modify it and we need a timer on
specific crash command as this patch does.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>