### PR TITLE
Add transtalations from Fedora Zanata

### DIFF
--- a/maint/pull-translations
+++ b/maint/pull-translations
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+shopt -s nullglob
+
+if [ ! -d po ]; then
+    echo "Run this script in the top source directory"
+    exit 1
+fi
+
+git update-index -q --refresh >/dev/null 2>&1
+if [ -n "$(git diff-index --name-only HEAD --)" ]; then
+    echo "Run this script only without uncommitted changes"
+    exit 1
+fi
+
+zanata pull || exit 1
+
+pushd po || exit 1
+
+ERR=false
+for pof in *.po
+do
+    msgfmt --check-format "$pof" || {
+        ERR=true
+    }
+done
+
+if $ERR; then
+    exit 1
+fi
+
+for pof in *.po;
+do
+    echo "${pof%.*}"
+    if ! git ls-files "$pof" --error-unmatch >/dev/null 2>&1; then
+        git add "$pof" >/dev/null 2>&1 || {
+            echo "Failed to 'git add $pof'"
+            exit 1
+        }
+    fi
+done | sort > LINGUAS
+
+popd || exit 1
+
+NEW_LINGUAS=$(git status -s --porcelain | grep "^A" | awk -F[/.] '{print $2}' | tr "\n" " " | sed 's/\(.*\) /\1/')
+if [ -n "$NEW_LINGUAS" ]; then
+    git add po/LINGUAS
+    git commit -s -m "Add new translation languages - $NEW_LINGUAS"
+fi
+
+git commit -a -s -m "Translation updates"
+git log --oneline -2

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,5 +1,5 @@
-as
 ar
+as
 ast
 bn_IN
 ca
@@ -28,15 +28,16 @@ nl
 or
 pa
 pl
-pt_BR
 pt
+pt_BR
 ru
 sk
-sr@latin
 sr
+sr@latin
 sv
 ta
 te
+tr
 uk
 zh_CN
 zh_TW

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,119 +1,151 @@
-# Catalan translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2016. #zanata
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2018. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2018-02-24 11:29+0000\n"
+"Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Heu d'utilitzar HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL incorrecte"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "No hi ha tal tasca"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Contrasenya incorrecta"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "No hi ha cap traça inversa per a la tasca especificada"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Actualment el servidor de retraçat està completament carregat"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Heu d'utilitzar el mètode POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "El format especificat de l'arxiu no és compatible"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Cal que establiu adequadament la capçalera Content-Length"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "L'arxiu especificat és massa gran"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"La capçalera X-CoreFileDirectory ha estat inhabilitada per l'administrador "
+"del servidor"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "No es pot crear el directori de treball"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "No es pot obtenir espai lliure en disc"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "No hi ha prou espai d'emmagatzematge al servidor"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "No es pot crear la tasca nova"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "No existeix el directori que s'ha especificat a «X-CoreFileDirectory»"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Hi ha %d fitxers al directori «%s». Actualment només està suportat un únic "
+"arxiu"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"La vostra capçalera especifica el tipus «%s», però el tipus de fitxer no "
+"correspon"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "No es pot desar l'arxiu"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "No es pot obtenir la mida un cop descomprimit"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "El contingut de l'arxiu especificat és massa gran"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "No es pot desempaquetar l'arxiu"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "No es permet que hi hagi enllaços simbòlics a l'arxiu"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "El fitxer «%s» era més gran del que s'esperava"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "El fitxer «%s» se li permet estar a l'arxiu"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+"Les tasques interactives van ser desactivades per l'administrador del "
+"servidor"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Falta el fitxer requerit «%s»"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Servidor de retraçat"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Benvingut al servidor de retraçat"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -121,29 +153,38 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"El servidor de retraçat és un servei que ofereix la possibilitat d'analitzar"
+" el bolc de memòria i generar la traça inversa a través de la xarxa. Podeu "
+"trobar més informació al wiki del servidor de retraçat:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Ara tan sols la connexió segura HTTPS està permesa pel servidor. Es "
+"denegaran les peticions HTTP."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Es permet HTTP i HTTPS. L'ús d'HTTPS és estrictament recomanable per raons "
+"de seguretat."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Els següents llançaments són compatibles: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"Actualment el servidor està carregat per %d%% (s'està executant el treball "
+"%d de %d)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -156,6 +197,15 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"El bolc de la memòria es manté al servidor mentre el treball de retaçat "
+"estigui en execució. Un cop finalitzat el treball, el servidor manté el "
+"registre de retaçat i de traça inversa. S'eliminen totes les altres dades "
+"(incloent-hi el bolc de la memòria). El registre de retraçat i de la traça "
+"inversa només són accessibles a través de l'id. únic de la tasca i una "
+"contrasenya, de manera que ningú (excepte l'autor) pot visualitzar-ho. Tota "
+"la informació de la pana (incloent-hi la traça inversa) s'elimina després de"
+" %d hores d'inactivitat. Possiblement cap dada privada es manté al servidor,"
+" per més temps."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -165,83 +215,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"El bolc de la memòria només s'utilitza per als propòsits de retraçat. Els "
+"administradors del servidor no intenten d'obtenir les vostres dades privades"
+" a partir dels bolcs de la memòria o de les traces inverses. L'ús d'un canal"
+" de comunicació segur (HTTPS) és estrictament recomanat. Els administradors "
+"del servidor no són responsables dels problemes relacionats amb l'ús d'un "
+"canal no segur (per exemple, HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "No hi ha cap registre per a la tasca especificada"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arquitectura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arquitectures"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Id. de la construcció"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Compte"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Treballs denegats"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Fracassat"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Primer retraça"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Estadístiques globals"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Falten els id. de la construcció"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nom"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Llançament"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Llançaments"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Paquets requerits"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Paquets retraçats"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Estadístiques del servidor de retraçat"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nom de l'objecte compartit"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Reeixit"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Total"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versions"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,120 +1,143 @@
-# Czech translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Jakub Filak <jfilak@redhat.com>, 2016. #zanata
+# Zdenek <chmelarz@gmail.com>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-09-03 09:24+0000\n"
+"Last-Translator: Zdenek <chmelarz@gmail.com>\n"
 "Language-Team: Czech\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Musíte použí HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Neplatná URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Žádná taková úolha neexistuje"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Neplatné heslo"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "backtrace pro zadaný úkol neexistuje"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Retrace server je momentálně plně vytížen"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Musíte použít POST metodu"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Formát zvoleného archívu není podporován"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Musíte správně vyplnit Content-Length hlavičku"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Zvolený archív je příliš velký"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "X-CoreFileDirectory hlavička byla zakázana administrátorem serveru"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Není možné vytvořit pracovní adresář"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Není možné zjistit velikost volného místa na disku"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Na serveru není dostatek volného uložného prostoru"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Není možné vytvořit novou úlohu"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Adresář specifikovaný v  'X-CoreFileDirectory'  neexistuje"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr "%d souborů v adresáři '%s' . Aktuálně podporován pouze jediný archív"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Vaše hlavička určuje typ '%s', ale typ souboru neodpovídá"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Není možné uložit archív"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Není možné získat velikost po rozbalení"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Obsah zvoleného archívu je příliš velký"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Není možné rozbalit archív"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symbolické odkazy nejsou v archívu povoleny"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Soubor '%s' je větší než bylo očekáváno"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Soubor '%s' se nesmí být součástí archívu"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interaktivní úlohy jsou administrátorem serveru zakázány"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Chybí vyžadovaný soubor '%s'"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace Server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Vítejte na Retrace Serveru"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +145,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Retrace server je servis poskytující možnost analýzy obrazu paměti a "
+"generace výpisu volání po síti. Další informace lze nalézt na Wiki Retrace "
+"serveru:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Server nyní povoluje pouze zabezpečené připojení HTTPS. Požadavek HTTP bude "
+"zamítnut."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Oba protokoly HTTP a HTTPS jsou povoleny. Z bezpečnostních důvodů je přísně "
+"doporučeno použití HTTPS."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Následující vydání jsou podporována: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "V tomto okamžiku je server vytížen na %d%% (%d z %d běžících úloh)"
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +187,13 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Váš obraz paměti je pouze ponechán na serveru po dobu běhu retrace úlohy. "
+"Jakmile je tato úloha dokončena, server si ponechá retrace záznamy a výpis "
+"volání. Všechna další data (včetně obrazu paměti) jsou vymazána. Retrace "
+"záznamy a výpis volání jsou dostupná jen za použití unikátního ID úlohy a "
+"hesla, čímž nikdo (kromě autora) je nemůže vidět. Všechny informace o pádu "
+"(včetně obrazu paměti) jsou po %d hodinách neaktivity smazány. Není tak "
+"možné, aby byla soukromá data uložena na serveru déle."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +203,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Vaš obraz paměti je použit pouze pro účely retrace. Administrátoři serveru "
+"se nesnaží dostat vaše soukromá data z obraz paměti a výpisu volání. Je "
+"přísně doporučeno použít zabezpečenou komunikaci (HTTPS). Administrátoři "
+"serveru nejsou zodpovědni za problémy spojené s použitím nezabezpečeného "
+"kanálu (jako je HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Pro zadaný úkol neexistuje žádný protokol"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architektura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architektury"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "ID Sestavení"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Počet"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Nepovolené úlohy"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Neúspěšný"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "První retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Globální statistiky"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Chybějící ID sestavení"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Jméno"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Vydání"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Vydání"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Požadované balíčky"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Vystopované balíčky"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Statistiky retrace serveru"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Jméno sdíleného objektu"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Úspěšný"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Celkový"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Verze"

--- a/po/da.po
+++ b/po/da.po
@@ -1,120 +1,146 @@
-# Danish translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# scootergrisen <scootergrisen@gmail.com>, 2017. #zanata
+# scootergrisen <scootergrisen@gmail.com>, 2018. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2018-09-20 09:50+0000\n"
+"Last-Translator: scootergrisen <scootergrisen@gmail.com>\n"
 "Language-Team: Danish\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Du skal bruge HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Ugyldig URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Opgaven findes ikke"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Ugyldig adgangskode"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Der er ingen backtrace til den angivne opgave"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Retrace-server er fuldt optaget på nuværende tidspunkt"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Du skal bruge POST-metode"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Angivne arkivformat understøttes ikke"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Du skal sætte Content-Length-header ordentligt"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Angivne arkiv er for stort"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"X-CoreFileDirectory-header er blevet deaktiveret af serveradministrator"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Kan ikke oprette arbejdsmappe"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Kan ikke hente diskens ledige plads"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Der er ikke nok lagerplads på serveren"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Kan ikke oprette ny opgave"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Mappen angivet i 'X-CoreFileDirectory' findes ikke"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Der er %d filer i mappen '%s'. Kun et enkelt arkiv understøttes på nuværende"
