### PR TITLE
py3 compatibility: Set literals

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -148,11 +148,11 @@ STATUS = [
     "Calculating md5sum",
 ]
 
-ARCHITECTURES = set(["src", "noarch", "i386", "i486", "i586", "i686", "x86_64",
+ARCHITECTURES = {"src", "noarch", "i386", "i486", "i586", "i686", "x86_64",
                      "s390", "s390x", "ppc", "ppc64", "ppc64le", "ppc64iseries",
                      "armel", "armhfp", "armv5tel", "armv7l", "armv7hl",
                      "armv7hnl", "aarch64", "sparc", "sparc64", "mips4kec",
-                     "ia64"])
+                     "ia64"}
 
 # armhfp is not correct, but there is no way to distinguish armv5/armv6/armv7 coredumps
 # as armhfp (RPM armv7hl) is the only supported now, let's approximate arm = armhfp
@@ -161,13 +161,13 @@ ARCHITECTURES = set(["src", "noarch", "i386", "i486", "i586", "i686", "x86_64",
 # "alarm" or "hdparm" and thus leads to wrong results.
 # As soon as plain "arm" needs to be supported, this needs to be solved properly.
 ARCH_MAP = {
-    "i386": set(["i386", "i486", "i586", "i686"]),
-    "armhfp": set(["armhfp", "armel", "armv5tel", "armv7l", "armv7hl", "armv7hnl"]),
-    "x86_64": set(["x86_64"]),
-    "s390x": set(["s390x"]),
-    "ppc64": set(["ppc64"]),
-    "ppc64le": set(["ppc64le"]),
-    "aarch64": set(["aarch64"]),
+    "i386": {"i386", "i486", "i586", "i686"},
+    "armhfp": {"armhfp", "armel", "armv5tel", "armv7l", "armv7hl", "armv7hnl"},
+    "x86_64": {"x86_64"},
+    "s390x": {"s390x"},
+    "ppc64": {"ppc64"},
+    "ppc64le": {"ppc64le"},
+    "aarch64": {"aarch64"},
 }
 
 PYTHON_LABLE_START = "----------PYTHON-START--------"


### PR DESCRIPTION
The new literal syntax for sets is available and preferred in Python 3 (the use of curly braces). It has been backported to Python 2.7.

Signed-off-by: Jan Beran <jberan@redhat.com>