### PR TITLE
Skip tasks with no vmcore or invalid md5sum

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -934,7 +934,7 @@ def get_md5_tasks():
         if not task.has_finished_time():
             continue
 
-        if not task.has_vmcore():
+        if not task.has_vmcore() and not task.has_coredump():
             continue
 
         if not task.has_md5sum():
@@ -1316,6 +1316,7 @@ class RetraceTask:
     URL_FILE = "url"
     VMLINUX_FILE = "vmlinux"
     VMCORE_FILE = "crash/vmcore"
+    COREDUMP_FILE = "crash/coredump"
     MOCK_DEFAULT_CFG = "default.cfg"
     MOCK_SITE_DEFAULTS_CFG = "site-defaults.cfg"
     MOCK_LOGGING_INI = "logging.ini"
@@ -1693,6 +1694,10 @@ class RetraceTask:
     def has_vmcore(self):
         vmcore_path = os.path.join(self._savedir, RetraceTask.VMCORE_FILE)
         return os.path.isfile(vmcore_path)
+
+    def has_coredump(self):
+        coredump_path = os.path.join(self._savedir, RetraceTask.COREDUMP_FILE)
+        return os.path.isfile(coredump_path)
 
     def download_block(self, data):
         self._progress_write_func(data)

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -97,6 +97,8 @@ DUMP_LEVEL_PARSER = re.compile("^[ \t]*dump_level[ \t]*:[ \t]*([0-9]+).*$")
 
 WORKER_RUNNING_PARSER = re.compile("^[ \t]*([0-9]+)[ \t]+[0-9]+[ \t]+([^ ^\t]+)[ \t]+.*retrace-server-worker ([0-9]+)( .*)?$")
 
+MD5_PARSER = re.compile("[a-fA-F0-9]{32}")
+
 UNITS = ["B", "kB", "MB", "GB", "TB", "PB", "EB"]
 
 HANDLE_ARCHIVE = {
@@ -932,8 +934,17 @@ def get_md5_tasks():
         if not task.has_finished_time():
             continue
 
-        if task.has_md5sum():
-            tasks.append(task)
+        if not task.has_vmcore():
+            continue
+
+        if not task.has_md5sum():
+            continue
+
+        md5 = str.split(task.get_md5sum())[0]
+        if not MD5_PARSER.search(md5):
+            continue
+
+        tasks.append(task)
 
     return tasks
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1304,6 +1304,7 @@ class RetraceTask:
     TYPE_FILE = "type"
     URL_FILE = "url"
     VMLINUX_FILE = "vmlinux"
+    VMCORE_FILE = "crash/vmcore"
     MOCK_DEFAULT_CFG = "default.cfg"
     MOCK_SITE_DEFAULTS_CFG = "site-defaults.cfg"
     MOCK_LOGGING_INI = "logging.ini"
@@ -1677,6 +1678,10 @@ class RetraceTask:
 
     def set_vmlinux(self, value):
         self.set(RetraceTask.VMLINUX_FILE, value)
+
+    def has_vmcore(self):
+        vmcore_path = os.path.join(self._savedir, RetraceTask.VMCORE_FILE)
+        return os.path.isfile(vmcore_path)
 
     def download_block(self, data):
         self._progress_write_func(data)


### PR DESCRIPTION
I did not file any bug for these two changes but they are minor fixups related to the md5sum patchset to cover a few corner cases.  This was tested in our development / test retrace-server instance and avoids the problems described in the patch header and not causing any valid dedup to be skipped.