### PR TITLE
py3 compatibility: Adjust urllib, urllib2 and urlparse

### DIFF
--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -1,8 +1,7 @@
 #!/usr/bin/python2
 import fnmatch
 import re
-import urllib
-import urlparse
+from six.moves import urllib
 from retrace import *
 
 CONFIG = config.Config()
@@ -29,7 +28,7 @@ def async_ftp_list_dir(filterexp):
 
     for fname in tasklist:
         available.append("<tr><td><a href=\"manager/%s\">%s</a></td></tr>" \
-                         % (urllib.quote(fname), fname))
+                         % (urllib.parse.quote(fname), fname))
 
     available.append(tablefooter)
     return "\n            ".join(available)
@@ -40,7 +39,7 @@ def application(environ, start_response):
     _ = parse_http_gettext("%s" % request.accept_language,
                            "%s" % request.accept_charset)
 
-    get = urlparse.parse_qs(request.query_string)
+    get = urllib.parse.parse_qs(request.query_string)
     filterexp = None
     if "filterexp" in get:
         filterexp = get["filterexp"][0]

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -2,8 +2,7 @@
 import datetime
 import fnmatch
 import re
-import urllib
-import urlparse
+from six.moves import urllib
 from retrace import *
 
 CONFIG = config.Config()
@@ -61,7 +60,7 @@ def application(environ, start_response):
 
     filename = match.group(4)
     if filename:
-        filename = urllib.unquote(match.group(4))
+        filename = urllib.parse.unquote(match.group(4))
 
     space = free_space(CONFIG["SaveDir"])
     if space is None:
@@ -79,7 +78,7 @@ def application(environ, start_response):
         return response(start_response, "200 OK", task.get_misc(match.group(9)))
     elif match.group(6) and match.group(6) == "start":
         # start
-        get = urlparse.parse_qs(request.query_string)
+        get = urllib.parse.parse_qs(request.query_string)
         ftptask = False
         try:
             task = RetraceTask(filename)
@@ -162,7 +161,7 @@ def application(environ, start_response):
 
         return response(start_response, "303 See Other", "", [("Location", "%s/%d" % (match.group(1), task.get_taskid()))])
     elif match.group(6) and match.group(6) == "savenotes":
-        POST = urlparse.parse_qs(request.body, keep_blank_values=1)
+        POST = urllib.parse.parse_qs(request.body, keep_blank_values=1)
         try:
             task = RetraceTask(filename)
         except:
@@ -173,7 +172,7 @@ def application(environ, start_response):
 
         return response(start_response, "302 Found", "", [("Location", "%s/%d" % (match.group(1), task.get_taskid()))])
     elif match.group(6) and match.group(6) == "notify":
-        POST = urlparse.parse_qs(request.body, keep_blank_values=1)
+        POST = urllib.parse.parse_qs(request.body, keep_blank_values=1)
         try:
             task = RetraceTask(filename)
         except:
@@ -184,7 +183,7 @@ def application(environ, start_response):
 
         return response(start_response, "302 Found", "", [("Location", "%s/%d" % (match.group(1), task.get_taskid()))])
     elif match.group(6) and match.group(6) == "caseno":
-        POST = urlparse.parse_qs(request.body, keep_blank_values=1)
+        POST = urllib.parse.parse_qs(request.body, keep_blank_values=1)
         try:
             task = RetraceTask(filename)
         except:
@@ -203,7 +202,7 @@ def application(environ, start_response):
 
         return response(start_response, "302 Found", "", [("Location", "%s/%d" % (match.group(1), task.get_taskid()))])
     elif match.group(6) and match.group(6) == "bugzillano":
-        POST = urlparse.parse_qs(request.body, keep_blank_values=1)
+        POST = urllib.parse.parse_qs(request.body, keep_blank_values=1)
         try:
             task = RetraceTask(filename)
         except Exception:
@@ -251,7 +250,7 @@ def application(environ, start_response):
 
         return response(start_response, "302 Found", "", [("Location", match.group(1))])
     elif filename and filename == "__custom__":
-        POST = urlparse.parse_qs(request.body, keep_blank_values=1)
+        POST = urllib.parse.parse_qs(request.body, keep_blank_values=1)
 
         qs_base = []
         if "md5sum" in POST and POST["md5sum"][0] == "on":
@@ -271,7 +270,7 @@ def application(environ, start_response):
                 except:
                     return response(start_response, "403 Forbidden", _("Please use VRA format for kernel version (e.g. 2.6.32-287.el6.x86_64)"))
 
-                qs_base.append("kernelver=%s" % urllib.quote(vra))
+                qs_base.append("kernelver=%s" % urllib.parse.quote(vra))
 
         try:
             task = RetraceTask()
@@ -711,7 +710,7 @@ def application(environ, start_response):
         if filterexp:
             qs["filterexp"] = filterexp
 
-        qs_text = urllib.urlencode(qs)
+        qs_text = urllib.parse.urlencode(qs)
 
         if qs_text:
             starturl = "\"%s?%s\"" % (starturl, qs_text)

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -2,9 +2,9 @@
 
 import sys
 import os
-import urllib2
 from subprocess import Popen, PIPE
 import argparse
+from six.moves import urllib
 
 
 argparser = argparse.ArgumentParser(description="Retrace Server plugin checker")
@@ -44,7 +44,7 @@ for i, r in enumerate(plugin.repos):
         mirror_path = p.replace("$VER", args.VERSION).replace("$ARCH", args.ARCHITECTURE)
         if p.startswith("http:") or p.startswith("https:") or p.startswith("ftp:"):
             try:
-                urllib2.urlopen(mirror_path)
+                urllib.request.urlopen(mirror_path)
                 path_ok = True
             except Exception as ex:
                 pass

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -13,18 +13,17 @@ import smtplib
 import sqlite3
 import stat
 import time
-import urllib
 import hashlib
 from signal import *
 from subprocess import *
 import magic
-from .argparser import *
+import six
+from six.moves import range, urllib
+from rpmUtils.miscutils import splitFilename
 from webob import Request
+from .argparser import *
 from .config import *
 from .plugins import *
-from rpmUtils.miscutils import splitFilename
-import six
-from six.moves import range
 
 GETTEXT_DOMAIN = "retrace-server"
 
@@ -1398,12 +1397,12 @@ class RetraceTask:
         if arch:
             qs["arch"] = arch
 
-        qs_text = urllib.urlencode(qs)
+        qs_text = urllib.parse.urlencode(qs)
 
         if qs_text:
             starturl = "%s?%s" % (starturl, qs_text)
 
-        url = urllib.urlopen(starturl)
+        url = urllib.request.urlopen(starturl)
         status = url.getcode()
         url.close()
 

--- a/src/start.wsgi
+++ b/src/start.wsgi
@@ -1,4 +1,4 @@
-import urlparse
+from six.moves import urllib
 from retrace import *
 
 CONFIG = config.Config()
@@ -24,7 +24,7 @@ def application(environ, start_response):
         return response(start_response, "404 Not Found",
                         _("There is no such task"))
 
-    qs = urlparse.parse_qs(request.query_string, keep_blank_values=True)
+    qs = urllib.parse.parse_qs(request.query_string, keep_blank_values=True)
 
     debug = "debug" in qs
 


### PR DESCRIPTION
`urllib2` and `urlparse` have been moved to `urllib` in Python 3 and `urllib` has been split up. The `urllib` changes follow an order of imports recommended by `pylint` tool.

Signed-off-by: Jan Beran <jberan@redhat.com>