+" tidspunkt"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Din header angiver '%s'-type, men filtypen passer ikke"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Kan ikke gemme arkiv"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Kan ikke hente udpakket størrelse"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Angivne arkivers indhold er for stort"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Kan ikke udpakke arkiv"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symlinks er ikke tilladt i arkivet"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Filen '%s' er større end ventet"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Filen '%s' må ikke være i arkivet"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interaktive opgaver er deaktiveret af serveradministrator"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Krævet fil '%s' mangler"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace-server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Velkommen til retrace-server"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +148,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Retrace-server er en tjeneste som giver mulighed for at analysere kernedump "
+"og generere backtrace over netværk. Du kan finde yderligere information på "
+"retrace-server&apos;s wiki:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Kun den sikre HTTPS-forbindelse er nu tilladt af serveren. HTTP-"
+"forespørgsler vil blive nægtet."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Både HTTP og HTTPS er tilladt. Brug af HTTPS anbefales på det kraftigste af "
+"sikkerhedsårsager."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Følgende udgivelser understøttes: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "Når serveren indlæses for %d%% (kører %d ud af %d jobs)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +190,13 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Din kernedump opbevares kun på serveren mens retrace-jobbet kører. Når "
+"jobbet er færdigt opbevarer serveren retrace-log og backtrace. Alle andre "
+"data (inklusiv kernedump) bliver slettet. Retrace-loggen og backtrace er kun"
+" tilgængelige via en unik ID og adgangskode, så ingen (undtagen forfatteren)"
+" har tilladelse til at se det. Al nedbrudsinformationen (inklusiv backtrace)"
+" slettes efter %d timers inaktivitet. Ingen data som muligvis er private "
+"opbevares på serveren længere end det."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +206,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Din kernedump bruges kun til retrace-formål. Serveradministratorer prøver "
+"ikke at få dine private data fra kernedumps eller backtraces. Brug af en "
+"sikker kommunikationskanal (HTTPS) anbefales på det kraftigste. "
+"Serveradministratorer er ikke ansvarlige for problemer relateret til "
+"anvendelsen af en usikker kanal (såsom HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Der er ingen log for den angive opgave"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arkitektur"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arkitekturer"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Bygge-id"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Antal"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Nægtet jobs"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Mislykkedes"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Første retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Global statistik"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Manglende bygge-id'er"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Navn"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Udgivelse"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Udgivelser"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Krævet pakker"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Retraced pakker"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Retrace-server statistik"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Delt objektnavn"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Succes"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Samlet"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versioner"

--- a/po/de.po
+++ b/po/de.po
@@ -1,120 +1,149 @@
-# German translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Thomas Eichhorn <tomislav@posteo.de>, 2017. #zanata
+# Tobias Weise <tobias.weise@web.de>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-04-17 03:59+0000\n"
+"Last-Translator: Tobias Weise <tobias.weise@web.de>\n"
 "Language-Team: German\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Sie müssen HTTPS verwenden"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Ungültige URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Es gibt keine solche Aufgabe"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Ungültiges Passwort"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Es gibt keine Ablaufverfolgung für die angegebenen Aufgabe"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Der Retrace-Server ist im Moment vollständig ausgelastet"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Sie müssen eine POST-Methode verwenden"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Das angegebene Archivformat wird nicht unterstützt"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Sie müssen den Content-Length-Header richtig einstellen"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Das angegebene Archiv ist zu groß"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"Der X-CoreFileDirectory-Header wurde vom Serveradministrator deaktiviert"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Das Arbeitsverzeichnis konnte nicht angelegt werden"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Der freie Speicher des Laufwerks konnte nicht ermittelt werden"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Es ist nicht genügend Speicherplatz auf dem Server vorhanden"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Es konnte kein neuer Task angelegt werden"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
 msgstr ""
+"Das Verzeichnis, welches in \"X-CoreFileDirectory\" spezifiziert wird, "
+"existiert nicht"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Es befinden sich %d Dateien im Verzeichnis '%s'. Nur ein einziges Archiv "
+"kann im Moment unterstützt werden"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"Ihr Header legt den Typ %s fest, aber die Dateityp stimmt nicht überein"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Archiv konnte nicht gespeichert werden"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Die ausgepackte Größe konnte nicht ermittelt werden"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Der angegebene Inhalt des Archivs ist zu groß"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Archiv konnte nicht entpackt werden"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symlinks dürfen in einem Archiv nicht vorkommen"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Die Datei '%s' ist größer als erwartet"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Die Datei '%s' darf nicht ins Archiv aufgenommen werden"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interaktive Aufgaben wurde von Serveradministrator deaktiviert"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Die benötigte Datei '%s' kann nicht gefunden werden"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace-Server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Willkommen beim Retrace-Server"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +151,38 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Der Retrace-Server ist ein Dienstprogramm, das die Möglichkeit bietet, "
+"Speicherauszüge zu analysieren und Ablaufverfolgungen über das Netzwerk zu "
+"erstellen. Weitere Informationen finden Sie im Retrace-Server-Wiki:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Der Server erlaubt im Moment nur HTTPS Verbindungen. HTTP Anfragen werden "
+"abgewiesen."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"HTTP und HTTPS sind erlaubt. Die Verwendung von HTTPS wird aus "
+"Sicherheitsgründen dringend empfohlen"
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Die folgenden Release werden unterstützt: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"Im Moment ist der Server zu %d%% ausgelastet (es werden %d von %d Aufgaben "
+"ausgeführt)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +195,15 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Ihr Speicherauszug wird nur auf dem Server belassen, während der Retrace-"
+"Vorgang läuft. Sowie der Vorgang abgeschlossen ist, erstellt der Server ein "
+"Retrace-Log und eine Ablaufverfolgung. Alle anderen Dateien (auch der "
+"Speicherauszug) werden gelöscht. Das Retrace-Log und die Ablaufverfolgung "
+"sind nur über die eindeutige ID und ein Passwort zugänglich. Es kann also "
+"von Niemandem (außer dem Auto) eingesehen werden. Alle Absturzinformationen "
+"(auch die Ablaufverfolgung) werden nach %d Stunden Inaktivität gelöscht. "
+"Keine potentiell vertraulichen Daten werden länger auf dem Server "
+"gespeichert."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +213,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Ihr Speicherauszug wird nur für Retrace-Zwecke verwendet. Server-"
+"Administratoren versuchen nicht auf ihre privaten Daten in Speicherauszügen "
+"und Ablaufverfolgungen zuzugreifen. Das Verwenden eines gesicherten "
+"Kommunikationskanals (HTTPS) wird sehr empfohlen. Server-Administratoren "
+"sind nicht verantwortlich für die Verwendung unsicherer Kommunikationskanäle"
+" (wie HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Für die angegebene Aufgabe gibt es keinen Log"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architektur"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architekturen"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Build-ID"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Anzahl"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Abgewiesene Aufgaben"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Fehlgeschlagen"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Erster Retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Globale Statistik"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Fehlende Build-IDs"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Name"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Release"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Release"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Benötigte Pakete"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Zurückverfolgte Pakete"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Retrace-Server Statistiken"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Names des geteilten Objekts"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Erfolgreich"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Insgesamt"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versionen"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2,19 +2,21 @@
 # Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the retrace-server package.
 # Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Jakub Filak <jfilak@redhat.com>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-07-01 02:55+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: English (British)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
@@ -37,7 +39,7 @@ msgstr "Invalid password"
 msgid "There is no backtrace for the specified task"
 msgstr "There is no backtrace for the specified task"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
 msgstr "Retrace server is fully loaded at the moment"
 
@@ -57,53 +59,77 @@ msgstr "You need to set Content-Length header properly"
 msgid "Specified archive is too large"
 msgstr "Specified archive is too large"
 
-#: ../src/create.wsgi:47
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr ""
+
+#: ../src/create.wsgi:53
 msgid "Unable to create working directory"
 msgstr "Unable to create working directory"
 
-#: ../src/create.wsgi:53
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
 msgstr "Unable to obtain disk free space"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
 msgstr "There is not enough storage space on the server"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
 msgstr "Unable to create new task"
 
 #: ../src/create.wsgi:83
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr ""
+
+#: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+
+#: ../src/create.wsgi:116
 msgid "Unable to save archive"
 msgstr "Unable to save archive"
 
-#: ../src/create.wsgi:89
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
 msgstr "Unable to obtain unpacked size"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
 msgstr "Specified archive's content is too large"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
 msgstr "Unable to unpack archive"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
 msgstr ""
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+
+#: ../src/create.wsgi:196
 #, fuzzy, c-format
 msgid "Required file '%s' is missing"
 msgstr "Required file \"%s\" is missing"
@@ -125,14 +151,14 @@ msgstr ""
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
 
 #: ../src/index.wsgi:24
@@ -171,87 +197,78 @@ msgstr ""
 msgid "There is no log for the specified task"
 msgstr "There is no log for the specified task"
 
-#: ../src/stats.wsgi:10
+#: ../src/stats.wsgi:12
 msgid "Architecture"
 msgstr ""
 
-#: ../src/stats.wsgi:11
+#: ../src/stats.wsgi:13
 msgid "Architectures"
 msgstr ""
 
-#: ../src/stats.wsgi:12
+#: ../src/stats.wsgi:14
 msgid "Build-id"
 msgstr ""
 
-#: ../src/stats.wsgi:13
+#: ../src/stats.wsgi:15
 msgid "Count"
 msgstr ""
 
-#: ../src/stats.wsgi:14
+#: ../src/stats.wsgi:16
 msgid "Denied jobs"
 msgstr ""
 
-#: ../src/stats.wsgi:15
+#: ../src/stats.wsgi:17
 msgid "Failed"
 msgstr ""
 
-#: ../src/stats.wsgi:16
+#: ../src/stats.wsgi:18
 msgid "First retrace"
 msgstr ""
 
-#: ../src/stats.wsgi:17
+#: ../src/stats.wsgi:19
 msgid "Global statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:18
+#: ../src/stats.wsgi:20
 msgid "Missing build-ids"
 msgstr ""
 
-#: ../src/stats.wsgi:19
+#: ../src/stats.wsgi:21
 msgid "Name"
 msgstr ""
 
-#: ../src/stats.wsgi:20
+#: ../src/stats.wsgi:22
 msgid "Release"
 msgstr ""
 
-#: ../src/stats.wsgi:21
+#: ../src/stats.wsgi:23
 msgid "Releases"
 msgstr ""
 
-#: ../src/stats.wsgi:22
+#: ../src/stats.wsgi:24
 msgid "Required packages"
 msgstr ""
 
-#: ../src/stats.wsgi:23
+#: ../src/stats.wsgi:25
 msgid "Retraced packages"
 msgstr ""
 
-#: ../src/stats.wsgi:24
+#: ../src/stats.wsgi:26
 msgid "Retrace Server statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:25
+#: ../src/stats.wsgi:27
 msgid "Shared object name"
 msgstr ""
 
-#: ../src/stats.wsgi:26
+#: ../src/stats.wsgi:28
 msgid "Successful"
 msgstr ""
 
-#: ../src/stats.wsgi:27
+#: ../src/stats.wsgi:29
 msgid "Total"
 msgstr ""
 
-#: ../src/stats.wsgi:28
+#: ../src/stats.wsgi:30
 msgid "Versions"
 msgstr ""
-
-#~ msgid "Unable to verify password"
-#~ msgstr "Unable to verify password"
-
-#~ msgid "Unable to read backtrace file"
-#~ msgstr "Unable to read backtrace file"
-
-#~ msgid "Unable to read log file"
-#~ msgstr "Unable to read log file"

--- a/po/es.po
+++ b/po/es.po
@@ -1,120 +1,148 @@
-# Spanish translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-07-03 06:39+0000\n"
+"Last-Translator: Máximo Castañeda Riloba <mcrcctm@gmail.com>\n"
 "Language-Team: Spanish\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Debe usar HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL inválida"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "No existe la tarea"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Contraseña inválida"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "No hay traza para esa tarea"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "El servidor está completamente ocupado en este momento"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Debe usar el método POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "No hay soporte para el formato de archivo indicado"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "La petición debe incluir el encabezamiento Content-Length"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "El archivo es demasiado grande"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"El administrador del servidor ha desactivado el encabezamiento "
