### PR TITLE
Fix message and code path when we fail to decode the release of vmcore

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -571,7 +571,8 @@ def get_kernel_release(vmcore, crash_cmd=["crash"]):
             release = KERNEL_RELEASE_PARSER.search(b)
             if release:
                 release = release.group(0)
-        release = release.decode('utf-8')
+        if release:
+            release = release.decode('utf-8')
         fd.close()
 
     # Clean up the release before returning or calling KernelVer


### PR DESCRIPTION
Currently there's a small bug if the release fails to decode on all
parsers.  In this case you will get a cryptic message as follows:
'NoneType' object has no attribute 'decode'

Fix this by checking to see if 'release' exists before trying decode.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>