### PR TITLE
Refactor into KernelVMcore and eliminate duplicate prepare_debuginfo

### DIFF
--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -199,7 +199,8 @@ def application(environ, start_response):
                             _("Required file '%s' is missing") % required_file)
 
     if task.get_type() in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE]:
-        task.strip_vmcore(os.path.join(crashdir, "vmcore"))
+        vmcore = KernelVMcore(os.path.join(crashdir, "vmcore"))
+        vmcore.strip_extra_pages(task)
 
     retcode = task.start()
     if retcode != 0:

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -5,6 +5,7 @@ to a log and for tasks found in the comments set bugzillano field with bugzilla 
 """
 
 import os
+import sys
 import re
 import time
 import bugzilla
@@ -27,7 +28,7 @@ if __name__ == "__main__":
             bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
         except (bugzilla.BugzillaError, ValueError) as e:
             log.write("Exception: {0}".format(e))
-            exit(1)
+            sys.exit(1)
 
         if not bzapi.logged_in and bz_creds:
             bzapi.readconfig(bz_creds)

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -72,7 +72,7 @@ def check_config():
                          "did you accidentally reverse the values for "
                          "DeleteTaskAfter and DeleteFailedTaskAfter? "
                          "Not touching any tasks.\n")
-        exit(1)
+        sys.exit(1)
 
 if __name__ == "__main__":
     check_config()

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -104,11 +104,13 @@ if __name__ == "__main__":
         sys.stderr.write("Action '%s' is not allowed for coredumps.\n" % args.action)
         exit(1)
     elif task.get_type() == TASK_VMCORE_INTERACTIVE:
-        vmcore = os.path.join(task.get_savedir(), "crash", "vmcore")
+        vmcore_path = os.path.join(task.get_savedir(), "crash", "vmcore")
+        vmcore = KernelVMcore(vmcore_path)
+
         if task.has_kernelver():
             kernelver = KernelVer(task.get_kernelver())
         else:
-            kernelver = get_kernel_release(vmcore, task.get_crash_cmd().split())
+            kernelver = vmcore.get_kernel_release(task.get_crash_cmd().split())
             if kernelver is None:
                 raise Exception("Unable to determine kernel version")
             task.set_kernelver(kernelver)
@@ -124,17 +126,17 @@ if __name__ == "__main__":
                 vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver)
             if not task.has_mock():
                 if task.has_crashrc():
-                    cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore, vmlinux]
+                    cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore_path, vmlinux]
                 else:
-                    cmdline = task.get_crash_cmd().split() + [vmcore, vmlinux]
+                    cmdline = task.get_crash_cmd().split() + [vmcore_path, vmlinux]
             else:
                 cfgdir = os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
-                               "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore, vmlinux)]
+                               "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore_path, vmlinux)]
                 else:
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
-                               "shell", "crash %s %s" % (vmcore, vmlinux)]
+                               "shell", "crash %s %s" % (vmcore_path, vmlinux)]
 
             print_cmdline(cmdline)
             os.execvp(cmdline[0], cmdline)

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     if not CONFIG["AuthGroup"] in groups:
         sys.stderr.write("You must be a member '%s' group in order to use "
                          "interactive debugging.\n" % CONFIG["AuthGroup"])
-        exit(1)
+        sys.exit(1)
 
     parser = argparse.ArgumentParser(description="Interact with retrace-server's chroot")
     parser.add_argument("task_id", help="Task ID")
@@ -32,21 +32,21 @@ if __name__ == "__main__":
 
     if not args.action in ACTIONS:
         sys.stderr.write("Invalid action. Allowed actions are: '%s'.\n" % "', '".join(ACTIONS))
-        exit(1)
+        sys.exit(1)
 
     try:
         taskid = int(args.task_id)
         task = RetraceTask(taskid)
     except Exception as ex:
         sys.stderr.write("%s\n" % ex)
-        exit(1)
+        sys.exit(1)
 
     # touch the task directory
     task.reset_age()
 
     if args.action == "printdir":
         sys.stdout.write("%s\n" % task.get_savedir())
-        exit(0)
+        sys.exit(0)
 
     if args.action == "delete":
         username = pwd.getpwuid(os.getuid()).pw_name
@@ -54,34 +54,34 @@ if __name__ == "__main__":
         if CONFIG["TaskManagerAuthDelete"] and \
            not username in CONFIG["TaskManagerDeleteUsers"]:
             sys.stderr.write("You are not allowed to delete tasks\n")
-            exit(1)
+            sys.exit(1)
 
         task.remove()
-        exit(0)
+        sys.exit(0)
 
     if args.action == "set-success":
         if task.is_running() and not args.force:
             sys.stderr.write("The task is still running and the effect of this "
                              "action will most probably be overwritten. If you "
                              "want to execute it anyway, use --force.\n")
-            exit(0)
+            sys.exit(0)
 
         task.set_status(STATUS_SUCCESS)
         if not task.has_finished_time():
             task.set_finished_time(int(time.time()))
-        exit(0)
+        sys.exit(0)
 
     if args.action == "set-fail":
         if task.is_running() and not args.force:
             sys.stderr.write("The task is still running and the effect of this "
                              "action will most probably be overwritten. If you "
                              "want to execute it anyway, use --force.\n")
-            exit(0)
+            sys.exit(0)
 
         task.set_status(STATUS_FAIL)
         if not task.has_finished_time():
             task.set_finished_time(int(time.time()))
-        exit(0)
+        sys.exit(0)
 
     if task.get_type() == TASK_RETRACE_INTERACTIVE:
         if args.action == "shell":
@@ -93,7 +93,7 @@ if __name__ == "__main__":
                 executable = exec_file.read(ALLOWED_FILES["executable"])
             if "'" in executable or '"' in executable:
                 sys.stderr.write("executable contains forbidden characters.\n")
-                exit(1)
+                sys.exit(1)
 
             cmdline = ["/usr/bin/mock", "--configdir", task.get_savedir(), "shell",
                        "gdb '%s' /var/spool/abrt/crash/coredump" % executable]
@@ -102,7 +102,7 @@ if __name__ == "__main__":
             os.execvp(cmdline[0], cmdline)
 
         sys.stderr.write("Action '%s' is not allowed for coredumps.\n" % args.action)
-        exit(1)
+        sys.exit(1)
     elif task.get_type() == TASK_VMCORE_INTERACTIVE:
         vmcore_path = os.path.join(task.get_savedir(), "crash", "vmcore")
         vmcore = KernelVMcore(vmcore_path)
@@ -163,10 +163,10 @@ if __name__ == "__main__":
                 os.execvp(cmdline[0], cmdline)
 
             sys.stderr.write("The task does not require a chroot. You can use the current shell.\n")
-            exit(1)
+            sys.exit(1)
 
         sys.stderr.write("Action '%s' is not allowed for vmcores.\n" % args.action)
-        exit(1)
+        sys.exit(1)
     else:
         sys.stderr.write("The specified task was not intended for interactive debugging.\n")
-        exit(1)
+        sys.exit(1)

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -123,7 +123,20 @@ if __name__ == "__main__":
             if task.has_vmlinux():
                 vmlinux = task.get_vmlinux()
             else:
-                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver)
+                if self.has_status() and \
+                   self.get_status() not in [STATUS_SUCCESS, STATUS_FAIL]:
+                    sys.stderr.write("Task '%s' still in progress or hung (status = %d), "
+                                     "please wait for task to complete.\n" %
+                                     (task.get_taskid(), task.get_status()))
+                    sys.stderr.write("If you suspect task is hung and will never "
+                                     "complete, try forcing failure with "
+                                     "retrace-server-interact, and restart the task.")
+                    sys.exit(1)
+                else:
+                    raise Exception("Task '%s' complete but no vmlinux.\n"
+                                    "Try restarting or resubmitting the task.\n" %
+                                    task.get_taskid())
+
             if not task.has_mock():
                 if task.has_crashrc():
                     cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), vmcore_path, vmlinux]

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -381,7 +381,7 @@ def get_backtrace(args):
             return 0
         else:
             print("Error: {0}".format(res.text))
-            exit(1)
+            sys.exit(1)
 
     with open("backtrace", "w") as fld:
         fld.write(res.text)

--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -20,19 +20,19 @@ if __name__ == "__main__":
     # do not use logging yet - we need the task
     if cmdline.kernelver and not cmdline.arch:
         sys.stderr.write("You also need to specify architecture when overriding kernel version\n")
-        exit(1)
+        sys.exit(1)
 
     try:
         task = RetraceTask(cmdline.task_id)
     except:
         sys.stderr.write("Task '%d' does not exist\n" % cmdline.task_id)
-        exit(1)
+        sys.exit(1)
 
     if task.has_status():
         if not cmdline.restart:
             sys.stderr.write("%s has already been executed for task %d\n" % (sys.argv[0], cmdline.task_id))
             sys.stdout.write("You can use --restart option if you really want to restart the task\n")
-            exit(1)
+            sys.exit(1)
 
         task.reset()
 
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 
         # parent - kill
         if pid != 0:
-            exit(0)
+            sys.exit(0)
 
         try:
             os.setpgrp()
@@ -68,4 +68,4 @@ if __name__ == "__main__":
     try:
         worker.start(kernelver=kernelver, arch=cmdline.arch)
     except RetraceWorkerError as ex:
-        exit(ex.errorcode)
+        sys.exit(ex.errorcode)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -635,10 +635,11 @@ class RetraceWorker(object):
 
         task = self.task
 
-        vmcore = os.path.join(task.get_savedir(), "crash", "vmcore")
+        vmcore_path = os.path.join(task.get_savedir(), "crash", "vmcore")
+        vmcore = KernelVMcore(vmcore_path)
 
         try:
-            self.stats["coresize"] = os.path.getsize(vmcore)
+            self.stats["coresize"] = os.path.getsize(vmcore_path)
         except:
             pass
 
@@ -646,7 +647,7 @@ class RetraceWorker(object):
             kernelver = custom_kernelver
             kernelver_str = custom_kernelver.kernelver_str
         else:
-            kernelver = get_kernel_release(vmcore, task.get_crash_cmd().split())
+            kernelver = vmcore.get_kernel_release(task.get_crash_cmd().split())
             if not kernelver:
                 raise Exception("Unable to determine kernel version")
 
@@ -755,9 +756,9 @@ class RetraceWorker(object):
 
             self.hook_pre_retrace()
             crash_normal = ["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
-                            task.get_crash_cmd() + " -s %s %s" % (vmcore, vmlinux) ]
+                            task.get_crash_cmd() + " -s %s %s" % (vmcore_path, vmlinux) ]
             crash_minimal = ["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
-                            task.get_crash_cmd() + " -s --minimal %s %s" % (vmcore, vmlinux) ]
+                            task.get_crash_cmd() + " -s --minimal %s %s" % (vmcore_path, vmlinux) ]
 
         else:
             try:
@@ -771,8 +772,8 @@ class RetraceWorker(object):
             task.set_status(STATUS_BACKTRACE)
             log_info(STATUS[STATUS_BACKTRACE])
 
-            crash_normal = task.get_crash_cmd().split() + ["-s", vmcore, vmlinux]
-            crash_minimal = task.get_crash_cmd().split() + ["--minimal", "-s", vmcore, vmlinux]
+            crash_normal = task.get_crash_cmd().split() + ["-s", vmcore_path, vmlinux]
+            crash_minimal = task.get_crash_cmd().split() + ["--minimal", "-s", vmcore_path, vmlinux]
 
         # Generate the kernel log and run other crash commands
         kernellog, ret = task.run_crash_cmdline(crash_minimal, "log\nquit\n")

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -749,7 +749,7 @@ class RetraceWorker(object):
             # no locks required, mock locks itself
             try:
                 self.hook_pre_prepare_debuginfo()
-                vmlinux = task.prepare_debuginfo(vmcore, cfgdir, kernelver=kernelver)
+                vmlinux = vmcore.prepare_debuginfo(task, cfgdir, kernelver=kernelver)
                 self.hook_post_prepare_debuginfo()
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))
@@ -763,7 +763,7 @@ class RetraceWorker(object):
         else:
             try:
                 self.hook_pre_prepare_debuginfo()
-                vmlinux = task.prepare_debuginfo(vmcore, kernelver=kernelver)
+                vmlinux = vmcore.prepare_debuginfo(task, kernelver=kernelver)
                 self.hook_post_prepare_debuginfo()
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))


### PR DESCRIPTION
This series of patches refactors a number of functions into the new KernelVMcore class, and eliminates some confusing and duplicate logic involving vmcore setup, especially the duplicate calls to prepare_debuginfo which happens on some vmcores.

There are likely further cleanups that can be done on this code but I felt this a fairly good series to move things forward.  I have tested this fairly thoroughly and I do not believe there are any regressions here, but it's always possible some corner case could have been missed.