+"X-CoreFileDirectory"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "No se pudo crear el directorio de trabajo"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "No se pudo determinar la cantidad de espacio libre del disco"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "No hay suficiente espacio de almacenamiento en el servidor"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "No se puedo crear una tarea nueva"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "El directorio indicado en 'X-CoreFileDirectory' no existe"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Hay %d archivos en el directorio '%s'. Por ahora sólo se permite un único "
+"archivo"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"El encabezamiento indica un tipo '%s', que no coincide con el tipo de "
+"archivo"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "No se pudo guardar el archivo"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "No se pudo determinar el tamaño descomprimido"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "El contenido del archivo es demasiado grande"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "No se pudo descomprimir el archivo"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "No se permiten los enlaces simbólicos en el archivo"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "El archivo '%s' es mayor de lo esperado"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "No se permite el archivo '%s' en el archivo comprimido"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "El administrador del servidor ha desactivado las tareas interactivas"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Falta el archivo obligatorio '%s'"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Servidor Retrace"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Bienvenido al servidor Retrace"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +150,38 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"El servidor Retrace es un servicio que ofrece la posibilidad de analizar "
+"volcados de procesos y generar trazas a través de la red. Puede encontrar "
+"más información en el wiki de Retrace Server."
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Ahora sólo se permiten las conexiones HTTPS. Se denegarán las peticiones "
+"HTTP."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Se permiten tanto HTTP como HTTPS. Se recomienda usar sólo HTTPS, por "
+"razones de seguridad."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Hay soporte para las siguientes versiones: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"En este momento el servidor está ocupado al %d%% (ejecutando %d tareas de "
+"%d)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +194,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Su volcado sólo permanece en el servidor mientras se ejecuta la obtención de"
+" las trazas. Una vez terminada esa tarea, se guardan las trazas y el "
+"registro del traceado; el resto de datos (incluido el volcado del proceso) "
+"se borran. Para acceder tanto a las trazas como al registro se necesitan el "
+"identificador de tarea y una clave, de forma que sólo se permite al autor "
+"verlas. Toda la información (incluidas las trazas) se borra tras %d horas de"
+" inactividad. No se guardan en el servidor datos que puedan ser privados "
+"durante más tiempo."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +211,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Los datos de su volcado sólo se usan para obtener las trazas de ejecución. "
+"Los administradores del servidor no están intentando obtener datos privados "
+"a partir de los mismos. Se recomienda usar únicamente un canal de "
+"comunicación seguro (HTTPS). Los administradores del servidor no se "
+"responsabilizan de las consecuencias de usar un canal inseguro (como HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "No hay registro para la tarea indicada"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arquitectura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arquitecturas"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Identificador de compilación"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Recuento"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Tareas denegadas"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Fallidas"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Primera traza"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Estadísticas generales"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Identificadores de compilación faltantes"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nombre"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Lanzamiento"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Lanzamientos"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Paquetes necesarios"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Paquetes traceados"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Estadísticas del servidor"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nombre de objeto compartido"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Con éxito"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Total"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versiones"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,29 +1,27 @@
-# Finnish translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Toni Rantala <trantalafilo@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-04-17 02:27+0000\n"
+"Last-Translator: Toni Rantala <trantalafilo@gmail.com>\n"
 "Language-Team: Finnish\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Sinun pitää käyttää HTTPS:ää"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Epäkelpo URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
@@ -31,13 +29,13 @@ msgstr ""
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Väärä salasana"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
 msgstr ""
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
 msgstr ""
 
@@ -57,64 +55,88 @@ msgstr ""
 msgid "Specified archive is too large"
 msgstr ""
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Hakemistoa ei voitu luoda"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
 msgstr ""
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Palvelimella ei ole tarpeeksi vapaata tilaa"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
 msgstr ""
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
 msgstr ""
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Arkistoa ei voitu tallentaa"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
 msgstr ""
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
 msgstr ""
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Arkistoa ei voitu purkaa"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symbolisetlinkit eivät ole sallittuja arkistossa"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Tiedosto  '%s' on suurempi kuin odotettin"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
+msgstr "Tiedosto '%s' ei ole sallittu arkistossa"
+
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
 msgstr ""
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Vaadittua tiedostoa  '%s' ei löydy"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Tervetuloa Retrace palvelimelle"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -125,20 +147,23 @@ msgstr ""
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Palvelin hyväksyy vain turvalliset HTTPS-yhteydet. HTTP-pyynnöt evätään."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Molemmat HTTP ja HTTPS sallitaan. HTTPS:n käyttöä suositellaan "
+"tietoturvasyiden vuoksi."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Seuraavia julkaisuja tuetaan: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
@@ -171,78 +196,78 @@ msgstr ""
 msgid "There is no log for the specified task"
 msgstr ""
 
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
-
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arkkitehtuuri"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arkkitehtuurit"
 
 #: ../src/stats.wsgi:14
+msgid "Build-id"
+msgstr "Koonti-id"
+
+#: ../src/stats.wsgi:15
+msgid "Count"
+msgstr "Luku"
+
+#: ../src/stats.wsgi:16
 msgid "Denied jobs"
 msgstr ""
 
-#: ../src/stats.wsgi:15
+#: ../src/stats.wsgi:17
 msgid "Failed"
-msgstr ""
+msgstr "Epäonistui"
 
-#: ../src/stats.wsgi:16
+#: ../src/stats.wsgi:18
 msgid "First retrace"
 msgstr ""
 
-#: ../src/stats.wsgi:17
+#: ../src/stats.wsgi:19
 msgid "Global statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
-
-#: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
-
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Puuttuvat koonti-id:t"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nimi"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Julkaisu"
 
 #: ../src/stats.wsgi:23
+msgid "Releases"
+msgstr "Julkaisut"
+
+#: ../src/stats.wsgi:24
+msgid "Required packages"
+msgstr "Vaadittavat paketit"
+
+#: ../src/stats.wsgi:25
 msgid "Retraced packages"
 msgstr ""
 
-#: ../src/stats.wsgi:24
+#: ../src/stats.wsgi:26
 msgid "Retrace Server statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:25
+#: ../src/stats.wsgi:27
 msgid "Shared object name"
 msgstr ""
 
-#: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
-
-#: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
-
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Onnistunut"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Yhteensä"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versiot"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,119 +2,153 @@
 # Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the retrace-server package.
 # Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Jean-Baptiste Holcroft <jean-baptiste@holcroft.fr>, 2016. #zanata
+# José Fournier <jaaf64@zoraldia.com>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-08-04 09:04+0000\n"
+"Last-Translator: Jean-Baptiste Holcroft <jean-baptiste@holcroft.fr>\n"
 "Language-Team: French\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Vous devez utiliser l'HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL invalide"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Aucune tâche correspondante"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Mot de passe invalide"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Il n'y a pas de trace arrière pour la tâche indiquée"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Le serveur de retraçage est complètement chargé en ce moment"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Vous devez utiliser la méthode POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Le format d'archive indiqué n'est pas pris en charge"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Vous devez renseigner correctement l'entête Content-Length"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "L'archive indiquée est trop volumineuse"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"L'entête X-CoreFileDirectory a été désactivée par l'administrateur du "
+"serveur"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Impossible de créer le dossier de travail"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Impossible d'obtenir de l'espace libre sur le disque"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Il n'y a pas assez d'espace de stockage sur le serveur"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Impossible de créer une nouvelle tâche"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Le dossier renseigné dans « X-CoreFileDirectory » n'existe pas"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Il y a %d fichiers dans le dossier « %s ». Seule une archive unique est "
+"prise en charge pour l'instant"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"Votre entête indique le type « %s », mais ce type de fichier ne correspond "
+"pas"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Impossible de sauvegarder l'archive"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Impossible d'obtenir la taille décompressée"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Le contenu de l'archive indiquée est trop volumineux"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Impossible de décompresser l'archive"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Les liens symboliques ne sont pas autorisés dans l'archive"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Le fichier « %s » est plus volumineux que prévu"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Le fichier « %s » n'est pas permis dans l'archive"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+"Les tâches interactives ont été désactivées par l'administrateur du serveur"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Le fichier requis « %s » est manquant"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Serveur de retraçage"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Bienvenue sur le serveur de retraçage"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +156,38 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Le serveur de retraçage est un service offrant la possibilité d'analyser des"
+" instantanés de la mémoire (coredump) et de générer des traces arrières "
+"depuis le réseau (backtrace). Vous pouvez trouver plus d'informations sur le"
+" wiki du serveur de retraçage :"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Seules les connexions sécurisées HTTPS sont désormais autorisées par le "
+"serveur. Les requêtes HTTP seront refusées."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"HTTP et HTTPS sont tous deux permis. Utiliser HTTPS est cependant fortement "
+"recommandé pour des raisons de sécurité."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Les versions suivantes sont prises en charge : %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"En ce moment, le serveur est chargé pour %d%% (%d travaux en cours sur %d)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +200,15 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"L'instantané de la mémoire n'est conservé sur le serveur que le temps de "
+"réaliser le travail de retraçage. Une fois terminé, le serveur conserve le "
+"journal du retraçage et de la trace arrière. Toutes les autres données "
+"(incluant l'instantané) sont supprimées. Le fichier journal du retraçage et "
+"de la trace arrière sont uniquement accessibles par un identifiant unique de"
+" tâche et un mot de passe, que personne (à l'exception de l'auteur) n'est "
+"autorisé à voir. Toutes les informations du plantage (incluant la trace "
+"arrière) sont supprimées après %d heures sans activité. À partir de ce "
+"moment, aucune donnée potentiellement privée n'est conservée sur le serveur."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +218,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Votre instantané de la mémoire est utilisé uniquement à des fins de "
+"retraçage. Les administrateurs du serveur ne sont pas en en train d'essayer "
+"de prendre vos données privées avec vos instantanés ou traces arrières. "
+"Utiliser un canal de communication sécurisé (HTTPS) est fortement "
+"recommandé. Les administrateurs systèmes ne sont pas responsables des "
+"problèmes liés à l'usage d'un canal non sécurisé (tel que HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Il n'y a aucun journal pour la tâche indiquée."
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architecture"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architectures"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Id-construction"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Nombre"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Travaux refusés"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Échecs"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Premier retraçage"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Statistiques globales"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Id-construction manquants"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nom"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Version"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Versions"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Paquets requis"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Paquets retraçés"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Statistiques du serveur de retraçage"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nom de l'objet partagé"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Avec succès"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Total"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versions"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,120 +1,145 @@
-# Hungarian translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Meskó Balázs <meskobalazs@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-07-08 08:06+0000\n"
+"Last-Translator: Meskó Balázs <meskobalazs@gmail.com>\n"
 "Language-Team: Hungarian\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "HTTPS-t kell használnia"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Helytelen URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Nincs ilyen feladat"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Helytelen jelszó"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Nincs nyomkövetési információ a meghatározott feladatra"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Nyomkövető szerver jelenleg teljesen telített"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "POST metódust kell használnia"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "A megadott archívum formátum nem támogatott"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Helyesen kell beállítania a Content-Length fejlécet"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "A megadott archívum túl nagy"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"Az X-CoreFileDirectory fejlécet a kiszolgáló adminisztrátora kikapcsolta"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Munkakönyvtár létrehozása sikertelen"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Szabad tárhely lekérése sikertelen"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Nincs elég tárhely a kiszolgálón"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Új feladat létrehozása sikertelen"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Az „X-CoreFileDirectory” fejlécben megadott könyvtár nem létezik"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"%d fájl van a(z) „%s” könyvtárban. Pillanatnyilag csak egyetlen archívum "
