### PR TITLE
Refactor crash commands run after prepare_debuginfo into run_crash_cm…

### DIFF
--- a/src/bt_filter
+++ b/src/bt_filter
@@ -45,7 +45,7 @@ else:
 
 
 
-version = '0.8'
+version = '0.9'
 
 debug = 0
 
@@ -96,7 +96,7 @@ def backtrace_get_proc_info(line):
     return ret
 
 def backtrace_calc_hash(proc_backtrace):
-    hash = sha(''.join(proc_backtrace))
+    hash = sha(''.join(proc_backtrace).encode('utf-8'))
     hash_digest = hash.hexdigest()
     if debug > 1:
         print("backtrace_calc_hash: %s" % hash_digest)

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -77,7 +77,7 @@ def application(environ, start_response):
         if not task.has_misc(match.group(9)):
             return response(start_response, "404 Not Found", _("There is no such record"))
 
-        return response(start_response, "200 OK", task.get_misc(match.group(9)))
+        return response(start_response, "200 OK", task.get_misc(match.group(9)).decode('utf-8','ignore'))
     elif match.group(6) and match.group(6) == "start":
         # start
         get = urllib.parse.parse_qs(request.query_string)

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1496,8 +1496,8 @@ class RetraceTask:
             self.chmod(key)
 
     def set_atomic(self, key, value, mode="w"):
-        if mode not in ["w", "a"]:
-            raise ValueError("mode must be either 'w' or 'a'")
+        if mode not in ["w", "a", "wb"]:
+            raise ValueError("mode must be 'w', 'a', or 'wb'")
 
         tmpfilename = self._get_file_path("%s.tmp" % key)
         filename = self._get_file_path(key)
@@ -1600,9 +1600,9 @@ class RetraceTask:
         # max 16 MB
         return self.get(RetraceTask.BACKTRACE_FILE, maxlen=1 << 24)
 
-    def set_backtrace(self, backtrace):
+    def set_backtrace(self, backtrace, mode="w"):
         """Atomically writes given string into BACKTRACE_FILE."""
-        self.set_atomic(RetraceTask.BACKTRACE_FILE, backtrace)
+        self.set_atomic(RetraceTask.BACKTRACE_FILE, backtrace, mode)
 
     def has_log(self):
         """Verifies whether LOG_FILE is present in the task directory."""
@@ -2182,7 +2182,7 @@ class RetraceTask:
 
         return os.listdir(miscdir)
 
-    def get_misc(self, name):
+    def get_misc(self, name, mode="rb"):
         """Gets content of a file named 'name' from MISC_DIR."""
         if "/" in name:
             raise Exception("name may not contain the '/' character")
@@ -2191,12 +2191,12 @@ class RetraceTask:
             raise Exception("There is no record with such name")
 
         miscpath = os.path.join(self._savedir, RetraceTask.MISC_DIR, name)
-        with open(miscpath, "r") as misc_file:
+        with open(miscpath, mode) as misc_file:
             result = misc_file.read(1 << 24) # 16MB
 
         return result
 
-    def add_misc(self, name, value, overwrite=False):
+    def add_misc(self, name, value, overwrite=False, mode="wb"):
         """Adds a file named 'name' into MISC_DIR and writes 'value' into it."""
         if "/" in name:
             raise Exception("name may not contain the '/' character")
@@ -2212,7 +2212,7 @@ class RetraceTask:
             os.umask(oldmask)
 
         miscpath = os.path.join(miscdir, name)
-        with open(miscpath, "w") as misc_file:
+        with open(miscpath, mode) as misc_file:
             misc_file.write(value)
 
     def del_misc(self, name):

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -645,20 +645,22 @@ class RetraceWorker(object):
         cmd_output = None
         returncode = 0
         try:
