### PR TITLE
py3 compatibility: Replacement of basestring with six.string_types

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -33,6 +33,8 @@ Requires: python2-requests
 Requires: python2-requests-kerberos
 Requires: python2-distro
 Requires: python2-bugzilla
+Requires: python2-six
+BuildRequires: python2-six
 %else
 Requires: mod_wsgi
 Requires: python-webob
@@ -41,6 +43,8 @@ Requires: python-requests
 Requires: python-requests-kerberos
 Requires: python-distro
 Requires: python-bugzilla
+Requires: python-six
+BuildRequires: python-six
 %endif
 Requires: mod_ssl
 Requires: sqlite

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -24,6 +24,7 @@ from yum import YumBase
 from config import *
 from plugins import *
 from rpmUtils.miscutils import splitFilename
+import six
 
 GETTEXT_DOMAIN = "retrace-server"
 
@@ -1653,7 +1654,7 @@ class RetraceTask:
         return filter(None, set(n.strip() for n in result.split("\n")))
 
     def set_notify(self, values):
-        if not isinstance(values, list) or not all([isinstance(v, basestring) for v in values]):
+        if not isinstance(values, list) or not all([isinstance(v, six.string_types) for v in values]):
             raise Exception, "values must be a list of strings"
 
         self.set_atomic(RetraceTask.NOTIFY_FILE,


### PR DESCRIPTION
`basestring` is an abstract type in Python 2, a superclass for both `str` and `unicode` string types. In Python 3, there is only one string type of `str`. The compatibility is solved by six library.

Signed-off-by: Jan Beran <jberan@redhat.com>