### PR TITLE
easy requires of createrepo on RHEL

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -24,7 +24,11 @@ Requires: p7zip
 Requires: unzip
 Requires: lzop
 Requires: elfutils
+%if 0%{?rhel} == 6 || 0%{?rhel} == 7
+Requires: createrepo
+%else
 Requires: createrepo >= 0.9.9-27
+%endif
 %if 0%{?fedora} > 27
 Requires: python2-mod_wsgi
 Requires: python2-webob


### PR DESCRIPTION
There is no such createrepo >= 0.9.9-27 and therefore retrace-server is not installable on RHEL7