+"támogatott."
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "A fejléc „%s” típust ad meg, de a fájltípus nem egyezik"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Az archívum mentése sikertelen"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "A kibontott méret lekérése sikertelen"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "A megadott archívum tartalma túl nagy"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Az archívum kibontása sikertelen"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Szimbolikus linkek nem lehetnek az archívumban"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "A(z) „%s” fájl nagyobb a vártnál"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "A(z) „%s” fájl nem lehet az archívumban"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Az interaktív műveleteket kikapcsolta a kiszolgáló adminisztrátora"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "A szükséges „%s” fájl hiányzik"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Nyomkövető kiszolgáló"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Üdvözöli a Nyomkövető kiszolgáló"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +147,37 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"A Nyomkövető kiszolgáló egy szolgáltatás, amely lehetővé teszi a "
+"programokból kigyűjtött adatok hibaelemzését, hálózaton keresztül. További "
+"információért keresse fel a Nyomkövető kiszolgáló wiki oldalát:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Már csak a biztonságos HTTPS kapcsolat engedélyezett a kiszolgálóval. A HTTP"
+" kérések megtagadásra kerülnek."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Mind a HTTP és a HTTPS engedélyezett. Biztonsági okokból azonban szigorúan "
+"csak a HTTPS-t javasoljuk."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "A következő kiadások támogatottak: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"Pillanatnyilag a kiszolgáló %d%%-ban terhelt (%d / %d feladat futtatása)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +190,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"A veremkiíratás csak a nyomkövetési feladat futásáig marad a kiszolgálón. "
+"Amint a feladat véget ért, a kiszolgáló csak a naplót és a nyomkövetési "
+"információkat tartja meg. Minden más adat (köztük a veremkiíratás is) "
+"törlésre kerül. A naplók és nyomkövetési információk csak az egyedi "
+"feladatazonosítóval és jelszóval érhetőek el, így senki (kivéve a szerzőt) "
+"nem nézheti meg. Minden összeomlás információ (beleértve a nyomkövetési "
+"információkat) törlésre kerül %d óra inaktivitás után. A lehetséges "
+"személyes adatok többet nem tárolódnak a kiszolgálón."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +207,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"A nyomkövetési információk csak elemzési célokra kerülnek felhasználásra. A "
+"kiszolgáló adminisztrátorok nem próbálnak meg személyes adatokat kinyerni a "
+"veremkiíratásokból vagy a nyomkövetési adatokból. A biztonságos "
+"kommunikációs csatorna (HTTPS) szigorúan javasolt. A kiszolgáló "
+"adminisztrátorok nem felelősek a nem biztonságok csatornák (mint a HTTP) "
+"használatából fakadó problémákért."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Nincs napló a megadott feladathoz"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architektúra"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architektúrák"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Építésazonosító"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Számláló"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Megtagadott feladatok"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Sikertelen"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Első elemzés"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Összesített statisztika"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Hiányzó építésazonosító"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Név"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Kiadás"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Kiadások"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Szükséges csomagok"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Elemzett csomagok"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Nyomkövetési kiszolgáló statisztikája"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Megosztott elem név"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Sikeres"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Összesítve"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Verziók"

--- a/po/id.po
+++ b/po/id.po
@@ -1,119 +1,145 @@
-# Indonesian translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Andika Triwidada <andika@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-08-06 06:11+0000\n"
+"Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Anda harus memakai HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL tidak valid"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Tidak ada tugas seperti itu"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Kata sandi tidak valid"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Tidak ada backtrace untuk tugas yang dinyatakan"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Server retrace sedang dalam beban penuh saat ini"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Anda mesti memakai metoda POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Format arsip yang dinyatakan tidak didukung"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Anda perlu menata header Content-Length dengan tepat"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Arsip yang dinyatakan terlalu besar"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"Header X-CoreFileDirectory telah dinonaktifkan oleh administrator server"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Tidak bisa membuat direktori kerja"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Tidak bisa mendapatkan ruang bebas disk"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Tidak cukup ruang penyimpanan pada server"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Tidak bisa mencipta tugas baru"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Direktori yang dinyatakan dalam \"X-CoreFileDirectory\" tidak ada"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Ada %d berkas dalam direktori '%s'. Hanya sebuah arsip tunggal yang didukung"
+" saat ini"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Header Anda menyatakan tipe '%s', tapi tipe berkas tidak cocok"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Tidak bisa menyimpan arsip"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Tidak bisa mendapatkan ukuran setelah dibongkar"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Isi arsip yang dinyatakan terlalu besar"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Tidak bisa membongkar arsip"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symlink tidak diizinkan berada di dalam arsip"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Berkas '%s' lebih besar dari yang diharapkan"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Berkas '%s' tidak diizinkan untuk berada di dalam arsip"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Tugas interaktif dinonaktifkan oleh administrator server"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Berkas '%s' yang diperlukan kurang"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Server Retrace"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Selamat Datang ke Server Retrace"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -121,29 +147,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Server Retrace adalah sebuah layanan yang menyediakan kemungkinan untuk "
+"menganalisis coredump dan menghasilkan backtrace melalui jaringan. Anda "
+"dapat menemukan informasi lebih jauh pada wiki Server Retrace:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Hanya koneksi HTTPS aman yang kini diizinkan oleh server. Permintaan HTTP "
+"akan ditolak."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"HTTP dan HTTPS keduanya diizinkan. Memakai HTTPS sangat disarankan karena "
+"alasan keamanan."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Rilis-rilis berikut didukung: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "Saat ini server dibebani untuk %d%% (menjalankan %d dari %d tugas)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -156,6 +189,13 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Coredump Anda hanya disimpan di server ketika tugas retrace sedang berjalan."
+" Sekali tugas selesai, server menyimpan log retrace dan backtrace. Semua "
+"data lain (termasuk coredump) dihapus. Log retrace dan backtrace hanya dapat"
+" diakses melalui ID tugas yang unik dan kata sandi, sehingga tidak "
+"seorangpun (kecuali pengarang) diizinkan melihatnya. Semua informasi kres "
+"(termasuk backtrace) dihapus setelah %d tanpa aktivitas. Tidak ada data "
+"privat yang disimpan di server lebih lama."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -165,83 +205,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Coredump Anda hanya dipakai untuk tujuan retrace. Administrator server tidak"
+" mencoba mendapatkan data privat dari coredump atau backtrace. Memakai suatu"
+" kanal komunikasi aman (HTTPS) sangat disarankan. Administrator server tidak"
+" bertanggung jawab atas masalah-masalah terkait penggunaan kanal tidak aman "
+"(seperti HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Tidak ada log untuk tugas yang dinyatakan"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arsitektur"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arsitektur"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "ID-build"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Cacah"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Tugas yang ditolak"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Gagal"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Retrace pertama"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Statistik global"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Kurang id-build"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nama"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Rilis"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Rilis"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Paket yang diperlukan"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Paket yang di-retrace"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Statistik Server Retrace"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nama objek bersama"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Sukses"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Total"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versi"

--- a/po/it.po
+++ b/po/it.po
@@ -1,120 +1,152 @@
-# Italian translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Davide Giunchi <davide@giunchi.net>, 2017. #zanata
+# Luca Ciavatta <luca.ciavatta@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-04-14 04:51+0000\n"
+"Last-Translator: Davide Giunchi <davide@giunchi.net>\n"
 "Language-Team: Italian\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "È necessario utilizzare HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL non valido"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
+#, fuzzy
 msgid "There is no such task"
-msgstr ""
+msgstr "Non è presente tale compito"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Passoword non valida"
 
 #: ../src/backtrace.wsgi:31
+#, fuzzy
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Non è presente alcun backtrace per il compito specificato."
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Il server Retrace è completamente attivo al momento"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "È necessario utilizzare il metodo POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Il formato di archiviazione specificato non è supportato"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "E' necessario impostare correttamente l'intestazione Content-Length"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "L'archivio specificato è troppo grande"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"L'intestazione X-CoreFileDirectory è stata disabilitata dall'amministratore "
+"del server"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Impossibile creare la directory di lavoro"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Impossibile ottenere spazio libero su disco"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
+#, fuzzy
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Spazio insufficiente nello storage sul server"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Impossibile creare un nuovo compito"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "La cartella specificata in 'X-CoreFileDirectory' non esiste"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Ci sono %d file nella '%s' cartella. Al momento è supportato un singolo "
+"archivio"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"L'intestazione specifica il tipo '%s', ma il tipo di file non combacia"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Impossibile salvare l'archivio"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Impossibile ottenere la dimensione scompattata"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Il contenuto dell'archivio specificato è troppo grande"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Impossibile scompattare l'archivio"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Nell'archivio non sono permessi link simbolici"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Il file '%s' è più grande di quanto previsto"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Nell'archivio non è permesso il file '%s'"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+"I lavori interattivi sono stati disabilitati dall'amministratore del server"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Il file '%s' richiesto è mancante"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Server Retrace"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Benvenuti al server Retrace"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +154,37 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Il server Retrace è un servizio che fonisce la possibilità di analizzare i "
+"coredump e generare  backtrace attraverso la rete. Potete trovare altre "
+"informazioni nel wiki del retrace server:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Solo le connessioni HTTPS sicure sono ora permesse dal server. Le richieste "
+"HTTP saranno negate"
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Sia le connssioni HTTP che HTTPS sono permesse. L'utilizzo di HTTPS è "
+"rigorosamente raccomandato per motivi di sicurezza"
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Le seguenti release sono supportate: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"Al momento il server è caricato per %d%% (eseguendo %d di %d attività)"
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +197,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Il tuo coredump è mantenuto solo nel server mentre l'attività di retrace è "
+"in esecuzione. Una volta che il job sarà terminato, il server manterrà il "
+"log di retrace ed il backtrace. Tutti gli altri dati (inclusi il coredump) "
+"saranno cancellati. Il log di retrace è accessibile solo attraverso un task "
+"ID univoco ed una passsword, quindi a nessuno (ad eccezione dell'autore) è "
+"permessa la visualizzazione. Tutte le informazioni di crash (incluso il "
+"backtrace) saranno cancellate dopo %d ore di inattività. Non è possibile che"
+" dati privati siano mantenuti nel server più a lungo."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +214,91 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Il proprio coredump è utilizzato solo per scopi di retrace. L'amministratore"
+" del server non sta cercando di ottenere i vostri dati privati dai coredump "
+"e backtrace. L'utilizzo di un canale di comunicazione sicuro (HTTPS) è "
+"fortemente raccomandato. Gli amministratori del server non sono responsabili"
+" per problemi legati all'uso di canali insicuri (come HTTP)"
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Non ci sono log per l'attività specificata"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architettura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architetture"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Build-id"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Conteggio"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+#, fuzzy
+msgid "Denied jobs"
+msgstr "Lavori negati"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Non riuscito"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Primo retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Statistiche globali"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "build-id mancanti"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nome"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+#, fuzzy
+msgid "Release"
+msgstr "Rilascio"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Rilasci"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Pacchetti richiesti"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+#, fuzzy
+msgid "Retraced packages"
+msgstr "Pacchetti retraced"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Statistiche del server di retrace"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nome dell'oggetto condiviso"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Riuscito"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Totale"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versioni"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,120 +1,146 @@
-# Dutch translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Geert Warrink <geert.warrink@onsnet.nu>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-03-31 03:00+0000\n"
+"Last-Translator: Geert Warrink <geert.warrink@onsnet.nu>\n"
 "Language-Team: Dutch\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Je moet HTTPS gebruiken"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Ongeldige URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Zo'n taak is er niet"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Ongeldig wachtwoord"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Er is geen backtrace voor de gespecificeerde taak"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Op dit moment is de trace server volledig belast"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Je moet POST methode gebruiken"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Het gespecificeerde archiefformaat wordt niet ondersteund"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Je moet de Content-Length koptekst juist instellen"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Het gespecificeerde archief is te groot"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "X-CoreFileDirectory koptekst is uitgezet door de serverbeheerder"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Kan geen werkmap aanmaken"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Kan geen vrije schijfruime verkrijgen"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Er is niet genoeg opslagruimte op de server"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Kan geen nieuwe taak aanmaken"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "De map gespecificeerd in 'X-CoreFileDirectory' bestaat niet"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Er zijn %d bestanden in de '%s' map. Op dit moment wordt alleen een enkel "
