### PR TITLE
Clean up handling of mock with x86 vmcores in x86_64 environments

### DIFF
--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -111,31 +111,24 @@ if __name__ == "__main__":
             kernelver = get_kernel_release(vmcore, task.get_crash_cmd().split())
             if kernelver is None:
                 raise Exception("Unable to determine kernel version")
-            task.set_kernelver(str(kernelver))
+            task.set_kernelver(kernelver)
 
         hostarch = os.uname()[4]
         if hostarch in ["i486", "i586", "i686"]:
             hostarch = "i386"
 
         if args.action == "crash":
-            if not task.use_mock(kernelver):
-                crash_cmd = task.get_crash_cmd().split()
-                if task.has_vmlinux():
-                    vmlinux = task.get_vmlinux()
-                else:
-                    vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
-                    task.set_crash_cmd(' '.join(crash_cmd))
+            if task.has_vmlinux():
+                vmlinux = task.get_vmlinux()
+            else:
+                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver)
+            if not task.has_mock():
                 if task.has_crashrc():
                     cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore, vmlinux]
                 else:
                     cmdline = task.get_crash_cmd().split() + [vmcore, vmlinux]
             else:
                 cfgdir = os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
-                if task.has_vmlinux():
-                    vmlinux = task.get_vmlinux()
-                else:
-                    vmlinux = task.prepare_debuginfo(vmcore, chroot=cfgdir, kernelver=kernelver,
-                                                     crash_cmd=task.get_crash_cmd().split())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
                                "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore, vmlinux)]
@@ -147,7 +140,7 @@ if __name__ == "__main__":
             os.execvp(cmdline[0], cmdline)
 
         if args.action == "shell":
-            if task.use_mock(kernelver):
+            if task.has_mock():
                 cmdline = ["/usr/bin/mock", "--configdir",
                            os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid()), "shell"]
 

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -651,7 +651,7 @@ class RetraceWorker(object):
 
             log_debug("Determined kernel version: %s" % kernelver)
 
-        task.set_kernelver(str(kernelver))
+        task.set_kernelver(kernelver)
         kernelver_str = kernelver.kernelver_str
 
         self.stats["package"] = "kernel"
@@ -665,7 +665,7 @@ class RetraceWorker(object):
         task.set_status(STATUS_INIT)
         vmlinux = ""
 
-        if task.use_mock(kernelver):
+        if task.get_mock():
             self.hook_post_prepare_mock()
 
             # we don't save config into task.get_savedir() because it is only
@@ -747,8 +747,7 @@ class RetraceWorker(object):
             # no locks required, mock locks itself
             try:
                 self.hook_pre_prepare_debuginfo()
-                vmlinux = task.prepare_debuginfo(vmcore, cfgdir, kernelver=kernelver,
-                                                 crash_cmd=task.get_crash_cmd().split())
+                vmlinux = task.prepare_debuginfo(vmcore, cfgdir, kernelver=kernelver)
                 self.hook_post_prepare_debuginfo()
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))
@@ -762,9 +761,7 @@ class RetraceWorker(object):
         else:
             try:
                 self.hook_pre_prepare_debuginfo()
-                crash_cmd = task.get_crash_cmd().split()
-                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver, crash_cmd=crash_cmd)
-                task.set_crash_cmd(' '.join(crash_cmd))
+                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver)
                 self.hook_post_prepare_debuginfo()
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))


### PR DESCRIPTION
Originally when RetraceTask.use_mock was introducted it was done
alongside the implementation of RetraceTask.crash_cmd.  When crash_cmd
was introduced it was not well understood where we really should set
this and read it.  Also, use_mock was not really well done either.

The right thing to do with crash_cmd and use_mock is only set both of
them once the arch has been properly detected from get_kernel_release.
Create methods get_mock(), set_mock(), and has_mock() to handle whether
mock is configured or not.

This cleans up the code quite a bit and fixes on bug which occurs
when 32-bit cores are run on a 64-bit machine where prepare_debuginfo
would be called twice:
https://bugzilla.redhat.com/show_bug.cgi?id=1536683

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>