### PR TITLE
Set md5sum as soon as possible.

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1932,6 +1932,7 @@ class RetraceTask:
                 log_info(STATUS[STATUS_CALCULATING_MD5SUM])
                 md5v = self.calculate_md5(os.path.join(crashdir, filename))
                 md5sums.append("{0} {1}".format(md5v, downloaded[-1]))
+                self.set_md5sum("\n".join(md5sums)+"\n")
 
             self.set_status(STATUS_POSTPROCESS)
             log_info(STATUS[STATUS_POSTPROCESS])
@@ -2098,8 +2099,6 @@ class RetraceTask:
                                  % coredump)
 
         os.unlink(os.path.join(self._savedir, RetraceTask.REMOTE_FILE))
-        if md5sums:
-            self.set_md5sum("\n".join(md5sums)+"\n")
         self.set_downloaded(", ".join(downloaded))
 
         return errors


### PR DESCRIPTION
The md5sum is calculated as soon as a file is downloaded but it is not
written to the file until after the task is processed.  As far as I
can tell the reason for this is due to the fact that multiple files
can in theory be inside the 'downloaded' file.  However, this leads to
the side-effect that a failed task may never write out the md5sum file
with the actual md5sum despite the fact it has been calculated.
Instead the only thing that remains in the file is "Enabled" which is
obviously not desireable.

Fix this by writing the md5sum as soon as it is calculated.  This may
lead to the file being written multiple times but this should not be
a problem.  Also in many instances (for example with vmcores) there is
only one file so it will only be written once.

NOTE: This problem was more obvious after the dedup_vmcore patch went
in.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>