### PR TITLE
py3 compatibility: Removal of tuple parameter unpacking

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -709,7 +709,7 @@ def get_files_sizes(directory):
         elif os.path.isdir(fullpath):
             result += get_files_sizes(fullpath)
 
-    return sorted(result, key=lambda (f, s): s, reverse=True)
+    return sorted(result, key=lambda f_s: f_s[1], reverse=True)
 
 def get_archive_type(path):
     ms = magic.open(magic.MAGIC_NONE)


### PR DESCRIPTION
Replacement of `lambda (a, b): function(a, b)` with `lambda a_b: function(a_b[0], a_b[1])` according to PEP 3113.

Signed-off-by: Jan Beran <jberan@redhat.com>