### PR TITLE
Pass results dir to hooks

### DIFF
--- a/doc/retrace-server.texi
+++ b/doc/retrace-server.texi
@@ -862,15 +862,15 @@ The local task is created by clicking @code{Start Task} link in
 the task manager. The task is automatically executed and begins
 downloading remote resources immediately.
 
-@section Miscleanous results
+@section Task results
 
 In addition to the standard @file{retrace_log} and
-@file{retrace_backtrace}, a managet task may contain more than a single
-result. All excessive data may be saved as miscleanous results. These
-are key-value pairs saved into @file{misc} subdirectory within
-the task directory. Each entry is saved into @file{<task_dir>/misc/key}
-file and the contents are the actual value. All miscleanous results
-are accessible from the task manager.
+@file{retrace_backtrace}, a manager task may contain more than a single
+result.  All excessive data may be saved as results. These
+are key-value pairs saved into @file{results} subdirectory within
+the task directory. Each entry is saved into @file{<task_dir>/results/key}
+file and the contents are the actual value. All results are accessible
+from the task manager.
 
 
 @node FAF integration

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -181,8 +181,8 @@ s390x =
 
 [hookscripts]
 # Parameters are replaced using python's format.
-# Available parameters: hook_name, task_id, task_dir
-# Example: pre_start = /bin/echo {hook_name} {task_id} {task_dir}
+# Available parameters: hook_name, task_id, task_results_dir
+# Example: pre_start = /bin/echo {hook_name} {task_id} {task_results_dir}
 # When worker.start() is called
 pre_start = 
 # When task type is determined and the main task starts

--- a/src/exploitable.wsgi
+++ b/src/exploitable.wsgi
@@ -29,10 +29,10 @@ def application(environ, start_response):
         return response(start_response, "403 Forbidden",
                         _("Invalid password"))
 
-    if not task.has_misc("exploitable"):
+    if not task.has_results("exploitable"):
         return response(start_response, "404 Not Found",
                         _("There is no exploitability data for the specified task"))
 
-    result = task.get_misc("exploitable")
+    result = task.get_results("exploitable")
 
     return response(start_response, "200 OK", result)

--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -8,7 +8,7 @@ from retrace import *
 CONFIG = config.Config()
 
 MANAGER_URL_PARSER = re.compile(r"^(.*/manager)(/(([^/]+)(/(__custom__|start|backtrace|savenotes|"
-                                r"caseno|notify|delete(/(sure/?)?)?|misc/([^/]+)/?)?)?)?)?$")
+                                r"caseno|notify|delete(/(sure/?)?)?|results/([^/]+)/?)?)?)?)?$")
 tableheader = """
           <table>
             <tr>

--- a/src/managertask.xhtml
+++ b/src/managertask.xhtml
@@ -109,7 +109,7 @@
       {finishtime}
       {downloaded}
       {md5sum}
-      {misc}
+      {results}
       {notify}
       {caseno}
       {bugzillano}

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -168,11 +168,11 @@ class RetraceWorker(object):
 
     def _symlink_log(self):
         if self.task.has_log():
-            # add a symlink to log to misc directory
+            # add a symlink to log to results directory
             # use underscore so that the log is first in the list
             try:
                 os.symlink(self.task._get_file_path(RetraceTask.LOG_FILE),
-                           os.path.join(self.task._get_file_path(RetraceTask.MISC_DIR), "retrace-log"))
+                           os.path.join(self.task.get_results_dir(), "retrace-log"))
             except OSError as ex:
                 if ex.errno != errno.EEXIST:
                     raise
@@ -528,7 +528,7 @@ class RetraceWorker(object):
 
         task.set_backtrace(backtrace)
         if exploitable is not None:
-            task.add_misc("exploitable", exploitable)
+            task.add_results("exploitable", exploitable)
 
         self.hook_post_retrace()
 
@@ -781,7 +781,7 @@ class RetraceWorker(object):
         # we likely have a semi-useful vmcore
         crash_sys, ret = task.run_crash_cmdline(crash_normal, "sys\nquit\n")
         if ret == 0 and crash_sys:
-            task.add_misc("sys", crash_sys)
+            task.add_results("sys", crash_sys)
         else:
             crash_sys = None
             # FIXME: Probably a better hueristic can be done here
@@ -798,8 +798,8 @@ class RetraceWorker(object):
         if "/" in vmlinux:
             crashrc_lines.append("mod -S %s > %s" % (vmlinux.rsplit("/", 1)[0], os.devnull))
 
-        miscdir = os.path.join(task.get_savedir(), RetraceTask.MISC_DIR)
-        crashrc_lines.append("cd %s" % miscdir)
+        results_dir = task.get_results_dir()
+        crashrc_lines.append("cd %s" % results_dir)
 
         if len(crashrc_lines) > 0:
             task.set_crashrc("%s\n" % "\n".join(crashrc_lines))

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -28,9 +28,10 @@ class RetraceWorker(object):
         """Called by the default hook implementations"""
         HOOK_SCRIPTS = CONFIG.get_hook_scripts()
         if hook in HOOK_SCRIPTS:
+            results_dir = self.task.get_results_dir()
             script = HOOK_SCRIPTS[hook].format(
                 hook_name=hook, task_id=self.task.get_taskid(),
-                task_dir=self.task.get_savedir())
+                task_results_dir=results_dir)
             log_info("Running hook {0} '{1}'".format(hook, script))
             child = Popen(script, shell=True, stdout=PIPE, stderr=PIPE, encoding='utf-8')
             (out, err) = child.communicate()


### PR DESCRIPTION
I've been testing these patches and I think they are a good modest change to the hooks interface.  If we stick with a lightweight interface to hooks and provide freedom for a hook script to interface with retrace-server via the existing retrace-server-* commands, the only thing I think we need to change is to give a hook a specific directory to write output (results files).  Note the renaming patch is backward compatible with tasks that have existing 'misc' subdirectory so this should not break anything.

I also thought of exporting the "add_results()" and similar functions to a hook script but I think it might be better to avoid that.