+"archief ondersteund"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"Jouw koptekst specificeert het '%s' type, maar het bestandstype komt niet "
+"overeen"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Kan het archief niet opslaan"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Kan de uitgepakte grootte niet verkrijgen"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "De inhoud van het gespecificeerde archief is te groot"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Kan het archief niet uitpakken"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symlinks zijn in het archief niet toegestaan"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Het '%s' bestand is groter dan verwacht"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Bestand '%s' mag niet in het archief aanwezig zijn"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interactieve taken zijn door de serverbeheerder uitgezet"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Het vereiste bestand '%s' ontbreekt"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace Server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Welckom bij Retrace Server"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +148,37 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Retrace Server is een service die mogelijkheden biedt voor het analyseren "
+"van een coredump en het genereren van een backtrace via het network. Je kunt"
+" meer informatie vinden op de wiki van Retrace Server:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Alleen de beveiligde HTTPS verbinding is bij de server nu toegestaan. HTTP "
+"verzoeken zullen geweigerd worden."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Zowel HTTP als HTTPS zijn toegestaan. Het gebruik van HTTPS wordt strikt "
+"aanbevolen omwille van veiligheidsredenen."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "De volgende releases worden ondersteund: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"Op dit mnoment is de server voor %d%%  belast (%d van de %d jobs draaien)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +191,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Je coredump wordt alleen op de server bewaard terwijl de retrace job draait."
+" Zodra de job beëindigd is, bewaart de server keeps de retrace log en "
+"backtrace. Alle andere data (inclusief coredump) wordt verwijdered. De "
+"retrace log en backtrace zijn alleen toegankelijk via een unieke taak-ID en "
+"wachtwoord, die niemand (behalve de auteur) wordt toegestaan om het te "
+"bekijken. Alle crash informatie (inclusief backtrace) wordt verwijderd na %d"
+" uur inactiviteit. Mogelijke privé data wordt niet langer op de server "
+"bewaard."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +208,85 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Je coredump wordt alleen voor retrace doeleinden gebruikt. Serverbeheerders proberen niet je privé data te verkrijgen uit coredumps of\n"
+"backtraces. Het gebruik van een beveiligd communicatiekanaal (HTTPS) wordt strikt aanbevolen. Serverbeheerders zijn niet verantwoordelijk voor problemen gerelateerd aan het gebruik van een onveilig kanaal (zoals HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Er is geen log voor de gespecificeerde taak"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architectuur"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architecturen"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Bouw-ID"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Telling"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Afgewezen taken"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Mislukt"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Eerste retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Globale statistieken"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Ontbrekende bouw-id's"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Naam"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Release"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Releases"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Vereiste pakketten"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Retraced pakketten"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Retrace Server statistieken"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Gedeelde object naam"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Succesvol"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Totaal"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versies"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,121 +1,144 @@
-# Polish translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Piotr Drąg <piotrdrag@gmail.com>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-09-01 09:40+0000\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Należy używać HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Nieprawidłowy adres URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Nie ma takiego zadania"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Nieprawidłowe hasło"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Brak wyjątku dla podanego zadania"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Serwer ponownego śledzenia jest całkowicie zajęty"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Należy używać metody POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Podany format archiwum jest nieobsługiwany"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Należy poprawnie ustawić nagłówek Content-Length"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Podane archiwum jest za duże"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
+"Nagłówek X-CoreFileDirectory został wyłączony przez administratora serwera"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Nie można utworzyć katalogu roboczego"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Nie można uzyskać wolnego miejsca na dysku"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Za mało miejsca na serwerze"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Nie można utworzyć nowego zadania"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Katalog podany w „X-CoreFileDirectory” nie istnieje"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"%d plików w katalogu „%s”. Obecnie obsługiwane są tylko pojedyncze archiwa"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Nagłówek określa typ „%s”, ale typ pliku się nie zgadza"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Nie można zapisać archiwum"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Nie można uzyskać rozpakowanego rozmiaru"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Zawartość podanego archiwum jest za duża"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Nie można rozpakować archiwum"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Dowiązania symboliczne w archiwach się niedozwolone"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Plik „%s” jest większy niż oczekiwano"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Plik „%s” nie jest dozwolony w archiwum"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Zadania interaktywne zostały wyłączone przez administratora serwera"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Brak wymaganego pliku „%s”"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Serwer ponownego śledzenia"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Witaj na serwerze ponownego śledzenia"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -123,29 +146,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Serwer ponownego śledzenia to usługa dostarczająca możliwość analizowania "
+"zrzutów core i tworzenia wyjątków przez sieć. Więcej informacji można "
+"znaleźć na wiki:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Tylko zabezpieczone połączenia HTTPS są dozwolone na serwerze. Żądania HTTP "
+"będą odrzucane."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Połączenia HTTP i HTTPS są dozwolone. Używanie HTTPS jest mocno zalecane "
+"z powodów bezpieczeństwa."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Obsługiwane wydania: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "Serwer jest zajęty w %d%% (wykonywanie zadań: %d z %d)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -158,6 +188,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Zrzut core jest przechowywany na serwerze tylko podczas działania zadania "
+"ponownego śledzenia. Po jego ukończeniu serwer przechowuje dziennik "
+"ponownego śledzenia i wyjątek. Wszystkie pozostałe dane (w tym zrzut core) "
+"są usuwane. Dziennik i wyjątek są dostępne tylko za pomocą unikalnego "
+"identyfikatora zadania i hasła, więc nikt (poza autorem) nie może ich "
+"wyświetlić. Wszystkie informacje o awarii (w tym wyjątek) są usuwane po %d "
+"godzinach nieaktywności. Żadne dane osobiste nie są przechowywane na "
+"serwerze po tym czasie."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -167,83 +205,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Zrzut core jest używany tylko w celu ponownego śledzenia. Administratorzy "
+"serwera nie uzyskują danych osobistych użytkowników ze zrzutów lub wyjątków."
+" Używanie zabezpieczonego kanału komunikacji (HTTPS) jest mocno zalecane. "
+"Administratorzy serwera nie są odpowiedzialni za problemy związane z użyciem"
+" niezabezpieczonego kanału komunikacji (takiego jak HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Brak dziennika dla podanego zadania"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architektura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architektury"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Identyfikator budowania"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Liczba"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Odrzucone zadania"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Niepowodzenie"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Pierwsze ponowne śledzenie"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Globalne statystyki"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Brak identyfikatorów budowania"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nazwa"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Wydanie"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Wydania"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Wymagane pakiety"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Ponownie prześledzone pakiety"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Statystyki serwera ponownego śledzenia"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nazwa obiektu współdzielonego"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Powodzenie"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Razem"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Wersje"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,53 +1,51 @@
-# Portuguese translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Manuela Silva <mmsrs@sky.com>, 2019. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2019-08-23 03:57+0000\n"
+"Last-Translator: Manuela Silva <mmsrs@sky.com>\n"
 "Language-Team: Portuguese\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Deve utilizar HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL inválido"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Não existe tal tarefa."
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Palavra-passe inválida"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
 msgstr ""
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
 msgstr ""
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Deve utilizar o método POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "O formato de ficheiro especificado não é suportado"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
@@ -57,53 +55,77 @@ msgstr ""
 msgid "Specified archive is too large"
 msgstr ""
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
 msgstr ""
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr ""
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
 msgstr ""
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
 msgstr ""
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
 msgstr ""
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
 msgstr ""
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr ""
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
 msgstr ""
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
 msgstr ""
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
 msgstr ""
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
 msgstr ""
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
 msgstr ""
@@ -125,14 +147,14 @@ msgstr ""
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
 
 #: ../src/index.wsgi:24
@@ -171,78 +193,78 @@ msgstr ""
 msgid "There is no log for the specified task"
 msgstr ""
 
-#: ../src/stats.wsgi:10
+#: ../src/stats.wsgi:12
 msgid "Architecture"
 msgstr ""
 
-#: ../src/stats.wsgi:11
+#: ../src/stats.wsgi:13
 msgid "Architectures"
 msgstr ""
 
-#: ../src/stats.wsgi:12
+#: ../src/stats.wsgi:14
 msgid "Build-id"
 msgstr ""
 
-#: ../src/stats.wsgi:13
+#: ../src/stats.wsgi:15
 msgid "Count"
 msgstr ""
 
-#: ../src/stats.wsgi:14
+#: ../src/stats.wsgi:16
 msgid "Denied jobs"
 msgstr ""
 
-#: ../src/stats.wsgi:15
+#: ../src/stats.wsgi:17
 msgid "Failed"
 msgstr ""
 
-#: ../src/stats.wsgi:16
+#: ../src/stats.wsgi:18
 msgid "First retrace"
 msgstr ""
 
-#: ../src/stats.wsgi:17
+#: ../src/stats.wsgi:19
 msgid "Global statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:18
+#: ../src/stats.wsgi:20
 msgid "Missing build-ids"
 msgstr ""
 
-#: ../src/stats.wsgi:19
+#: ../src/stats.wsgi:21
 msgid "Name"
 msgstr ""
 
-#: ../src/stats.wsgi:20
+#: ../src/stats.wsgi:22
 msgid "Release"
 msgstr ""
 
-#: ../src/stats.wsgi:21
+#: ../src/stats.wsgi:23
 msgid "Releases"
 msgstr ""
 
-#: ../src/stats.wsgi:22
+#: ../src/stats.wsgi:24
 msgid "Required packages"
 msgstr ""
 
-#: ../src/stats.wsgi:23
+#: ../src/stats.wsgi:25
 msgid "Retraced packages"
 msgstr ""
 
-#: ../src/stats.wsgi:24
+#: ../src/stats.wsgi:26
 msgid "Retrace Server statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:25
+#: ../src/stats.wsgi:27
 msgid "Shared object name"
 msgstr ""
 
-#: ../src/stats.wsgi:26
+#: ../src/stats.wsgi:28
 msgid "Successful"
 msgstr ""
 
-#: ../src/stats.wsgi:27
+#: ../src/stats.wsgi:29
 msgid "Total"
 msgstr ""
 
-#: ../src/stats.wsgi:28
+#: ../src/stats.wsgi:30
 msgid "Versions"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,120 +1,146 @@
-# Portuguese translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Daniel Lara <danniel@fedoraproject.org>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
-"Language-Team: Brazilian Portuguese\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-09-05 03:40+0000\n"
+"Last-Translator: Emerson Santos <em3rson@linuxmail.org>\n"
+"Language-Team: Portuguese (Brazil)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Você deve usar HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL inválida"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Não existe tal tarefa"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Senha inválida"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Não há registro de chamadas para a tarefa especificada"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Servidor de retorno está totalmente carregado no momento"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Você deve usar o método POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "O formato do arquivo especificado não é suportado"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Você precisa definir o cabeçalho Content-Length corretamente"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "O arquivo especificado é muito grande"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "X-CoreFileDirectory foi desabilitado pelo administrador do servidor"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Não foi possível criar diretório de trabalho"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Não foi possível obter espaço livre em disco"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Não há espaço de armazenamento suficiente no servidor"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Não foi possível criar uma nova tarefa"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "O diretório especificado em 'X-Core Diretório File' não existe"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Existem %d arquivos no '%s' diretório. É suportado apenas um arquivo no "
+"momento"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"Seu cabeçalho especifica '%s' tipo, mas o tipo de arquivo não corresponde"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Não foi possível salvar o arquivo"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Não foi possível obter o tamanho descompactado"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "O conteúdo do arquivo especificado é muito grande"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Impossível descompactar arquivo"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Links simbólicos não são permitidos para estar no arquivo"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "O arquivo '%s' é maior que o esperado"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Arquivo '%s' não é permitido estar no aquivo"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+"Tarefas interativas foram desabilitadas pelo administrador do servidor"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Arquivo exigido '%s' está ausente"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Servidor Retrace"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Bem-vindo ao Servidor Retrace"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +148,38 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Servidor Retrace é um serviço que fornece a possibilidade de analisar o "
+"despejo de memória e gerar backtrace sobre a rede. Você pode encontrar "
+"informações adicionais na wiki do Servidor Retrace:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Agora apenas conexões seguras HTTPS são permitidas pelo servidor. "
+"Requisições HTTP serão negadas."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Ambos HTTP e HTTPS são permitidos. A utilização do HTTPS é altamente "
+"recomendado por questões de segurança."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "As seguintes versões são suportadas: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
 msgstr ""
