### PR TITLE
Fix retrace-server-interact and retrace-server-cleanup man pages

### DIFF
--- a/src/retrace-server-cleanup.txt
+++ b/src/retrace-server-cleanup.txt
@@ -13,8 +13,7 @@ DESCRIPTION
 -----------
 The tool collects different kinds of garbage created by Retrace server:
 
-* Deletes old tasks based on mtime. The limit to proclaim task 
-  old can be changed in the configuration file. Will remove the tasks 
+* Deletes old tasks based on mtime. Will remove the tasks 
   with a failure status with an mtime defined by the DeleteFailedTaskAfter 
   variable set in the configuration file. Successful tasks will be deleted 
   with an mtime defined by the DeleteTaskAfter variable set in the configuration file.

--- a/src/retrace-server-cleanup.txt
+++ b/src/retrace-server-cleanup.txt
@@ -13,13 +13,16 @@ DESCRIPTION
 -----------
 The tool collects different kinds of garbage created by Retrace server:
 
-* Deletes old tasks. The limit to proclaim task old can be changed
-in the configuration file (DeleteTaskAfter).
+* Deletes old tasks based on mtime. The limit to proclaim task 
+  old can be changed in the configuration file. Will remove the tasks 
+  with a failure status with an mtime defined by the DeleteFailedTaskAfter 
+  variable set in the configuration file. Successful tasks will be deleted 
+  with an mtime defined by the DeleteTaskAfter variable set in the configuration file.
 
 * Kills tasks running for a long time (> 1 hour).
 
 * Cleans up fakeroots and task directories from jobs finished
-in an unexpected way.
+  in an unexpected way.
 
 Should be set in root\'s crontab to run every hour.
 

--- a/src/retrace-server-interact.txt
+++ b/src/retrace-server-interact.txt
@@ -31,6 +31,27 @@ crash::
    Run Crash, load vmcore and vmlinux and jump to prompt. Only available
    for kernel crashes (vmcores).
 
+printdir::
+   Print the directory of the task.
+
+delete::
+   Delete the task.  Use with caution (there is no undo).
+
+set-success::
+   Force task status to 'success'.  This may be useful if a task has been
+   marked as "failed" by retrace-server but a user has other knowledge it
+   is still useful.  This will avoid a possible early deletion of the task
+   by retrace-server-cleanup which uses the DeleteFailedTaskAfter 
+   configuration setting.
+
+set-fail::
+   Force task status to 'fail'.  This may be useful if a task has been
+   marked as "success" by retrace-server but a user has other knowledge it
+   is not useful.  This will allow a possible early deletion of the task
+   by retrace-server-cleanup which uses DeleteFailedTaskAfter 
+   configuration setting.
+
+
 OPTIONS
 -------
 -h::

--- a/src/retrace-server-task.txt
+++ b/src/retrace-server-task.txt
@@ -39,10 +39,14 @@ create::
 
 set::
     Write (set) information on an existing task. Available only for manager
-    and ftp task.
+    and ftp task. See retrace-server-interact for setting the success or
+    failure of a task. See SET OPTIONS section for list of set options 
+    available.
 
 get::
-   Read (get) information on an existing task.
+   Read (get) information on an existing task. If no parameters specified 
+   the output will default to the task status. See GET OPTIONS section
+   for list of get options available.
 
 batch::
    Very similar to 'create' (has the same parameters) but also waits until

--- a/src/retrace-server-task.txt
+++ b/src/retrace-server-task.txt
@@ -3,7 +3,7 @@ retrace-server-task(1)
 
 NAME
 ----
-retrace-server-task - Create tasks, get and set fields on existing tasks
+retrace-server-task - Create a task, get and set fields on an existing task
 
 SYNOPSIS
 --------
@@ -24,7 +24,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 This tool is able to communicate with Retrace server: create a new task,
-get and set values in existing tasks. If kerberos ticket is available, all
+get and set values of an existing task. If kerberos ticket is available, all
 communication uses it. To stop using the ticket you must destroy it (kdestroy).
 
 OPERATIONS
@@ -50,7 +50,9 @@ get::
 
 batch::
    Very similar to 'create' (has the same parameters) but also waits until
-   task is finished. If tasks finishes successfully backtrace is downloaded
+   task is finished. If the task finishes successfully thebacktrace is 
+   downloaded
+
 
 COMMON OPTIONS
 -------------


### PR DESCRIPTION
There are a few omissions from the retrace-server-interact and
retrace-server-cleanup man pages. Add the missing information
which includes details on the set-success and set-fail options
for retrace-server-cleanup. Pointed to the OPTIONS section for
available switches for set and get parameters for
retrace-server-interact.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>
Signed-off-by: Audra Baker <aubaker@redhat.com>