### PR TITLE
Fix module extraction from kernel-debuginfo

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1890,12 +1890,12 @@ class RetraceTask:
             return vmlinux
 
         modules = []
-        for line in stdout.splitlines():
+        for line in stdout.decode('utf-8').splitlines():
             # skip header
-            if b"NAME" in line:
+            if "NAME" in line:
                 continue
 
-            if b" " in line:
+            if " " in line:
                 modules.append(line.split()[1])
 
         todo = []


### PR DESCRIPTION
Commit 2199ab8 broke module extraction because it did handle the
byte arrary return from run_crash_cmdline properly.
Rather than a string, run_crash_cmdline returns a byte array.  When
we are obtaining the list of module object files to extract from crash's
'mod' command, these should be in the form of strings so we can pass
them to 'cpio'.  The reason for the default byte array return on
run_crash_cmdline is found in the discussion of 7ea86bd:
1) some crash commands (not the 'mod' command) may return non-'utf-8'
characters (for example a command that reads a lot of
memory from a vmcore that may be incomplete or damaged)
2) often we save the output of crash commands to a file so we do not
care necessarily if we have non-'utf-8' characters.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>