### PR TITLE
py3 compatibility: try-except statement

### DIFF
--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -27,7 +27,7 @@ def kill_process_and_childs(process_id, ps_output=None):
     for pid in get_process_tree(process_id, ps_output):
         try:
             os.kill(pid, 9)
-        except OSError, ex:
+        except OSError:
             result = False
 
     return result
@@ -115,7 +115,7 @@ if __name__ == "__main__":
             # archive old tasks
             try:
                 files = os.listdir(CONFIG["SaveDir"])
-            except OSError, ex:
+            except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 
@@ -151,7 +151,7 @@ if __name__ == "__main__":
             # clean up old tasks
             try:
                 files = os.listdir(CONFIG["SaveDir"])
-            except OSError, ex:
+            except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 
@@ -169,7 +169,7 @@ if __name__ == "__main__":
             # clean up old failed tasks
             try:
                 files = os.listdir(CONFIG["SaveDir"])
-            except OSError, ex:
+            except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 


### PR DESCRIPTION
1. Python 3 uses `as` keyword after the exception type where comma is used in Python 2.
2. Clean-up of unused exception value.

Signed-off-by: Jan Beran <jberan@redhat.com>