+"No momento o servidor está carregado por %d%% (executando %d de %d "
+"trabalhos)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +192,14 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"O seu despejo de memória só é mantido no servidor enquanto o trabalho do "
+"retrace estiver executando. Uma vez que o trabalho for finalizado, o "
+"servidor mantém registros do retrace e backtrace. Todos os outros dados "
+"(incluindo despejo de memória) são removidos. O registro do retrace e o "
+"backtrace são acessíveis somente pelo ID único da tarefa e senha, assim "
+"ninguém (exceto o autor) é permitida a sua visualização. Todas as "
+"informações de quebra (incluindo o backtrace) é removida após %d horas de "
+"inatividade. Nenhum dado privado possível é mantido no servidor."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +209,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"O seu despejo de memória só é utilizado para fins do retrace. "
+"Administradores de servidor não estão tentando obter seus dados privados "
+"através de despejos de memória ou backtraces. A utilização de um canal de "
+"comunicação seguro (HTTPS) é altamente recomendado. Administradores de "
+"servidor não são responsáveis por problemas relacionados com a utilização de"
+" um canal inseguro (como o HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Não há nenhum registro sobre a tarefa especificada"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arquitetura"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arquiteturas"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Id da compilação"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Contagem"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Trabalhos negados"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Falhou"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "primeiro retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Estatísticas globais"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Id das compilações ausentes"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Nome"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Versão"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Versões"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Pacotes exigidos"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Pacote retraçado"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Estatísticas do Servidor retraçada"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Nome do objeto compartilhado"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Bem sucessido"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Total"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versões"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,120 +1,145 @@
-# Slovak translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# feonsu <feonsu@gmail.com>, 2016. #zanata
+# Matej Marusak <mmarusak@redhat.com>, 2019. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2019-10-24 03:24+0000\n"
+"Last-Translator: Matej Marusak <mmarusak@redhat.com>\n"
 "Language-Team: Slovak\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Musíte použiť HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Neplatná URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Žiadna takáto úloha neexistuje"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Neplatné heslo"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Backtrace pre zadanú úlohu neexistuje"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Retrace server je momentálne plne vyťažený"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Musíte použiť metódu POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Zadaný formát archívu nie je podporovaný"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Hlavičku Content-Length musíte nastaviť správne"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Zadaný archív je príliš veľký"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "Hlavička X-CoreFileDirectory bola zakázaný administrátorom servera"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Nepodarilo sa vytvoriť pracovný adresár"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Nepodarilo sa získať voľné miesto na disku"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Na serveri nie je dostatok voľného úložného miesta"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Nepodarilo sa vytvoriť novú úlohu"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Adresár uvedený v 'X-CoreFileDirectory'  neexistuje"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Existuje %d súborov v adresári '%s'. Momentálne je podporovaný iba jeden "
+"archív"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Hlavička špecifikuje typ '%s', ale typ súboru neodpovedá"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Nepodarilo sa uložiť archív"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Nepodarilo sa získať veľkosť po rozbalení"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Obsah zadaného archív je príliš veľký"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Nepodarilo sa rozbaliť archív"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symbolické odkazy nie sú v archíve povolené"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Súbor '%s' je väčší ako bolo očakávané"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Súbor '%s' nie je povolený v archíve"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interaktívne úlohy boli zakázané administrátorom servera"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Chýba požadovaný súbor '%s'"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace Server"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Vitajte v Retrace Serveri"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +147,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Retrace server je služba, ktorá poskytuje možnosť analyzovať coredumpy a "
+"generovať backtrace cez sieť. Viac informácií nájdete na wiki Retrace "
+"Servera: "
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Server teraz povoľuje iba bezpečné pripojenia HTTPS. Požiadavky HTTP budú "
+"zamietnuté."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Povolené je HTTP a HTTPS. Z bezpečnostných dôvodov sa prísne odporúča "
+"používať HTTPS."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Podporované sú nasledujúce vydania: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "Momentálne je server vyťažený na %d%% (beží %d z %d úloh)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +189,13 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Váš coredump je uschovaný iba na serveri počas behu retrace úlohy. Po "
+"skončení úlohy server ponechá iba retrace log a backtrace. Všetky ďalšie "
+"dáta (vrátane coredump) sa vymažú. Retrace log a backtrace sú dostupné iba "
+"cez jedinečné ID úlohy a heslo, teda nikto iný (okrem autora) ich nemôže "
+"vidieť. Všetky informácie o páde (vrátane backtrace) sú po %d hodinách "
+"nečinnosti vymazané.  Nie je teda možné, aby zostali súkromné dáta na "
+"serveri nejako dlhšie. "
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +205,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Vaš coredump je použitý iba pre účely retrace. Administrátori servera sa "
+"nesnažia získať vaše súkromné dáta z coredumpov ani retrace. Prísne sa "
+"odporúča používať bezpečný komunikačný kanál (HTTPS). Administrátori server "
+"nie sú zodpovedný za problémy súvisiace s používaním nezabezpečeného kanálu "
+"(ako je HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Pre zadanú úlohu neexistuje žiadny log"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Architektúra"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Architektúry"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "ID zostavenia"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Počet"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Zamietnuté úlohy"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Neúspešné"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Prvý retrace"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Globálne štatistiky"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Chýbajúce ID zostavenia"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Názov"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Vydanie"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Vydania"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Požadované balíčky"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Vystopované balíčky"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Štatistiky serveru Retrace"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Názov zdieľaného objektu"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Úspešné"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Celkovo"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Verzie"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,120 +1,144 @@
-# Swedish translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Göran Uddeborg <goeran@uddeborg.se>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-10-10 03:37+0000\n"
+"Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
 "Language-Team: Swedish\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Du måste använda HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Felaktig URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Det finns ingen sådan uppgift"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Felaktigt lösenord"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Det finns inget stackspår för den angivna uppgiften"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Spårningsservern är fullt belastad för tillfället"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Du måste använda metoden POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Det angivna arkivformatet stödjs inte"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "Du behöver sätta huvudet Content-Length ordentligt"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Det angivna arkivet är för stort"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "Huvudet X-CoreFileDirectory har avaktiverats av serveradministratören"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Kan inte skapa en arbetskatalog"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Kan inte få tag i ledigt diskutrymme"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "Det finns inte tillräckligt med lagringsutrymme på servern"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Kan inte skapa en ny uppgift"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Katalogen som anges i ”X-CoreFileDirectory” finns inte"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Det finns %d filer i katalogen ”%s”.  Endast ett ensamt arkiv stödjs för "
+"närvarande"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "Ditt huvud anger typen ”%s”, men filtypen stämmer inte med det"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Kan inte spara arkivet"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Kan inte ta fram den opackade storleken"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Det angivna arkivets innehåll är för stort"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Kan inte packa upp arkivet"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "Symlänkar får inte finnas i arkivet"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Filen ”%s” är större än förväntat"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Filen ”%s” får inte finnas i arkivet"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Interaktiva uppgifter har avaktiverats av serveradministratören"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Den nödvändiga filen ”%s” saknas"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Spårningsserver"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Välkommen till Spårningsservern"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -122,29 +146,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Spårningsservern är en tjänst som ger möjligheten att analysera en "
+"minnesdump och generera ett stackspår över nätverket.  Du kan hitta mer "
+"information på Spårningsserverns wiki:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Endast en säker HTTPS-anslutning tillåts nu av servern.  HTTP-begäranden "
+"kommer att avvisas."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Både HTTP och HTTPS är tillåtna.  Att använda HTTPS rekommenderas starkt av "
+"säkerhetsskäl."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Följande utgåvor stödjs: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "För närvarande är servern lastad till %d %% (kör %d av %d jobb)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +188,13 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Din minnesdump sparas bara på servern medan spårjobbet kör.  När jobbet är "
+"klart behåller servern spårningsloggen och stackspåret.  All annan data "
+"(inklusive minnesdumpen) raderas.  Spårningsloggen och stackspåret är endast"
+" tillgängliga via unika uppgifts-ID och lösenord, alltså får ingen (utom "
+"författaren) se det.  All kraschinformation (inklusive stackspåret) raderas "
+"efter %d timmars inaktivitet.  Ingen eventuell personlig information sparas "
+"på servern längre."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +204,88 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Din minnesdump används bara för spårningssyften.  Serveradministratörerna "
+"försöker inte få tag i din privata information från minnesdumpar eller "
+"stackspår.  Att använda en säker kommunikationskanal (HTTPS) rekommenderas "
+"starkt.  Serveradministratörer är inte ansvariga för problem kopplade till "
+"användningen av en osäker kanal (såsom HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Det finns ingen logg för den angivna uppgiften"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Arkitektur"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Arkitekturer"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Bygg-id"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "Antal"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Nekade jobb"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Misslyckade"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Första spårning"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Global statistik"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Saknade bygg-id:n"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Namn"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Utgåva"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Utgåvor"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Nödvändiga paket"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Spårade paket"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Spårserverstatistik"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Delade objekt-namn"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Lyckade"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Totalt"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Versioner"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,0 +1,273 @@
+# Serdar Sağlam <teknomobil@msn.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2019-05-11 09:55+0000\n"
+"Last-Translator: Serdar Sağlam <teknomobil@msn.com>\n"
+"Language-Team: Turkish\n"
+"Language: tr\n"
+"X-Generator: Zanata 4.6.2\n"
+"Plural-Forms: nplurals=2; plural=(n>1)\n"
+
+#: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
+#: ../src/status.wsgi:11
+msgid "You must use HTTPS"
+msgstr "HTTPS kullanmalısınız"
+
+#: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
+msgid "Invalid URL"
+msgstr "Geçersiz URL"
+
+#: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
+msgid "There is no such task"
+msgstr "Böyle bir görev yok"
+
+#: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
+msgid "Invalid password"
+msgstr "Geçersiz parola"
+
+#: ../src/backtrace.wsgi:31
+msgid "There is no backtrace for the specified task"
+msgstr "Belirtilen görev için geri bildirim yok"
+
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
+msgid "Retrace server is fully loaded at the moment"
+msgstr "Retrace sunucusu şu anda tamamen yükleniyor"
+
+#: ../src/create.wsgi:23
+msgid "You must use POST method"
+msgstr "POST yöntemini kullanmanız gerekir"
+
+#: ../src/create.wsgi:27
+msgid "Specified archive format is not supported"
+msgstr "Belirtilen arşiv biçimi desteklenmiyor"
+
+#: ../src/create.wsgi:31
+msgid "You need to set Content-Length header properly"
+msgstr "İçerik Uzunluğu üst bilgisini uygun şekilde ayarlamanız gerekir."
+
+#: ../src/create.wsgi:35
+msgid "Specified archive is too large"
+msgstr "Belirtilen arşiv çok büyük"
+
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr ""
+"X-CoreFileDirectory başlığı sunucu yöneticisi tarafından devre dışı "
+"bırakıldı"
+
+#: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Çalışma dizini oluşturulamıyor"
+
+#: ../src/create.wsgi:59
+msgid "Unable to obtain disk free space"
+msgstr "Disk boş alanı alınamadı"
+
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
+msgid "There is not enough storage space on the server"
+msgstr "Sunucuda yeterli depolama alanı yok"
+
+#: ../src/create.wsgi:71
+msgid "Unable to create new task"
+msgstr "Yeni görev oluşturulamıyor"
+
+#: ../src/create.wsgi:83
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "'X-CoreFileDirectory' de belirtilen dizin mevcut değil"
+
+#: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported "
+"at the moment"
+msgstr ""
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Arşiv kaydedilemedi"
+
+#: ../src/create.wsgi:124
+msgid "Unable to obtain unpacked size"
+msgstr "Paketlenmemiş boyut alınamıyor"
+
+#: ../src/create.wsgi:129
+msgid "Specified archive's content is too large"
+msgstr "Belirtilen arşivin içeriği çok büyük"
+
+#: ../src/create.wsgi:146
+msgid "Unable to unpack archive"
+msgstr "Arşiv açılmıyor"
+
+#: ../src/create.wsgi:158
+msgid "Symlinks are not allowed to be in the archive"
+msgstr "Sembolik bağlantıların arşivde bulunmasına izin verilmemektedir."
+
+#: ../src/create.wsgi:166
+#, c-format
+msgid "The '%s' file is larger than expected"
+msgstr "'%s' dosyası beklenenden daha büyük"
+
+#: ../src/create.wsgi:170
+#, c-format
+msgid "File '%s' is not allowed to be in the archive"
+msgstr "'%s' dosyasının arşivde bulunmasına izin verilmiyor"
+
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+"Etkileşimli görevler sunucu yöneticisi tarafından devre dışı bırakıldı"
+
+#: ../src/create.wsgi:196
+#, c-format
+msgid "Required file '%s' is missing"
+msgstr "Gerekli '%s' dosyası eksik"
+
+#: ../src/index.wsgi:12
+msgid "Retrace Server"
+msgstr ""
+
+#: ../src/index.wsgi:13
+msgid "Welcome to Retrace Server"
+msgstr ""
+
+#: ../src/index.wsgi:15
+msgid ""
+"Retrace Server is a service that provides the possibility to analyze "
+"coredump and generate backtrace over network. You can find further "
+"information at Retrace Server&apos;s wiki:"
+msgstr ""
+
+#: ../src/index.wsgi:21
+msgid ""
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
+"will be denied."
+msgstr ""
+
+#: ../src/index.wsgi:23
+msgid ""
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
+"of security reasons."
+msgstr ""
+
+#: ../src/index.wsgi:24
+#, c-format
+msgid "The following releases are supported: %s"
+msgstr ""
+
+#: ../src/index.wsgi:26
+#, c-format
+msgid ""
+"At the moment the server is loaded for %d%% (running %d out of %d jobs)."
+msgstr ""
+
+#: ../src/index.wsgi:27
+#, c-format
+msgid ""
+"Your coredump is only kept on the server while the retrace job is running. "
+"Once the job is finished, the server keeps retrace log and backtrace. All "
+"the other data (including coredump) are deleted. The retrace log and "
+"backtrace are only accessible via unique task ID and password, thus no one "
+"(except the author) is allowed to view it. All the crash information "
+"(including backtrace) is deleted after %d hours of inactivity. No possibly "
+"private data are kept on the server any longer."
+msgstr ""
+
+#: ../src/index.wsgi:33
+msgid ""
+"Your coredump is only used for retrace purposes. Server administrators are "
+"not trying to get your private data from coredumps or backtraces. Using a "
+"secure communication channel (HTTPS) is strictly recommended. Server "
+"administrators are not responsible for the problems related to the usage of "
+"an insecure channel (such as HTTP)."
+msgstr ""
+
+#: ../src/log.wsgi:30
+msgid "There is no log for the specified task"
+msgstr ""
+
+#: ../src/stats.wsgi:12
+msgid "Architecture"
+msgstr ""
+
+#: ../src/stats.wsgi:13
+msgid "Architectures"
+msgstr ""
+
+#: ../src/stats.wsgi:14
+msgid "Build-id"
+msgstr ""
+
+#: ../src/stats.wsgi:15
+msgid "Count"
+msgstr ""
+
+#: ../src/stats.wsgi:16
+msgid "Denied jobs"
+msgstr ""
+
+#: ../src/stats.wsgi:17
+msgid "Failed"
+msgstr ""
+
+#: ../src/stats.wsgi:18
+msgid "First retrace"
+msgstr ""
+
+#: ../src/stats.wsgi:19
+msgid "Global statistics"
+msgstr ""
+
+#: ../src/stats.wsgi:20
+msgid "Missing build-ids"
+msgstr ""
+
+#: ../src/stats.wsgi:21
+msgid "Name"
+msgstr ""
+
+#: ../src/stats.wsgi:22
+msgid "Release"
+msgstr ""
+
+#: ../src/stats.wsgi:23
+msgid "Releases"
+msgstr ""
+
+#: ../src/stats.wsgi:24
+msgid "Required packages"
+msgstr ""
+
+#: ../src/stats.wsgi:25
+msgid "Retraced packages"
+msgstr ""
+
+#: ../src/stats.wsgi:26
+msgid "Retrace Server statistics"
+msgstr ""
+
+#: ../src/stats.wsgi:27
+msgid "Shared object name"
+msgstr ""
+
+#: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr ""
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Toplam"
+
+#: ../src/stats.wsgi:30
+msgid "Versions"
+msgstr "Sürümler"

