### PR TITLE
Update plugins

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -1,2 +1,6 @@
-plugins_PYTHON = __init__.py fedora.py rhel.py
+plugins_PYTHON = __init__.py \
+                 centos.py \
+                 fedora.py \
+                 rhel.py
+
 pluginsdir = $(datadir)/retrace-server/plugins

--- a/src/plugins/centos.py
+++ b/src/plugins/centos.py
@@ -1,0 +1,16 @@
+import re
+
+distribution = "centos"
+abrtparser = re.compile(r"^CentOS Linux release ([0-9]+) \(([^\)]+)\)$")
+guessparser = re.compile(r"\.el([0-9]+)")
+displayrelease = "CentOS release"
+gdb_package = "gdb"
+gdb_executable = "/usr/bin/gdb"
+versionlist = [
+    "el6",
+    "el7",
+    "el8",
+]
+repos = [
+    []
+]

--- a/src/plugins/fedora.py
+++ b/src/plugins/fedora.py
@@ -7,30 +7,17 @@ displayrelease = "Fedora release"
 gdb_package = "gdb"
 gdb_executable = "/usr/bin/gdb"
 versionlist = [
-    "fc1",
-    "fc2",
-    "fc3",
-    "fc4",
-    "fc5",
-    "fc6",
-    "fc7",
-    "fc8",
-    "fc9",
-    "fc10",
-    "fc11",
-    "fc12",
-    "fc13",
-    "fc14",
-    "fc15",
-    "fc16",
-    "fc17",
-    "fc18",
-    "fc19",
-    "fc20",
-    "fc21",
     "fc22",
     "fc23",
     "fc24",
+    "fc25",
+    "fc26",
+    "fc27",
+    "fc28",
+    "fc29",
+    "fc30",
+    "fc31",
+    "fc32",
 ]
 
 # Find more details about Fedora Mirroring at:

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -14,5 +14,6 @@ versionlist = [
     "el5",
     "el6",
     "el7",
+    "el8",
 ]
 repos = [[]]

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -4,8 +4,8 @@ distribution = "rhel"
 abrtparser = re.compile(r"^Red Hat Enterprise Linux release ([0-9]+) \(([^\)]+)\)$")
 guessparser = re.compile(r"\.el([0-9]+)")
 displayrelease = "Red Hat Enterprise Linux release"
-gdb_package = "devtoolset-4-gdb"
-gdb_executable = "/opt/rh/devtoolset-4/root/usr/bin/gdb"
+gdb_package = "devtoolset-8-gdb"
+gdb_executable = "/opt/rh/devtoolset-8/root/usr/bin/gdb"
 versionlist = [
     "el1",
     "el2",


### PR DESCRIPTION
The devtools-4 was EOL in Dec 2017.
softwarecollections.org/en/scls/rhscl/devtoolset-4

Current one:
softwarecollections.org/en/scls/rhscl/devtoolset-8
___
We have centos plugin in production but it is missing in upstream.
___
Updates to stats page to show latest 10 Fedora releases and RHEL8/CentOS8.