### PR TITLE
Add bugzilla field and related tools

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -32,6 +32,7 @@ Requires: python2-magic
 Requires: python2-requests
 Requires: python2-requests-kerberos
 Requires: python2-distro
+Requires: python2-bugzilla
 %else
 Requires: mod_wsgi
 Requires: python-webob
@@ -39,6 +40,7 @@ Requires: python-magic
 Requires: python-requests
 Requires: python-requests-kerberos
 Requires: python-distro
+Requires: python-bugzilla
 %endif
 Requires: mod_ssl
 Requires: sqlite
@@ -133,6 +135,7 @@ fi
 %{_bindir}/%{name}-reposync-faf
 %{_bindir}/%{name}-plugin-checker
 %{_bindir}/%{name}-task
+%{_bindir}/%{name}-bugzilla-refresh
 %{_bindir}/bt_filter
 %{_bindir}/coredump2packages
 %{python_sitelib}/retrace/*

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -136,6 +136,7 @@ fi
 %{_bindir}/%{name}-plugin-checker
 %{_bindir}/%{name}-task
 %{_bindir}/%{name}-bugzilla-refresh
+%{_bindir}/%{name}-bugzilla-query
 %{_bindir}/bt_filter
 %{_bindir}/coredump2packages
 %{python_sitelib}/retrace/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,8 @@ dist_bin_SCRIPTS = bt_filter \
                    retrace-server-worker \
                    retrace-server-interact\
                    retrace-server-plugin-checker\
-                   retrace-server-task
+                   retrace-server-task \
+                   retrace-server-bugzilla-refresh
 
 interface_PYTHON = backtrace.wsgi \
                    create.wsgi \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,7 +27,8 @@ dist_bin_SCRIPTS = bt_filter \
                    retrace-server-interact\
                    retrace-server-plugin-checker\
                    retrace-server-task \
-                   retrace-server-bugzilla-refresh
+                   retrace-server-bugzilla-refresh \
+                   retrace-server-bugzilla-query
 
 interface_PYTHON = backtrace.wsgi \
                    create.wsgi \

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -152,6 +152,16 @@ EmailNotifyFrom = retrace@localhost
 # Calculate md5sum for remote resources - changeable on manager page
 CalculateMd5 = 0
 
+# URL of Bugzilla
+BugzillaURL = https://bugzilla.redhat.com
+# Username to log in to Bugzilla (if needed)
+BugzillaUsername =
+# Password to log in to Bugzilla (if needed)
+BugzillaPassword =
+# Clean up tasks with assigned bugzilla bugs in following states
+# NEW, ASSIGNED, ON_DEV, POST, MODIFIED, ON_QA, VERIFIED, RELEASE_PENDING, CLOSED
+BugzillaStatus = VERIFIED, RELEASE_PENDING, CLOSED
+
 [archhosts]
 i386 =
 x86_64 =

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -154,10 +154,13 @@ CalculateMd5 = 0
 
 # URL of Bugzilla
 BugzillaURL = https://bugzilla.redhat.com
-# Username to log in to Bugzilla (if needed)
-BugzillaUsername =
-# Password to log in to Bugzilla (if needed)
-BugzillaPassword =
+# Custom path to the file with Bugzilla credentials, stored in format:
+# [bugzilla.yoursite.com]
+# user =
+# password =
+# If not set checks for credentials in:
+# ~/.config/python-bugzilla/bugzillarc, ~/.bugzillarc, /etc/bugzillarc
+BugzillaCredentials =
 # Clean up tasks with assigned bugzilla bugs in following states
 # NEW, ASSIGNED, ON_DEV, POST, MODIFIED, ON_QA, VERIFIED, RELEASE_PENDING, CLOSED
 BugzillaStatus = VERIFIED, RELEASE_PENDING, CLOSED

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -164,6 +164,14 @@ BugzillaCredentials =
 # Clean up tasks with assigned bugzilla bugs in following states
 # NEW, ASSIGNED, ON_DEV, POST, MODIFIED, ON_QA, VERIFIED, RELEASE_PENDING, CLOSED
 BugzillaStatus = VERIFIED, RELEASE_PENDING, CLOSED
+# Search query options for bugzilla bugs
+BugzillaProduct = Red Hat Enterprise Linux 7
+BugzillaComponent = kernel
+# Number and order of values in TriggerWords and RegExes should be identical
+# Trigger words to look for in the text of bugzilla bugs
+BugzillaTriggerWords = retrace-server-interact, retrace/tasks
+# Regular expressions used to get task numbers from the text of bugzilla bugs
+BugzillaRegExes = retrace-server-interact\\s+([0-9]{9}), /var/spool/retrace-server/([0-9]{9})/crash/vmcore
 
 [archhosts]
 i386 =

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -597,7 +597,11 @@ def application(environ, start_response):
 
                 bugzillano = ""
                 if task.has_bugzillano():
-                    bugzillano = ", ".join(task.get_bugzillano())
+                    bugzillano = min(task.get_bugzillano(), key=int)
+
+                    bzurl = CONFIG["BugzillaURL"].strip()
+                    if bzurl:
+                        bugzillano = "<a href={0}/{1}>{1}</a>".format(bzurl, bugzillano)
 
                 files = ""
                 if task.has_downloaded():
@@ -641,7 +645,11 @@ def application(environ, start_response):
 
                 bugzillano = ""
                 if task.has_bugzillano():
-                    bugzillano = ", ".join(task.get_bugzillano())
+                    bugzillano = min(task.get_bugzillano(), key=int)
+
+                    bzurl = CONFIG["BugzillaURL"].strip()
+                    if bzurl:
+                        bugzillano = "<a href={0}/{1}>{1}</a>".format(bzurl, bugzillano)
 
                 files = ""
                 if task.has_remote():

--- a/src/manager.xhtml
+++ b/src/manager.xhtml
@@ -154,6 +154,11 @@
         width: 56px;
       }
 
+      table th.bugzillano
+      {
+        width: 56px;
+      }
+
       table th {
         border: 1px solid black;
         background-color: #ccc;
@@ -200,11 +205,12 @@
         <div id="running">
           <table>
             <tr>
-              <th colspan="5" class="tablename">{running_str}</th>
+              <th colspan="6" class="tablename">{running_str}</th>
             </tr>
             <tr>
               <th class="taskid">{taskid_str}</th>
               <th class="caseno">{caseno_str}</th>
+              <th class="bugzillano">{bugzillano_str}</th>
               <th>{files_str}</th>
               <th class="timestamp">{starttime_str}</th>
               <th class="status">{status_str}</th>
@@ -215,11 +221,12 @@
         <div id="finished">
           <table>
             <tr>
-              <th colspan="4" class="tablename">{finished_str}</th>
+              <th colspan="5" class="tablename">{finished_str}</th>
             </tr>
             <tr>
               <th class="taskid">{taskid_str}</th>
               <th class="caseno">{caseno_str}</th>
+              <th class="bugzillano">{bugzillano_str}</th>
               <th>{files_str}</th>
               <th class="timestamp">{finishtime_str}</th>
             </tr>

--- a/src/managertask.xhtml
+++ b/src/managertask.xhtml
@@ -112,6 +112,7 @@
       {misc}
       {notify}
       {caseno}
+      {bugzillano}
       {unknownext}
       {interactive}
       {start}

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -41,19 +41,20 @@ if __name__ == "__main__":
         else:
             log.write("Not logged in. Continue as anonymous user.\n")
 
+        product_list = CONFIG.get_list("BugzillaProduct")
+        component_list = CONFIG.get_list("BugzillaComponent")
+
         query = bzapi.build_query(
-            product="Red Hat Enterprise Linux 7",
-            component="kernel",
+            product=product_list,
+            component=component_list,
             include_fields=["id"])
 
         # I don't want to run regex on each and every comment, at first try fast check
         # if trigger word is in comment and if is, then use slower regex
-        trigger_words = ["retrace-server-interact", "retrace/tasks"]
+        trigger_words = CONFIG.get_list("BugzillaTriggerWords")
+        regexes = CONFIG.get_list("BugzillaRegExes")
 
-        regexes = ["retrace-server-interact\s+([0-9]{9})",
-                   CONFIG["SaveDir"] + "/([0-9]{9})/crash/vmcore"]
-
-        config_status = [x.strip() for x in CONFIG["BugzillaStatus"].split(",")]
+        config_status = CONFIG.get_list("BugzillaStatus")
         query["status"] = list(set(BUGZILLA_STATUS).difference(config_status))
 
         found_tasks = {}

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -21,16 +21,23 @@ if __name__ == "__main__":
 
         # connect to bugzilla
         bz_url = CONFIG["BugzillaURL"]
-        bz_user = CONFIG["BugzillaUsername"]
-        bz_password = CONFIG["BugzillaPassword"]
+        bz_creds = CONFIG["BugzillaCredentials"]
 
-        bzapi = bugzilla.Bugzilla(bz_url, cookiefile=None, tokenfile=None)
+        try:
+            bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
+        except (bugzilla.BugzillaError, ValueError) as e:
+            log.write("Exception: {0}".format(e))
+            exit(1)
 
-        if bz_user and bz_password:
-            bzapi.login(bz_user, bz_password)
+        if not bzapi.logged_in and bz_creds:
+            bzapi.readconfig(bz_creds)
+            try:
+                bzapi.connect()
+            except (bugzilla.BugzillaError, ValueError) as e:
+                log.write("Exception: {0}".format(e))
 
         if bzapi.logged_in:
-            log.write("Successfuly logged in as {0}.\n".format(bz_user))
+            log.write("Successfuly logged in as {0}.\n".format(bzapi.user))
         else:
             log.write("Not logged in. Continue as anonymous user.\n")
 

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -1,0 +1,117 @@
+#!/usr/bin/python2
+"""
+Query bugzilla for component bugs and search through comments for trigger words. Output results
+to a log and for tasks found in the comments set bugzillano field with bugzilla ids.
+"""
+
+import os
+import re
+import time
+import bugzilla
+from retrace import config, RetraceTask
+
+CONFIG = config.Config()
+
+if __name__ == "__main__":
+
+    logfile = os.path.join(CONFIG["LogDir"], "bugzilla-query.log")
+
+    with open(logfile, "a") as log:
+        log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running bugzilla query\n"))
+
+        # connect to bugzilla
+        bz_url = CONFIG["BugzillaURL"]
+        bz_user = CONFIG["BugzillaUsername"]
+        bz_password = CONFIG["BugzillaPassword"]
+
+        bzapi = bugzilla.Bugzilla(bz_url, cookiefile=None, tokenfile=None)
+
+        if bz_user and bz_password:
+            bzapi.login(bz_user, bz_password)
+
+        if bzapi.logged_in:
+            log.write("Successfuly logged in as {0}.\n".format(bz_user))
+        else:
+            log.write("Not logged in. Continue as anonymous user.\n")
+
+        query = bzapi.build_query(
+            product="Red Hat Enterprise Linux 7",
+            component="kernel",
+            include_fields=["id"])
+
+        # I don't want to run regex on each and every comment, at first try fast check
+        # if trigger word is in comment and if is, then use slower regex
+        trigger_words = ["retrace-server-interact", "retrace/tasks"]
+
+        regexes = ["retrace-server-interact\s+([0-9]{9})",
+                   CONFIG["SaveDir"] + "/([0-9]{9})/crash/vmcore"]
+
+        query["status"] = ["NEW", "ASSIGNED", "POST", "MODIFIED"]
+
+        found_tasks = {}
+
+        bugs = [x.bug_id for x in bzapi.query(query)]
+
+        while bugs:
+            query = bzapi.build_query(
+                bug_id=bugs[:250],
+                include_fields=["id", "comments"])
+
+            cur_bugs = bzapi.query(query)
+            bugs = bugs[250:]
+            for bug in cur_bugs:
+                found_ids = []
+                for comment in bug.comments:
+                    for i, trigger_word in enumerate(trigger_words):
+                        if trigger_word in comment["text"]:
+                            m = re.findall(regexes[i], comment["text"])
+                            if m:
+                                for bzid in m:
+                                    if bzid not in found_ids:
+                                        found_ids.append(bzid)
+                for f in found_ids:
+                    if f in found_tasks.keys():
+                        found_tasks[f].append(str(bug.bug_id))
+                    else:
+                        found_tasks[f] = [str(bug.bug_id)]
+
+        try:
+            files = sorted(os.listdir(CONFIG["SaveDir"]))
+        except OSError as ex:
+            files = []
+            log.write("Error listing task directory: %s\n" % ex)
+
+        # Find all tasks
+        existing_tasks = []
+        for taskid in files:
+            if not os.path.isdir(os.path.join(CONFIG["SaveDir"], taskid)):
+                continue
+
+            existing_tasks.append(taskid)
+
+        log.write("------------Existing tasks with found bugzillas-----------\n")
+        for taskid in found_tasks.keys():
+            if taskid in existing_tasks:
+                log.write("Task {0} has following bugzilla(s): {1}.\n".format(taskid, ", ".join(found_tasks[taskid])))
+                try:
+                    task = RetraceTask(taskid)
+                except Exception:
+                    continue
+
+                if task.has_bugzillano():
+                    current = task.get_bugzillano()
+                    found = found_tasks[taskid]
+                    # only set bugzillano if some found bugzillas aren't in current bugzillano list
+                    if not set(found).issubset(current):
+                        task.set_bugzillano(current + found)
+                else:
+                    task.set_bugzillano(found_tasks[taskid])
+
+        log.write("\n\n------------Found tasks in bugzillas that do not exist on local system-----------\n")
+        for taskid in found_tasks.keys():
+            if taskid not in existing_tasks:
+                log.write("Unknown task {0} has following bugzilla(s): {1}.\n".format(taskid, ", ".join(found_tasks[taskid])))
+
+        log.write("\n\n------------Existing tasks that no bugzilla was found for-----------\n")
+        no_bz_tasks = [taskid for taskid in existing_tasks if taskid not in found_tasks.keys()]
+        log.write("{0}\n\n".format(", ".join(no_bz_tasks)))

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -8,7 +8,7 @@ import os
 import re
 import time
 import bugzilla
-from retrace import config, RetraceTask
+from retrace import BUGZILLA_STATUS, config, RetraceTask
 
 CONFIG = config.Config()
 
@@ -46,7 +46,8 @@ if __name__ == "__main__":
         regexes = ["retrace-server-interact\s+([0-9]{9})",
                    CONFIG["SaveDir"] + "/([0-9]{9})/crash/vmcore"]
 
-        query["status"] = ["NEW", "ASSIGNED", "POST", "MODIFIED"]
+        config_status = [x.strip() for x in CONFIG["BugzillaStatus"].split(",")]
+        query["status"] = list(set(BUGZILLA_STATUS).difference(config_status))
 
         found_tasks = {}
 

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -20,17 +20,24 @@ if __name__ == "__main__":
 
         # connect to bugzilla
         bz_url = CONFIG["BugzillaURL"]
-        bz_user = CONFIG["BugzillaUsername"]
-        bz_password = CONFIG["BugzillaPassword"]
+        bz_creds = CONFIG["BugzillaCredentials"]
         bz_status_list = [x.strip() for x in CONFIG["BugzillaStatus"].split(",")]
 
-        bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
+        try:
+            bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
+        except (bugzilla.BugzillaError, ValueError) as e:
+            log.write("Exception: {0}".format(e))
+            exit(1)
 
-        if bz_user and bz_password:
-            bzapi.login(bz_user, bz_password)
+        if not bzapi.logged_in and bz_creds:
+            bzapi.readconfig(bz_creds)
+            try:
+                bzapi.connect()
+            except (bugzilla.BugzillaError, ValueError) as e:
+                log.write("Exception: {0}".format(e))
 
         if bzapi.logged_in:
-            log.write("Successfuly logged in as {0}.\n".format(bz_user))
+            log.write("Successfuly logged in as {0}.\n".format(bzapi.user))
         else:
             log.write("Not logged in. Continue as anonymous user.\n")
 

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -56,5 +56,5 @@ if __name__ == "__main__":
                 for bgz in bz_list:
                     if bgz and bgz.status not in bz_status_list:
                         log.write("Modifying time of the task %s\n" % filename)
-                        os.utime(task.get_savedir(), None)
+                        task.reset_age()
                         break

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         # connect to bugzilla
         bz_url = CONFIG["BugzillaURL"]
         bz_creds = CONFIG["BugzillaCredentials"]
-        bz_status_list = [x.strip() for x in CONFIG["BugzillaStatus"].split(",")]
+        bz_status_list = CONFIG.get_list("BugzillaStatus")
 
         try:
             bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -1,0 +1,60 @@
+#!/usr/bin/python2
+"""
+Refresh tasks that have bugzilla bugs in an open state to prevent them from getting deleted by
+retrace-server-cleanup tool.
+"""
+
+import os
+import bugzilla
+from retrace import config, RetraceTask
+import time
+
+CONFIG = config.Config()
+
+if __name__ == "__main__":
+
+    logfile = os.path.join(CONFIG["LogDir"], "bugzilla-refresh.log")
+
+    with open(logfile, "a") as log:
+        log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running bugzilla refresh\n"))
+
+        # connect to bugzilla
+        bz_url = CONFIG["BugzillaURL"]
+        bz_user = CONFIG["BugzillaUsername"]
+        bz_password = CONFIG["BugzillaPassword"]
+        bz_status_list = [x.strip() for x in CONFIG["BugzillaStatus"].split(",")]
+
+        bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
+
+        if bz_user and bz_password:
+            bzapi.login(bz_user, bz_password)
+
+        if bzapi.logged_in:
+            log.write("Successfuly logged in as {0}.\n".format(bz_user))
+        else:
+            log.write("Not logged in. Continue as anonymous user.\n")
+
+        try:
+            files = os.listdir(CONFIG["SaveDir"])
+        except OSError as ex:
+            files = []
+            log.write("Error listing task directory: %s\n" % ex)
+
+        for filename in files:
+            try:
+                task = RetraceTask(filename)
+            except Exception:
+                continue
+
+            if task.has_bugzillano():
+                bz_id_list = task.get_bugzillano()
+                if not bz_id_list:
+                    continue
+
+                bz_list = bzapi.getbugs(bz_id_list)
+
+                for bgz in bz_list:
+                    if bgz and bgz.status not in bz_status_list:
+                        log.write("Modifying time of the task %s\n" % filename)
+                        os.utime(task.get_savedir(), None)
+                        break

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         exit(1)
 
     # touch the task directory
-    os.utime(task.get_savedir(), None)
+    task.reset_age()
 
     if args.action == "printdir":
         sys.stdout.write("%s\n" % task.get_savedir())

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -123,6 +123,19 @@ def parse_caseno(response):
                 return "Case number is not set."
             return candidate
 
+def parse_bugzillano(response):
+    """Parse bugzillano from manager page."""
+    key_string = 'Update bugzilla no.'
+    lines = response.text.split("\n")
+    for line in lines:
+        if key_string in line:
+            first = line.find("value=")+7
+            last = line.find('"', first)
+            candidate = line[first:last]
+            if candidate == key_string:
+                return "Bugzilla number is not set."
+            return candidate
+
 
 def create_new_task(args):
     """Start new task."""
@@ -221,6 +234,9 @@ def create_new_task(args):
 
     if ARGS['caseno']:
         update_caseno(ARGS)
+
+    if ARGS['bugzillano']:
+        update_bugzillano(ARGS)
 
     return (task_id, None)
 
@@ -321,6 +337,27 @@ def get_caseno(args):
     print(caseno)
     return 1
 
+def get_bugzillano(args):
+    """Get bugzilla number of a task."""
+    # Only supported for manager tasks
+    if args['password']:
+        print("Bugzilla numbers are supported for manager and ftp tasks")
+        sys.exit(1)
+
+    LOGGER.info("Getting bugzilla number from server %s",
+                args['server'] + "/manager/" + args['TASK_ID'])
+
+    server = args['server'] + "/manager/" + args['TASK_ID']
+    res = requests.get(server,
+                       verify=(not args['no_verify']),
+                       auth=args['kerberos'])
+
+    if check_response(res, False):
+        print("Error: bugzillano is only supported for manager and ftp tasks")
+        return 0
+    bugzillano = parse_bugzillano(res)
+    print(bugzillano)
+    return 1
 
 def get_backtrace(args):
     """Get a backtrace of the task."""
@@ -407,6 +444,22 @@ def update_caseno(args):
     print("Added case number '{0}' to the task '{1}'"
           .format(args['caseno'], args['TASK_ID']))
 
+def update_bugzillano(args):
+    """Update bugzilla number of the task."""
+    # Only supported for manager tasks
+    if args['password']:
+        print("Case number is only supported for manager and ftp tasks")
+        sys.exit(1)
+    server = args['server'] + "/manager/" + args['TASK_ID'] + "/bugzillano"
+    res = requests.post(server,
+                        data={"bugzillano": args['bugzillano']},
+                        verify=(not args['no_verify']),
+                        auth=args['kerberos'])
+
+    check_response(res)
+    print("Added bugzilla number '{0}' to the task '{1}'"
+          .format(args['bugzillano'], args['TASK_ID']))
+
 if __name__ == "__main__":
     # parse arguments
     PARSER = argparse.ArgumentParser(description=("Create, watch and set"
@@ -463,6 +516,9 @@ if __name__ == "__main__":
         tmp.add_argument("-c", "--caseno",
                          help=("Set caseno to the task."
                                "Only takes affect with -f or -m"))
+        tmp.add_argument("-bz", "--bugzillano",
+                         help=("Set bugzillano to the task."
+                               "Only takes affect with -f or -m"))
 
     TMP = TASK_PARSER.add_parser('get')
     TMP.add_argument("TASK_ID",
@@ -491,6 +547,9 @@ if __name__ == "__main__":
     GET_TYPE.add_argument("-c", "--caseno", action="store_const",
                           dest="get_type", const="caseno",
                           help="Get set case number of the task.")
+    GET_TYPE.add_argument("-bz", "--bugzillano", action="store_const",
+                          dest="get_type", const="bugzillano",
+                          help="Get set bugzilla number of the task.")
 
     TMP = TASK_PARSER.add_parser('set')
     TMP.add_argument("TASK_ID",
@@ -507,6 +566,8 @@ if __name__ == "__main__":
                      help="Set case number of the task.")
     TMP.add_argument("-e", "--email",
                      help="Set email to the task.")
+    TMP.add_argument("-bz", "--bugzillano",
+                     help="Set bugzilla number of the task.")
 
     ARGS = vars(PARSER.parse_args())
 
@@ -575,6 +636,8 @@ if __name__ == "__main__":
             get_email(ARGS)
         elif ARGS['get_type'] == "caseno":
             get_caseno(ARGS)
+        elif ARGS['get_type'] == "bugzillano":
+            get_bugzillano(ARGS)
         else:
             print("Status: {0}".format(get_status(ARGS)))
 
@@ -583,3 +646,5 @@ if __name__ == "__main__":
             update_email(ARGS)
         if ARGS['caseno']:
             update_caseno(ARGS)
+        if ARGS['bugzillano']:
+            update_bugzillano(ARGS)

--- a/src/retrace-server-task.txt
+++ b/src/retrace-server-task.txt
@@ -10,15 +10,15 @@ SYNOPSIS
 'retrace-server-task' create [-h] [-u | -k] [-t | -m | -f] [-i] [-d]
                              [-s SERVER] [-n] [-v] [-r KERNELVER]
                              [-o OS_RELEASE] [-p PACKAGE] [-x EXECUTABLE]
-                             [-e EMAIL] [-c CASENO]
+                             [-e EMAIL] [-c CASENO] [-bz BUGZILLANO]
                              COREFILE
 
 'retrace-server-task' get [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
-                          [-t | -b | -m | -e | -c]
+                          [-t | -b | -m | -e | -c | -bz]
                           TASK_ID
 
 'retrace-server-task' set [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
-                          [-c CASENO] [-e EMAIL]
+                          [-c CASENO] [-e EMAIL] [-bz BUGZILLANO]
                           TASK_ID
 
 DESCRIPTION
@@ -112,6 +112,10 @@ GET OPTIONS
 -b, --backtrace::
    Return the backtrace in a file in the current directory
 
+-bz, --bugzillano::
+   Return the value of the bugzillano field in the task to the terminal.
+   Available only for manager and ftp task.
+
 -c, --caseno::
    Return the value of the caseno field in the task to the terminal.
    Available only for manager and ftp task.
@@ -126,6 +130,9 @@ GET OPTIONS
 
 SET OPTIONS
 -----------
+-bz BUGZILLANO, --bugzillano BUGZILLANO::
+   Write the bugzillano field in the task to BUGZILLANO.
+   Available only for manager and ftp task.
 
 -c CASENO, --caseno CASENO::
    Write the caseno field in the task to CASENO.
@@ -158,6 +165,10 @@ Read the md5sum field for task 925483242
 Write the caseno field for task 925483242 to 01234567
 
    retrace-server-task set --caseno 01234567 925483242
+
+Write the bugzillano field for task 31415926 to 53589793, 23846264
+
+   retrace-server-task set --bugzillano 53589793,23846264 31415926
 
 AUTHORS
 -------

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -77,6 +77,10 @@ class Config(object):
             "BugzillaURL": "https://bugzilla.redhat.com",
             "BugzillaStatus": "VERIFIED, RELEASE_PENDING, CLOSED",
             "BugzillaCredentials": "",
+            "BugzillaProduct": "Red Hat Enterprise Linux 7",
+            "BugzillaComponent": "kernel",
+            "BugzillaTriggerWords": "",
+            "BugzillaRegExes": "",
             "Crashi386": "",
         }
 
@@ -128,6 +132,9 @@ class Config(object):
 
         def get_arch_hosts(self):
             return self.ARCH_HOSTS
+
+        def get_list(self, key, sep=","):
+            return [val.strip() for val in self.GLOBAL[key].split(sep) if val.strip()]
 
     instance = None
 

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -76,8 +76,7 @@ class Config(object):
             "CaseNumberURL": "",
             "BugzillaURL": "https://bugzilla.redhat.com",
             "BugzillaStatus": "VERIFIED, RELEASE_PENDING, CLOSED",
-            "BugzillaUsername": "",
-            "BugzillaPassword": "",
+            "BugzillaCredentials": "",
             "Crashi386": "",
         }
 

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -74,6 +74,10 @@ class Config(object):
             "EmailNotifyFrom": "retrace@localhost",
             "CalculateMd5": True,
             "CaseNumberURL": "",
+            "BugzillaURL": "https://bugzilla.redhat.com",
+            "BugzillaStatus": "VERIFIED, RELEASE_PENDING, CLOSED",
+            "BugzillaUsername": "",
+            "BugzillaPassword": "",
             "Crashi386": "",
         }
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1280,6 +1280,7 @@ class RetraceTask:
 
     BACKTRACE_FILE = "retrace_backtrace"
     CASENO_FILE = "caseno"
+    BUGZILLANO_FILE = "bugzillano"
     CRASHRC_FILE = "crashrc"
     CRASH_CMD_FILE = "crash_cmd"
     DOWNLOADED_FILE = "downloaded"
@@ -2279,6 +2280,26 @@ class RetraceTask:
 
         self.set(RetraceTask.CASENO_FILE, "%d" % data)
 
+    def has_bugzillano(self):
+        """Verifies whether BUGZILLANO_FILE exists"""
+        return self.has(RetraceTask.BUGZILLANO_FILE)
+
+    def get_bugzillano(self):
+        """Gets the bugzilla number from BUGZILLANO_FILE"""
+        result = self.get(RetraceTask.BUGZILLANO_FILE, maxlen=1 << 8)
+        if result is None:
+            return None
+
+        return filter(None, set(n.strip() for n in result.split("\n")))
+
+    def set_bugzillano(self, values):
+        """Writes bugzilla numbers into BUGZILLANO_FILE"""
+        if not isinstance(values, list) or not all([isinstance(v, basestring) for v in values]):
+            raise Exception, "values must be a list of integers"
+
+        self.set_atomic(RetraceTask.BUGZILLANO_FILE,
+                        "%s\n" % "\n".join(filter(None, set(v.strip().replace("\n", " ") for v in values))))
+
     def has_finished_time(self):
         """Verifies whether FINISHED_FILE exists"""
         return self.has(RetraceTask.FINISHED_FILE)
@@ -2328,7 +2349,7 @@ class RetraceTask:
                          RetraceTask.TYPE_FILE, RetraceTask.MISC_DIR,
                          RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
                          RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
-                         RetraceTask.VMLINUX_FILE]:
+                         RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE]:
 
                 path = os.path.join(self._savedir, f)
                 try:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1523,6 +1523,10 @@ class RetraceTask:
         """Returns the age of the task in hours."""
         return int(time.time() - os.path.getmtime(self._savedir)) / 3600
 
+    def reset_age(self):
+        """Reset the age of the task to the current time."""
+        os.utime(self._savedir, None)
+
     def calculate_md5(self, file_name, chunk_size=65536):
         hash_md5 = hashlib.md5()
         with open(file_name, "rb") as f:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -69,6 +69,9 @@ SUFFIX_MAP = {
     ARCHIVE_UNKNOWN: "",
 }
 
+BUGZILLA_STATUS = ["NEW", "ASSIGNED", "ON_DEV", "POST", "MODIFIED", "ON_QA", "VERIFIED",
+                   "RELEASE_PENDING", "CLOSED"]
+
 #characters, numbers, dash (utf-8, iso-8859-2 etc.)
 INPUT_CHARSET_PARSER = re.compile("^([a-zA-Z0-9\-]+)(,.*)?$")
 #en_GB, sk-SK, cs, fr etc.


### PR DESCRIPTION
The field is to be filled with bugzilla numbers. This should help to create
an association between task and bugzilla bugs.

The field is used by these tools:
retrace-server-bzquery:
  Query bugzilla for trigger words. For found tasks fill the bugzilla field
  with bugzilla number.

retrace-server-bugzilla-cleanup:
  Look for tasks with bugzilla field filled in and check the status
  of entered bugzilla bugs. Refresh ones with open bugzilla bugs.