### PR TITLE
Correct syntax for gdb backtrace command

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -383,7 +383,7 @@ def run_gdb(savedir, plugin):
                           "-ex 'py-list' "
                           "-ex 'py-locals' "
                           "-ex 'echo %s\n' "
-                          "-ex 'thread apply all -ascending backtrace 2048 full' "
+                          "-ex 'thread apply all -ascending backtrace full 2048' "
                           "-ex 'info sharedlib' "
                           "-ex 'print (char*)__abort_msg' "
                           "-ex 'print (char*)__glib_assert_msg' "


### PR DESCRIPTION
The test failed on rawhide (gdb v8.1.50) with error message:
"A syntax error in expression, near `full'."

According to the GDB documentation the correct syntax for backtrace
command is `backtrace [full] n`.

- https://sourceware.org/gdb/onlinedocs/gdb/Backtrace.html

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>