-            child = Popen(crash_start, stdin=PIPE, stdout=PIPE, stderr=STDOUT, encoding='utf-8')
-            cmd_output = child.communicate(crash_cmdline)[0]
+            child = Popen(crash_start, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+            cmd_output = child.communicate(crash_cmdline.encode())[0]
         except OSError as err:
             log_warn("crash command: '%s' triggered OSError " %
-                     crash_cmdline.replace('\r', '; ').replace('\n', '; '))
-            log_warn("  %s" % err)
-        except UnicodeDecodeError as err:
-            log_warn("crash command: '%s' triggered UnicodeDecodeError " %
                      crash_cmdline.replace('\r', '; ').replace('\n', '; '))
             log_warn("  %s" % err)
         except:
             log_warn("crash command: '%s' triggered Unknown exception %s" %
                      crash_cmdline.replace('\r', '; ').replace('\n', '; '))
             log_warn("  %s" % sys.exc_info()[0])
+        try:
+            cmd_output.decode('utf-8')
+        except UnicodeDecodeError as err:
+            log_warn("crash command: '%s' triggered UnicodeDecodeError " %
+                     crash_cmdline.replace('\r', '; ').replace('\n', '; '))
+            log_warn("  %s" % err)
 
         if child.wait():
             log_warn("crash '%s' exitted with %d" % (crash_cmdline.replace('\r', '; ').replace('\n', '; '),
@@ -839,7 +841,7 @@ class RetraceWorker(object):
         crash_foreach_bt, ret = self.run_crash_cmdline(crash_normal,
                                                       "set hex\nforeach bt\nquit\n")
 
-        task.set_backtrace(kernellog)
+        task.set_backtrace(kernellog, "wb")
         # If crash sys command exited with non-zero status, we likely have a semi-useful vmcore
         if not crash_sys_c:
             # FIXME: Probably a better hueristic can be done here
@@ -862,10 +864,10 @@ class RetraceWorker(object):
         if crash_sys_c:
             task.add_misc("sys-c", crash_sys_c)
         if crash_foreach_bt and len(crash_foreach_bt) >= 1024:
-            child = Popen(["bt_filter"], stdin=PIPE, stdout=PIPE, stderr=STDOUT, encoding='utf-8')
+            child = Popen([b"bt_filter"], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
             bt_filter = child.communicate(crash_foreach_bt)[0]
             if child.wait():
-                bt_filter = "bt_filter exitted with %d\n\n%s" % (child.returncode, bt_filter)
+                bt_filter = b"bt_filter exitted with %d\n\n%s" % (child.returncode, bt_filter)
 
             task.add_misc("bt-filter", bt_filter)
 


### PR DESCRIPTION
…dline helper

When processing a vmcore and after prepare_debuginfo() runs successfully,
we run a series of crash commands.  These commands are the same whether
mock is used or not.  Create a helper function, run_crash_cmdline which
removes a lot of redundancy and improve maintainability.  In addition
to refactoring and maintenance improvements, there are a couple slight
functional changes with this patch.

First, the patch changes what happens with crash commands when the
'if child.wait()' condition is true.  Prior to this patch, we would call
log_warn() then set the output to 'None', with the only exception being
the 'log' command which we would not set output to 'None'.  With this
patch, we never set the output to 'None' for any command.  This should
not be an issue for most commands, and might even be viewed as a feature
since it will create output files in 'misc' for these other commands,
possibly with just error output in them.  However there is one possible
issue with creating error output in these files and involves 'foreach_bt'.
In the case of error output in 'foreach_bt', probably we should skip
calling bt_filter.  To avoid calling bt_filter, add a len() check similar
to what we do with the kernellog - if it is less than 1024 bytes we
assume it is not valid and skip calling bt_filter.

Second, the new function should handle non-printable characters in the
output of any crash command.  Prior to this patch, a partially damaged
vmcore with one or more corrupted task stacks could exit with a cryptic
error and task failure:
2019-06-10 10:43:42 'utf-8' codec can't decode byte 0xac in position 10472: invalid start byte
This only started happening on Python3 (previous python2 code handles
the same vmcore fine and does not fail the task).  This patch handles
this case by wrapping the child.communicate() in a try...except and
printing the error in that case:
 2019-06-11 17:57:51 crash command: 'set hex; foreach bt; quit; ' triggered UnicodeDecodeError
 2019-06-11 17:57:51   'utf-8' codec can't decode byte 0xac in position 10522: invalid start byte
If we hit the above error, we do not obtain any output in the command that
failed, so it does slightly change the behavior from Python2.  However,
at least now the specific command is now flagged as having an error,
the task is not failed, and the user may decide what to do with the error.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>