--- a/po/tr.po
+++ b/po/tr.po
@@ -4,15 +4,15 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-01 08:48+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2019-05-11 09:55+0000\n"
 "Last-Translator: Serdar Sağlam <teknomobil@msn.com>\n"
 "Language-Team: Turkish\n"
 "Language: tr\n"
-"X-Generator: Zanata 4.6.2\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n>1)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
@@ -84,8 +84,8 @@ msgstr "'X-CoreFileDirectory' de belirtilen dizin mevcut değil"
 #: ../src/create.wsgi:89
 #, c-format
 msgid ""
-"There are %d files in the '%s' directory. Only a single archive is supported "
-"at the moment"
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
 msgstr ""
 
 #: ../src/create.wsgi:98
@@ -150,14 +150,14 @@ msgstr ""
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
 
 #: ../src/index.wsgi:24

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,121 +1,146 @@
-# Ukrainian translations for retrace-server package.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Yuri Chornoivan <yurchor@ukr.net>, 2016. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
-"Language-Team: Ukrainian\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2016-07-03 05:13+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
-"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "Вам слід скористатися HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "Некоректна адреса"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "Такого завдання не існує"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Некоректний пароль"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "Не існує зворотного трасування для вказаного завдання"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Зараз сервер повторного трасування повністю завантажено"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "Вам слід скористатися методом POST"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "Підтримки вказаного формату архівів не передбачено"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
 msgstr ""
+"Вам слід встановити властивість заголовка Content-Length належним чином"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "Вказаний архів є надто великим"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "Заголовок X-CoreFileDirectory було вимкнено адміністратором сервера"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "Не вдалося створити робочий каталог"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "Не вдалося отримати дані щодо вільного місця на диску"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "На сервері недостатньо вільного місця для зберігання даних"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "Не вдалося створити завдання"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "Каталогу, вказаного у «X-CoreFileDirectory», не існує"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr ""
+"Маємо %d файлів у каталозі «%s». У поточній версії передбачено лише один "
+"архів."
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+"У заголовку тип вказано як «%s», але тип файла не збігається із вказаним"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "Не вдалося зберегти архів"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "Не вдалося отримати дані щодо розміру розпакованого"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "Вказаний вміст архіву є надто великим"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "Не вдалося розпакувати архів"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "У архіві не повинно бути символічних посилань"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "Файл «%s» має більший за очікуваний розмір"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "Файл «%s» не може бути архівом"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "Інтерактивні завдання було вимкнено адміністратором сервера"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "Не вистачає потрібного файла «%s»"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Сервер повторного трасування"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "Вітаємо на сервері повторного трасування"
 
 #: ../src/index.wsgi:15
 msgid ""
@@ -123,29 +148,36 @@ msgid ""
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
 msgstr ""
+"Сервер повторного трасування — служба, яка надає можливість проаналізувати "
+"дамп ядра і створити дані зворотного трасування за допомогою мережі. "
+"Докладніші відомості можна знайти у вікі сервера повторного трасування:"
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
 msgstr ""
+"Сервер може працювати лише із захищеними з’єднаннями HTTPS. Запити HTTP "
+"автоматично відхилятимуться."
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
 msgstr ""
+"Можна використовувати HTTP і HTTPS. З міркувань безпеки наполегливо "
+"рекомендуємо використовувати HTTPS."
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "Передбачено підтримку таких випусків: %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "Зараз сервер навантажено на %d%% (виконується %d з %d завдань)."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -158,6 +190,16 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"Ваші дані ядра зберігатимуться на сервері лише протягом виконання завдання "
+"із повторного трасування. Щойно завдання буде виконано, сервер збереже "
+"журнал і дані повторного трасування. Усі інші дані (зокрема і дамп ядра) "
+"буде вилучено. Доступ до журналу повторного трасування і даних самого "
+"трасування можна буде отримати лише вказавши унікальний ідентифікатор "
+"завдання та пароль. Отже, ніхто (окрім автора) не зможе переглянути ці дані."
+" Усі відомості щодо аварійного завершення роботи (зокрема дані зворотного "
+"трасування) буде вилучено за %d годин після останнього запиту щодо них. По "
+"завершенню цього періоду часу ніяких потенційно конфіденційних даних на "
+"сервері не залишиться."
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -167,83 +209,89 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"Ваші дані дампу ядра використовуватимуться лише для зворотного трасування. "
+"Адміністратори сервера не намагатимуться отримати якісь конфіденційні дані з"
+" дампів ядра і даних зворотного трасування. Наполегливо рекомендуємо "
+"використовувати захищений канал обміну даними (HTTPS). Адміністратори "
+"сервера не несуть відповідальності за проблеми, пов’язані із використанням "
+"незахищеного каналу обміну (зокрема HTTP)."
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "Для вказаного завдання немає журналу"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "Архітектура"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "Архітектури"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Ід. збирання"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "К-ть"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "Відкинуті завдання"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "Помилки"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "Перше повторне трасування"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "Загальна статистика"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "Немає ід. збирання"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "Назва"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "Випуск"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "Випуски"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "Потрібні пакунки"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "Пакунки для трасування"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Статистика сервера повторного трасування"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "Назва спільного об’єкта"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "Успішно"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "Загалом"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "Версії"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,150 +1,167 @@
-# Chinese translations for retrace-server package
-# retrace-server �������ļ������ķ���.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Qi Fan <fun224@gmail.com>, 2016. #zanata
+# Jerry Lee <lchopn@gmail.com>, 2017. #zanata
+# Zamir SUN <sztsian@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
-"Language-Team: Chinese (simplified)\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-04-14 10:53+0000\n"
+"Last-Translator: Zamir SUN <sztsian@gmail.com>\n"
+"Language-Team: Chinese (China)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=GB2312\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "您必须使用 HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "无效 URL"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "没有这个任务"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "无效密码"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "没有对特定任务的追踪"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "Retrace 服务器当前负载已满"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "必须使用POST方法"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "不支持指定的归档格式"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "你需要设置合适的 Content-Length 头"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "指定的归档过大"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "X-CoreFileDirectory 头被管理员禁用"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "不能创建工作目录"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "不能获得磁盘空余空间"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "服务器上的存储空间不够"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "不能创建新任务"
 
 #: ../src/create.wsgi:83
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "'X-CoreFileDirectory' 所指定的目录不存在"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr " 头信息设定了 '%s' 类型，但文件类型与之不匹配"
+
+#: ../src/create.wsgi:116
 msgid "Unable to save archive"
-msgstr ""
+msgstr "无法保存归档"
 
-#: ../src/create.wsgi:89
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "无法获取解包后大小"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "所指定的归档内容过大"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "无法解包归档"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "归档中不允许存在软链接"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "'%s' 文件比预期大"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "归档中不允许出现文件 '%s' "
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "交互式任务被服务器管理员禁用"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "缺少必须的文件 '%s'"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "Retrace 服务器"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "欢迎来到 Retrace 服务器"
 
 #: ../src/index.wsgi:15
 msgid ""
 "Retrace Server is a service that provides the possibility to analyze "
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
-msgstr ""
+msgstr "Retrace 服务器提供了在网络上分析核心转储和生成回溯的服务。 你可以在 Retrace 服务器的维基页面找到更多信 : "
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
-msgstr ""
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
+msgstr "服务器仅允许 HTTPS 连接。HTTP 请求将被禁止。"
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
-msgstr ""
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
+msgstr "HTTP 和 HTTPS 都被允许。出于安全原因强烈建议使用 HTTPS。"
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "支持以下版本 : %s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "服务器当前已加载 %d%% ( 正在运行 %d , 总计  %d 任务 )."
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -169,80 +186,80 @@ msgstr ""
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "没有对特定任务的日志"
 
 #: ../src/stats.wsgi:12
+msgid "Architecture"
+msgstr "架构"
+
+#: ../src/stats.wsgi:13
+msgid "Architectures"
+msgstr "架构"
+
+#: ../src/stats.wsgi:14
 msgid "Build-id"
 msgstr ""
 
-#: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
-
-#: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
-
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "计数"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "被拒绝的任务"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "失败"
 
 #: ../src/stats.wsgi:18
