### PR TITLE
Fix backtrace when updating bugzillano from web UI due to use of base…

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -2348,7 +2348,7 @@ class RetraceTask:
 
     def set_bugzillano(self, values):
         """Writes bugzilla numbers into BUGZILLANO_FILE"""
-        if not isinstance(values, list) or not all([isinstance(v, basestring) for v in values]):
+        if not isinstance(values, list) or not all([isinstance(v, str) for v in values]):
             raise Exception("values must be a list of integers")
 
         self.set_atomic(RetraceTask.BUGZILLANO_FILE,


### PR DESCRIPTION
…string

Python3 no longer has 'basestring' class but instead 'str' should be used.
https://docs.python.org/3.0/whatsnew/3.0.html

Use of 'basestring' in set_bugzillano causes the following backtrace:
Traceback (most recent call last):
  File "/usr/share/retrace-server/manager.wsgi", line 228, in application
    task.set_bugzillano(bugzillano)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 2358, in set_bugzillano
    if not isinstance(values, list) or not all([isinstance(v, str) for v in values]):
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 2358, in <listcomp>
    if not isinstance(values, list) or not all([isinstance(v, str) for v in values]):
NameError: name 'basestring' is not defined

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>