### PR TITLE
py3 compatibility: Adjust imports

### DIFF
--- a/src/retrace/__init__.py
+++ b/src/retrace/__init__.py
@@ -1,2 +1,2 @@
-from retrace import *
-from retrace_worker import RetraceWorker
+from .retrace import *
+from .retrace_worker import RetraceWorker

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -19,11 +19,11 @@ import hashlib
 from signal import *
 from subprocess import *
 import magic
-from argparser import *
+from .argparser import *
 from webob import Request
 from yum import YumBase
-from config import *
-from plugins import *
+from .config import *
+from .plugins import *
 from rpmUtils.miscutils import splitFilename
 import six
 
@@ -2407,7 +2407,7 @@ class RetraceTask:
     def create_worker(self):
         """Get default worker instance for this task"""
         # TODO: let it be configurable
-        from retrace_worker import RetraceWorker
+        from .retrace_worker import RetraceWorker
         return RetraceWorker(self)
 
 ### create ConfigClass instance on import ###

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -4,7 +4,7 @@ import time
 import sys
 import distro
 sys.path.insert(0, "/usr/share/retrace-server/")
-from retrace import *
+from .retrace import *
 
 CONFIG = Config()
 


### PR DESCRIPTION
In Python 3, imports can be either absolute or explicitly relative; implicit relative imports are forbidden.

Signed-off-by: Jan Beran <jberan@redhat.com>