### PR TITLE
py3 compatibility: Replace ConfigParser module with configparser

### DIFF
--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -8,8 +8,14 @@
 #   must be called. When this function was not called, is automatically called
 #   before first reading from GLOBAL with default path.
 #Note:all modules share one instance, therefore only one load is needed.
-import ConfigParser
 import os
+
+if sys.version_info.major == 2:
+#Python 2
+    import ConfigParser as configparser # pylint: disable=import-error
+else:
+#Python 3+
+    import configparser
 
 DF_BIN = "@DF_BIN@"
 DU_BIN = "@DU_BIN@"
@@ -95,7 +101,7 @@ class Config(object):
             env_config_path = os.environ.get('RETRACE_SERVER_CONFIG_PATH')
             if env_config_path:
                 filepath = env_config_path
-            parser = ConfigParser.ConfigParser()
+            parser = configparser.ConfigParser()
             parser.read(filepath)
             for key in self.GLOBAL.keys():
                 vartype = type(self.GLOBAL[key])
@@ -112,7 +118,7 @@ class Config(object):
 
                 try:
                     self.GLOBAL[key] = get("retrace", key)
-                except ConfigParser.NoOptionError:
+                except configparser.NoOptionError:
                     pass
 
             if "archhosts" in parser.sections():


### PR DESCRIPTION
The `ConfigParser` module of Python 2 is renamed to `configparser` in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>