### PR TITLE
Fix ftp.wsgi for Python3 due to sorted() method api change, speed man…

### DIFF
--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -26,7 +26,7 @@ def async_ftp_list_dir(filterexp):
     if filterexp:
         tasklist = sorted(fnmatch.filter(rawtasklist, filterexp))
     else:
-        tasklist = sorted(rawtasklist, cmp=cmp_vmcores_first)
+        tasklist = sorted(rawtasklist)
 
     for fname in tasklist:
         available.append("<tr><td><a href=\"manager/%s\">%s</a></td></tr>" \

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1189,17 +1189,6 @@ def ftp_list_dir(ftpdir="/", ftp=None):
 
     return result
 
-def cmp_vmcores_first(str1, str2):
-    vmcore1 = "vmcore" in str1.lower()
-    vmcore2 = "vmcore" in str2.lower()
-
-    if vmcore1 and not vmcore2:
-        return -1
-    elif not vmcore1 and vmcore2:
-        return 1
-
-    return cmp(str1, str2)
-
 def check_run(cmd):
     child = Popen(cmd, stdout=PIPE, stderr=STDOUT, encoding='utf-8')
     stdout = child.communicate()[0]


### PR DESCRIPTION
…ager load

In Python3 the sorted() method changed to no longer have a 'cmp' method.
Further, the 'cmp' method is stated to be slow, and we've had issues
where the 'manager' page can be slow to load.  Per Python2 reference:
https://docs.python.org/2/library/functions.html#sorted
"In general, the key and reverse conversion processes are much
faster than specifying an equivalent cmp function. This is because
cmp is called multiple times for each list element while key and
reverse touch each element only once. Use functools.cmp_to_key()
to convert an old-style cmp function to a key function."

Change this to a 'key' method with equivalent functionality.  The only purpose
on the 'manager' page appears to list files with 'vmcore' in them first.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>