+msgid "First retrace"
+msgstr "第一个回溯"
+
+#: ../src/stats.wsgi:19
+msgid "Global statistics"
+msgstr "全局统计"
+
+#: ../src/stats.wsgi:20
 msgid "Missing build-ids"
 msgstr ""
 
-#: ../src/stats.wsgi:19
+#: ../src/stats.wsgi:21
 msgid "Name"
-msgstr ""
+msgstr "名称"
 
-#: ../src/stats.wsgi:20
+#: ../src/stats.wsgi:22
 msgid "Release"
 msgstr ""
 
-#: ../src/stats.wsgi:21
+#: ../src/stats.wsgi:23
 msgid "Releases"
 msgstr ""
 
-#: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
-
-#: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
-
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "必须的软件包"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "回溯的软件包"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "Retrace 服务器统计"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "共享对象名称"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "成功"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "总计"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "版本"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,150 +1,172 @@
-# Chinese translations for retrace-server package
-# Traditional Chinese translation for retrace-server.
-# Copyright (C) 2011 THE retrace-server'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the retrace-server package.
-# Michal Toman <mtoman@redhat.com>, 2011.
-#
+# Cheng-Chia Tseng <pswo10680@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
-"Project-Id-Version: retrace-server 1.0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
-"PO-Revision-Date: 2011-05-17 09:53+0200\n"
-"Last-Translator: Michal Toman <mtoman@redhat.com>\n"
-"Language-Team: Chinese (traditional)\n"
+"POT-Creation-Date: 2016-07-01 08:48+0200\n"
+"PO-Revision-Date: 2017-09-06 03:04+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Chinese (Taiwan)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=BIG5\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
 #: ../src/status.wsgi:11
 msgid "You must use HTTPS"
-msgstr ""
+msgstr "您必須使用 HTTPS"
 
 #: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
 msgid "Invalid URL"
-msgstr ""
+msgstr "URL 無效"
 
 #: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
 msgid "There is no such task"
-msgstr ""
+msgstr "沒有這種作業"
 
 #: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
 msgid "Invalid password"
-msgstr ""
+msgstr "密碼無效"
 
 #: ../src/backtrace.wsgi:31
 msgid "There is no backtrace for the specified task"
-msgstr ""
+msgstr "指定的作業沒有回資訊溯"
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:19 ../src/create.wsgi:78
 msgid "Retrace server is fully loaded at the moment"
-msgstr ""
+msgstr "追溯伺服器此刻達完全負載"
 
 #: ../src/create.wsgi:23
 msgid "You must use POST method"
-msgstr ""
+msgstr "您必須使用 POST 方法"
 
 #: ../src/create.wsgi:27
 msgid "Specified archive format is not supported"
-msgstr ""
+msgstr "不支援指定的封存格式"
 
 #: ../src/create.wsgi:31
 msgid "You need to set Content-Length header properly"
-msgstr ""
+msgstr "您需要正確設定 Content-Length 標頭檔"
 
 #: ../src/create.wsgi:35
 msgid "Specified archive is too large"
-msgstr ""
+msgstr "指定的封存檔過大"
 
-#: ../src/create.wsgi:47
-msgid "Unable to create working directory"
-msgstr ""
+#: ../src/create.wsgi:40
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr "X-CoreFileDirectory 標頭已經由伺服器管理員停用"
 
 #: ../src/create.wsgi:53
+msgid "Unable to create working directory"
+msgstr "無法建立工作目錄"
+
+#: ../src/create.wsgi:59
 msgid "Unable to obtain disk free space"
-msgstr ""
+msgstr "無法取得磁碟可用空間"
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:63 ../src/create.wsgi:134
 msgid "There is not enough storage space on the server"
-msgstr ""
+msgstr "伺服器上已無足夠存放空間"
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:71
 msgid "Unable to create new task"
-msgstr ""
+msgstr "無法建立新作業"
 
 #: ../src/create.wsgi:83
-msgid "Unable to save archive"
-msgstr ""
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr "「X-CoreFileDirectory」中指定的目錄不存在"
 
 #: ../src/create.wsgi:89
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported"
+" at the moment"
+msgstr "有 %d 份檔案在「%s」目錄中。此刻只支援一份封存檔"
+
+#: ../src/create.wsgi:98
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr "您的標頭指定的是「%s」類型，但是檔案類型不相符"
+
+#: ../src/create.wsgi:116
+msgid "Unable to save archive"
+msgstr "無法儲存封存檔"
+
+#: ../src/create.wsgi:124
 msgid "Unable to obtain unpacked size"
-msgstr ""
+msgstr "無法取得未解開的大小"
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:129
 msgid "Specified archive's content is too large"
-msgstr ""
+msgstr "指定的封存檔內容過大"
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:146
 msgid "Unable to unpack archive"
-msgstr ""
+msgstr "無法解開封存檔"
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:158
 msgid "Symlinks are not allowed to be in the archive"
-msgstr ""
+msgstr "封存檔中不允許有符號連結"
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:166
 #, c-format
 msgid "The '%s' file is larger than expected"
-msgstr ""
+msgstr "「%s」檔大於預期"
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:170
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
-msgstr ""
+msgstr "封存檔中不允許有「%s」檔案"
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:186
+msgid "Interactive tasks were disabled by server administrator"
+msgstr "互動式作業已由伺服器管理員停用"
+
+#: ../src/create.wsgi:196
 #, c-format
 msgid "Required file '%s' is missing"
-msgstr ""
+msgstr "遺失必要的「%s」檔"
 
 #: ../src/index.wsgi:12
 msgid "Retrace Server"
-msgstr ""
+msgstr "追溯伺服器"
 
 #: ../src/index.wsgi:13
 msgid "Welcome to Retrace Server"
-msgstr ""
+msgstr "歡迎使用追溯伺服器"
 
 #: ../src/index.wsgi:15
 msgid ""
 "Retrace Server is a service that provides the possibility to analyze "
 "coredump and generate backtrace over network. You can find further "
 "information at Retrace Server&apos;s wiki:"
-msgstr ""
+msgstr "追溯伺服器是個提供核心傾印分析並透過網路生成回溯資料的可能性。您可以在追溯伺服器的 wiki 上找到更深入的資訊："
 
 #: ../src/index.wsgi:21
 msgid ""
-"Only the secure HTTPS connection is now allowed by the server. HTTP requests "
-"will be denied."
-msgstr ""
+"Only the secure HTTPS connection is now allowed by the server. HTTP requests"
+" will be denied."
+msgstr "現在伺服器僅允許安全 HTTPS 連線。HTTP 連線請求會被拒絕。"
 
 #: ../src/index.wsgi:23
 msgid ""
-"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
-"of security reasons."
-msgstr ""
+"Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because"
+" of security reasons."
+msgstr "HTTP 和 HTTPS 都允許。基於安全問題，嚴格建議使用 HTTPS。"
 
 #: ../src/index.wsgi:24
 #, c-format
 msgid "The following releases are supported: %s"
-msgstr ""
+msgstr "有支援下列發行版本：%s"
 
 #: ../src/index.wsgi:26
 #, c-format
 msgid ""
 "At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
+msgstr "此時此刻伺服器負載為 %d%%（正在執 %d / %d 作業）。"
 
 #: ../src/index.wsgi:27
 #, c-format
@@ -157,6 +179,9 @@ msgid ""
 "(including backtrace) is deleted after %d hours of inactivity. No possibly "
 "private data are kept on the server any longer."
 msgstr ""
+"您的核心傾印僅在追溯作業執行期間作保留。一旦完成作業，伺服器只留下追溯紀錄與回溯資料。所有其他資料（包括核心傾印）皆會刪除。追溯紀錄與回溯資料僅可透過獨特的作業"
+" ID 與密碼才能存取，因此沒人（除作者外）允許檢視這些資料。所有的崩潰資訊（包括回溯資料）會在無動作 %d "
+"小時後自動刪除。伺服器上便不再留存可能的隱私資料。"
 
 #: ../src/index.wsgi:33
 msgid ""
@@ -166,83 +191,85 @@ msgid ""
 "administrators are not responsible for the problems related to the usage of "
 "an insecure channel (such as HTTP)."
 msgstr ""
+"您的核心傾印僅用於追溯用途。伺服器管理員不會從核心傾印或回溯資料中試圖取用您的私人資料。嚴格建議使用安全的溝通管道 "
+"(HTTPS)。伺服器管理員對於使用不安全溝通管道（例如 HTTP）所衍生出的任何問題一概不負責。"
 
 #: ../src/log.wsgi:30
 msgid "There is no log for the specified task"
-msgstr ""
-
-#: ../src/stats.wsgi:10
-msgid "Architecture"
-msgstr ""
-
-#: ../src/stats.wsgi:11
-msgid "Architectures"
-msgstr ""
+msgstr "沒有指定作業的紀錄"
 
 #: ../src/stats.wsgi:12
-msgid "Build-id"
-msgstr ""
+msgid "Architecture"
+msgstr "架構"
 
 #: ../src/stats.wsgi:13
-msgid "Count"
-msgstr ""
+msgid "Architectures"
+msgstr "架構"
 
 #: ../src/stats.wsgi:14
-msgid "Denied jobs"
-msgstr ""
+msgid "Build-id"
+msgstr "Build-id"
 
 #: ../src/stats.wsgi:15
-msgid "Failed"
-msgstr ""
+msgid "Count"
+msgstr "計數"
 
 #: ../src/stats.wsgi:16
-msgid "First retrace"
-msgstr ""
+msgid "Denied jobs"
+msgstr "拒絕的工作"
 
 #: ../src/stats.wsgi:17
-msgid "Global statistics"
-msgstr ""
+msgid "Failed"
+msgstr "失敗"
 
 #: ../src/stats.wsgi:18
-msgid "Missing build-ids"
-msgstr ""
+msgid "First retrace"
+msgstr "第一次追溯"
 
 #: ../src/stats.wsgi:19
-msgid "Name"
-msgstr ""
+msgid "Global statistics"
+msgstr "全域統計數據"
 
 #: ../src/stats.wsgi:20
-msgid "Release"
-msgstr ""
+msgid "Missing build-ids"
+msgstr "遺失 build-id"
 
 #: ../src/stats.wsgi:21
-msgid "Releases"
-msgstr ""
+msgid "Name"
+msgstr "名稱"
 
 #: ../src/stats.wsgi:22
-msgid "Required packages"
-msgstr ""
+msgid "Release"
+msgstr "發行版"
 
 #: ../src/stats.wsgi:23
-msgid "Retraced packages"
-msgstr ""
+msgid "Releases"
+msgstr "發行版"
 
 #: ../src/stats.wsgi:24
-msgid "Retrace Server statistics"
-msgstr ""
+msgid "Required packages"
+msgstr "需要的軟體包"
 
 #: ../src/stats.wsgi:25
-msgid "Shared object name"
-msgstr ""
+msgid "Retraced packages"
+msgstr "追溯的軟體包"
 
 #: ../src/stats.wsgi:26
-msgid "Successful"
-msgstr ""
+msgid "Retrace Server statistics"
+msgstr "追溯伺服器統計數據"
 
 #: ../src/stats.wsgi:27
-msgid "Total"
-msgstr ""
+msgid "Shared object name"
+msgstr "共享的物件名稱"
 
 #: ../src/stats.wsgi:28
+msgid "Successful"
+msgstr "成功"
+
+#: ../src/stats.wsgi:29
+msgid "Total"
+msgstr "總計"
+
+#: ../src/stats.wsgi:30
 msgid "Versions"
-msgstr ""
+msgstr "版本"

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+  <url>https://fedora.zanata.org/</url>
+  <project>retrace-server</project>
+  <project-version>master</project-version>
+  <project-type>gettext</project-type>
+  <src-dir>po</src-dir>
+  <trans-dir>po</trans-dir>
+</config>


### PR DESCRIPTION
Copy-pasted from abrt.

Pulls the translations from fedora.zanata.org/project/view/retrace-server.

Closes #173