### PR TITLE
py3 compatibility: Classic division

### DIFF
--- a/src/index.wsgi
+++ b/src/index.wsgi
@@ -1,3 +1,4 @@
+from __future__ import division
 from retrace import *
 
 CONFIG = config.Config()
@@ -25,7 +26,7 @@ def application(environ, start_response):
         https = _("Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because of security reasons.")
     releases = _("The following releases are supported: %s" % ", ".join(sorted(get_supported_releases())))
     active = len(get_active_tasks())
-    running = _("At the moment the server is loaded for %d%% (running %d out of %d jobs)." % (100 * active / CONFIG["MaxParallelTasks"], active, CONFIG["MaxParallelTasks"]))
+    running = _("At the moment the server is loaded for %d%% (running %d out of %d jobs)." % (100 * active // CONFIG["MaxParallelTasks"], active, CONFIG["MaxParallelTasks"]))
     disclaimer1 = _("Your coredump is only kept on the server while the retrace job is running. "
                     "Once the job is finished, the server keeps retrace log and backtrace. "
                     "All the other data (including coredump) are deleted. "

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -1,4 +1,5 @@
 #!/usr/bin/python2
+from __future__ import division
 import os
 import sys
 from retrace import *
@@ -109,7 +110,7 @@ if __name__ == "__main__":
             else:
                 md5_tasks[md5] = task
 
-        log.write("Total space savings from duplicate task hardlinking (md5sums equal, different inodes): %d MB\n" % (total_savings / 1024 / 1024))
+        log.write("Total space savings from duplicate task hardlinking (md5sums equal, different inodes): %d MB\n" % (total_savings // 1024 // 1024))
 
         if CONFIG["ArchiveTaskAfter"] > 0:
             # archive old tasks

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import ConfigParser
 import datetime
 import errno
@@ -1525,7 +1526,7 @@ class RetraceTask:
 
     def get_age(self):
         """Returns the age of the task in hours."""
-        return int(time.time() - os.path.getmtime(self._savedir)) / 3600
+        return int(time.time() - os.path.getmtime(self._savedir)) // 3600
 
     def reset_age(self):
         """Reset the age of the task to the current time."""
@@ -1682,7 +1683,7 @@ class RetraceTask:
     def download_block(self, data):
         self._progress_write_func(data)
         self._progress_current += len(data)
-        progress = "%d%% (%s / %s)" % ((100 * self._progress_current) / self._progress_total,
+        progress = "%d%% (%s / %s)" % ((100 * self._progress_current) // self._progress_total,
                                        human_readable_size(self._progress_current),
                                        self._progress_total_str)
         self.set_atomic(RetraceTask.PROGRESS_FILE, progress)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import grp
 import time
 import sys
@@ -611,7 +612,7 @@ class RetraceWorker(object):
             log_error("ERROR: Failed to dedup %s and %s - rename hardlink %s to %s failed" % (v1, v2, v2_link, v2));
             return 0
 
-        log_warn("Successful dedup - created hardlink from %s to %s saving %d MB" % (v2, v1, s1.st_size / 1024 / 1024))
+        log_warn("Successful dedup - created hardlink from %s to %s saving %d MB" % (v2, v1, s1.st_size // 1024 // 1024))
 
         return s1.st_size
 


### PR DESCRIPTION
Support of the same "classic" division in both Python 2 and 3 simultaneously. It is related to such a division when both operators are `int`.

Signed-off-by: Jan Beran <jberan@redhat.com>