### PR TITLE
retrace-server-worker: Correct import of ArgumentParser

### DIFF
--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 import sys
 import os
-from argparse import ArgumentParser
-
+from retrace.argparser import ArgumentParser
 from retrace.retrace import (log_debug,
                              log_error,
                              log_warn,


### PR DESCRIPTION
The custom ArgumentParser has a `_log` attribute.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>