### PR TITLE
cleanup: Add check for opened crash files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,15 @@ AC_PATH_PROG([XMLTO], [xmlto], [no])
     [exit 1]
 [fi]
 
+AC_PATH_PROG([LSOF], [lsof], [no])
+[if test "$LSOF" = "no"]
+[then]
+    [echo "The lsof program was not found in the search path. Please ensure"]
+    [echo "that it is installed and its directory is included in the search path."]
+    [echo "Then run configure again before attempting to build Retrace server."]
+    [exit 1]
+[fi]
+
 PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -18,6 +18,7 @@ BuildRequires: libtool
 BuildRequires: texinfo
 BuildRequires: asciidoc
 BuildRequires: xmlto
+BuildRequires: lsof
 BuildRequires: python3-six
 BuildRequires: python3-devel
 
@@ -30,6 +31,7 @@ Requires: tar
 Requires: p7zip
 Requires: unzip
 Requires: lzop
+Requires: lsof
 Requires: elfutils
 Requires: createrepo_c
 Requires: python3-mod_wsgi

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -33,6 +33,25 @@ def kill_process_and_childs(process_id, ps_output=None):
 
     return result
 
+def check_open_crash_file(task):
+    """
+    Check if vmcore or coredump for given task is used by another process.
+    """
+    if task.has_vmcore():
+        crash_path = os.path.join(task.get_savedir(), task.VMCORE_FILE)
+    elif task.has_coredump():
+        crash_path = os.path.join(task.get_savedir(), task.COREDUMP_FILE)
+    else:
+        return False
+
+    lsof = Popen([LSOF_BIN, "+wt", crash_path], stdout=PIPE, encoding='utf-8')
+    pids = lsof.communicate()[0]
+
+    if pids:
+        return True
+
+    return False
+
 def check_config():
     if CONFIG["DeleteTaskAfter"] > 0 and CONFIG["ArchiveTaskAfter"] > 0:
         winner = "archiving"
@@ -164,6 +183,10 @@ if __name__ == "__main__":
                     continue
 
                 if task.get_age() >= CONFIG["DeleteTaskAfter"]:
+                    if check_open_crash_file(task):
+                        log.write("Deletion of task %d skipped - crash file is opened.\n" % task.get_taskid())
+                        continue
+
                     log.write("Deleting old task %s\n" % filename)
                     task.create_worker().remove_task()
 
@@ -182,5 +205,9 @@ if __name__ == "__main__":
                     continue
 
                 if task.get_age() >= CONFIG["DeleteFailedTaskAfter"] and task.get_status() == STATUS_FAIL:
+                    if check_open_crash_file(task):
+                        log.write("Deletion of task %d skipped - crash file is opened.\n" % task.get_taskid())
+                        continue
+
                     log.write("Deleting old failed task %s\n" % filename)
                     task.create_worker().remove_task()

--- a/src/retrace/Makefile.am
+++ b/src/retrace/Makefile.am
@@ -18,4 +18,5 @@ config.py: config.py.in
 	    -e "s|@GZIP_BIN@|$(GZIP)|g" \
 	    -e "s|@TAR_BIN@|$(TAR)|g" \
 	    -e "s|@XZ_BIN@|$(XZ)|g" \
+	    -e "s|@LSOF_BIN@|$(LSOF)|g" \
 	    $< > $@

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -23,6 +23,7 @@ DU_BIN = "@DU_BIN@"
 GZIP_BIN = "@GZIP_BIN@"
 TAR_BIN = "@TAR_BIN@"
 XZ_BIN = "@XZ_BIN@"
+LSOF_BIN = "@LSOF_BIN@"
 
 class Config(object):
     class __config:


### PR DESCRIPTION
Adds a new check to Delete(Failed)TaskAfter procedure to prevent tasks with opened/used vmcore/coredump files from being deleted.

Related: rhbz#1253908

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>