### PR TITLE
py3 compatibility: Use 'sorted' built-in function

### DIFF
--- a/src/bt_filter
+++ b/src/bt_filter
@@ -195,8 +195,7 @@ def backtrace_report(bt_hash, bt_proc):
 
         pid_output = ""
         line = ''
-        tasks = task_list.keys()
-        tasks.sort()
+        tasks = sorted(task_list.keys())
         for t in tasks:
             line = line + "  %s *%d[" % (t, len(task_list[t]))
             for pid in task_list[t]:


### PR DESCRIPTION
`sorted()` built-in function builds a new sorted list from an iterable.

Signed-off-by: Jan Beran <jberan@redhat.com>