### PR TITLE
retrace_worker: Fix file mode to write to file

### DIFF
--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -563,7 +563,7 @@ class RetraceWorker(object):
 
         task.set_backtrace(backtrace)
         if exploitable is not None:
-            task.add_results("exploitable", exploitable)
+            task.add_results("exploitable", exploitable, mode="w")
 
         self.hook_post_retrace()
 


### PR DESCRIPTION
Introduced in 9e79d410d9b5a882fa3770f24b78f930def9ab29

The default file mode used to be "write" but it was changed to write raw bytes.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>