### PR TITLE
retrace: Fix undefined vmcore variable

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1527,7 +1527,7 @@ class KernelVMcore:
         if chroot:
             with open(os.devnull, "w") as null:
                 crash_normal = ["/usr/bin/mock", "--configdir", chroot, "shell",
-                                "--", "crash -s %s %s" % (vmcore.get_path(), vmlinux)]
+                                "--", "crash -s %s %s" % (self._vmcore_path, vmlinux)]
         else:
             crash_normal = crash_cmd + ["-s", self._vmcore_path, vmlinux]
         stdout, returncode = task.run_crash_cmdline(crash_normal, "mod\nquit")


### PR DESCRIPTION
Introduced in 6173c728b2daa7c92c12947ddd488377ca0efa91

vmcore used to be passed to prepare_debuginfo. The prepare_debuginfo is now a method
of KernelVMcore (the vmcore).

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>