### PR TITLE
py3 compatibility: Ensure map function to return a list

### DIFF
--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -590,7 +590,7 @@ def application(environ, start_response):
 
                 files = ""
                 if task.has_remote():
-                    remote = map(lambda x: x[4:] if x.startswith("FTP ") else x, task.get_remote())
+                    remote = [x[4:] if x.startswith("FTP ") else x for x in task.get_remote()]
                     files = ", ".join(remote)
 
                 if task.has_downloaded():

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -130,7 +130,7 @@ class RetraceWorker(object):
             if task.has_remote() or task.has_downloaded():
                 files = ""
                 if task.has_remote():
-                    remote = map(lambda x: x[4:] if x.startswith("FTP ") else x, task.get_remote())
+                    remote = [x[4:] if x.startswith("FTP ") else x for x in task.get_remote()]
                     files = ", ".join(remote)
 
                 if task.has_downloaded():


### PR DESCRIPTION
`map()` built-in function returns a list on Python 2, but an iterator on Python 3. If the first argument to `map()` is a lambda function, then it is converted to an equivalent list comprehension.

Signed-off-by: Jan Beran <jberan@redhat.com>