### PR TITLE
Make retrace-server-cleanup more resilient to non-existent tasks

### DIFF
--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -88,10 +88,12 @@ if __name__ == "__main__":
         for pid, taskid, runtime in running_tasks:
             # do not kill tasks started from task manager
             if CONFIG["AllowTaskManager"]:
-                task = RetraceTask(taskid)
-
-                if task.get_managed():
-                    continue
+                try:
+                    task = RetraceTask(taskid)
+                    if task.get_managed():
+                        continue
+                except:
+                    log.write("RetraceTask with taskid %d does not exist\n" % taskid)
 
             # ToDo: 5 = mm:ss, >5 = hh:mm:ss
             if len(runtime) > 5:


### PR DESCRIPTION
We've seen in production where a retrace-server-worker task may
hang and yet the task directory become deleted.  Once this happens
the cleanup job will crash completely and no tasks will be cleaned
up after this point.  The backtrace is as follows:
Traceback (most recent call last):
 File "/usr/bin/retrace-server-cleanup", line 91, in <module>
 task = RetraceTask(taskid)
 File "/usr/lib/python2.6/site-packages/retrace/retrace.py", line 1405, in __init__
 raise Exception, "The task %d does not exist" % self._taskid
Exception: The task 837225131 does not exist

The above is due to a combination of get_running_tasks() not checking
to see if a tasks's directory exists before returning the value, as
well as the RetraceTask constructor Exception clause.  We could fix
this with a check inside get_running_tasks(), but that would be racy.
The better fix is in the caller which is sensitive to the exception.

Fix the above with a simple 'try / except' inside retrace-server-cleanup
to handle the case where RetraceTask constructor fails due to non-existent
taskid directory.  If this issue ever happens again, the cleanup job
will kill any hanging tasks, which looks to be the intent of the
original code.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>