### PR TITLE
py3 compatibility: Replace filter function with a list equivalent

### DIFF
--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -126,7 +126,7 @@ def application(environ, start_response):
 
             if "bugzillano" in get:
                 try:
-                    bugzillano = filter(int, set(n.strip() for n in get["bugzillano"][0].replace(";", ",").split(",")))
+                    bugzillano = list(filter(int, set(n.strip() for n in get["bugzillano"][0].replace(";", ",").split(","))))
                     task.set_bugzillano(bugzillano)
                 except Exception:
                     # bugzillano is invalid number - do nothing, it can be set later
@@ -150,7 +150,7 @@ def application(environ, start_response):
             kernelver = str(kernelver)
 
         if "notify" in get:
-            task.set_notify(filter(None, set(n.strip() for n in get["notify"][0].replace(";", ",").split(","))))
+            task.set_notify([email for email in set(n.strip() for n in get["notify"][0].replace(";", ",").split(",")) if email])
 
         if "md5sum" in get:
             task.set_md5sum("Enabled")
@@ -180,7 +180,7 @@ def application(environ, start_response):
             return response(start_response, "404 Not Found", _("There is no such task"))
 
         if "notify" in POST and len(POST["notify"]) > 0:
-            task.set_notify(filter(None, set(n.strip() for n in POST["notify"][0].replace(";", ",").split(","))))
+            task.set_notify([email for email in set(n.strip() for n in POST["notify"][0].replace(";", ",").split(",")) if email])
 
         return response(start_response, "302 Found", "", [("Location", "%s/%d" % (match.group(1), task.get_taskid()))])
     elif match.group(6) and match.group(6) == "caseno":
@@ -214,7 +214,7 @@ def application(environ, start_response):
                 task.delete(RetraceTask.BUGZILLANO_FILE)
             else:
                 try:
-                    bugzillano = filter(int, set(n.strip() for n in POST["bugzillano"][0].replace(";", ",").split(",")))
+                    bugzillano = list(filter(int, set(n.strip() for n in POST["bugzillano"][0].replace(";", ",").split(","))))
                 except ValueError as ex:
                     return response(start_response, "404 Not Found", _("Bugzilla numbers must be integers; %s" % ex))
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1653,7 +1653,7 @@ class RetraceTask:
 
     def get_notify(self):
         result = self.get(RetraceTask.NOTIFY_FILE, maxlen=1 << 16)
-        return filter(None, set(n.strip() for n in result.split("\n")))
+        return [email for email in set(n.strip() for n in result.split("\n")) if email]
 
     def set_notify(self, values):
         if not isinstance(values, list) or not all([isinstance(v, six.string_types) for v in values]):
@@ -2300,7 +2300,7 @@ class RetraceTask:
         if result is None:
             return None
 
-        return filter(None, set(n.strip() for n in result.split("\n")))
+        return [bz_number for bz_number in set(n.strip() for n in result.split("\n")) if bz_number]
 
     def set_bugzillano(self, values):
         """Writes bugzilla numbers into BUGZILLANO_FILE"""


### PR DESCRIPTION
In Python 2, `filter(function, iterable)` returns a list and is equivalent
to `[item for item in iterable if function(item)]` if function is not `None`
and `[item for item in iterable if item]` if function is `None`. In Python 3,
the function returns an iterator. The replacement of Python 2 `filter()`
function with a proper equivalent or wrapping a call to `filter()`
with a call to `list()` solves the Python 3 compatibility.

Signed-off-by: Jan Beran <jberan@redhat.com>