### PR TITLE
Switch to requests-gssapi

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -39,7 +39,7 @@ Requires: python3-mod_wsgi
 Requires: python3-webob
 Requires: python3-magic
 Requires: python3-requests
-Requires: python3-requests-kerberos
+Requires: python3-requests-gssapi
 Requires: python3-distro
 Requires: python3-bugzilla
 Requires: python3-six

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -13,7 +13,7 @@ import argparse
 import tempfile
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 
 
 TASK_RETRACE, TASK_DEBUG, TASK_VMCORE, TASK_RETRACE_INTERACTIVE, \
@@ -581,7 +581,7 @@ if __name__ == "__main__":
     # check kerberos
     if ticket_check():
         LOGGER.info("Kerberos ticket is valid.")
-        ARGS['kerberos'] = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        ARGS['kerberos'] = HTTPSPNEGOAuth(mutual_authentication=DISABLED)
     else:
         ARGS['kerberos'] = None
 


### PR DESCRIPTION
This also explicitly disables mutual authentication, which seems to be
causing issues with redirects to /start and friends.

Context:
  https://fedoraproject.org/wiki/Changes/kerberos-in-python-modernization
  https://github.com/requests/requests-kerberos/issues/64
  https://github.com/pythongssapi/requests-gssapi/issues/12
  https://github.com/pythongssapi/requests-gssapi/commit/498da2e55f98847c9eeb698f50ac00a2e252cacd

Fixes https://github.com/abrt/retrace-server/issues/263

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>