### PR TITLE
Run retrace in a podman container instead of mock

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -70,6 +70,22 @@
 
             # setenforce 0
 
+   6. Set `subuid` and `subgid` for user `retrace` (optional)
+        If you want to use podman as your retrace environment, the user `retrace`
+        needs to have `subuid` and `subgid` set in `/etc/subuid` and `/etc/subgid`
+        respectively. See `man 5 /etc/subuid` and the `SUB_UID_...` section in `man useradd`.
+
+   7. Set up your system to use cgroups v1 (optional)
+        You might need to do this if you want to use podman. For example:
+
+            # grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+
+        followed by a reboot.
+
+   8. Make sure the `retrace` user's home directory is set to `/var/lib/retrace`
+        when updating from an older version of retrace-server.
+
+
 4. Test your server
 
     There are two ways how to test if your server is running:
@@ -171,6 +187,19 @@ how to deploy such a server. Each point corresponds with point from section
    5. Disable SELinux
 
         There is no change when deploying real and testing retrace server.
+
+   6. Set `subuid` and `subgid` for user `retrace` (optional)
+
+        There is no change when deploying real and testing retrace server.
+
+   7. Set up your system to use cgroups v1 (optional)
+
+        There is no change when deploying real and testing retrace server.
+
+   8. Make sure the `retrace` user's home directory is set to `/var/lib/retrace`
+
+        There is no change when deploying real and testing retrace server.
+
 
 4. Test your server
 

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -88,6 +88,7 @@ mkdir -p %{buildroot}%{_localstatedir}/log/%{name}
 mkdir -p %{buildroot}%{_localstatedir}/spool/%{name}
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}%{_datadir}/%{name}
+mkdir -p %{buildroot}%{_sharedstatedir}/retrace
 mkdir -p %{buildroot}%{_libexecdir}/%{name}
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_start
@@ -117,7 +118,7 @@ rm -f %{buildroot}%{_infodir}/dir
 #retrace uid/gid reserved in setup, rhbz #706012
 %define retrace_gid_uid 174
 getent group retrace > /dev/null || groupadd -f -g %{retrace_gid_uid} --system retrace
-getent passwd retrace > /dev/null || useradd --system -g retrace -u %{retrace_gid_uid} -d %{_datadir}/%{name} -s /sbin/nologin retrace
+getent passwd retrace > /dev/null || useradd --system -g retrace -u %{retrace_gid_uid} -d %{_sharedstatedir}/retrace -s /sbin/nologin retrace
 exit 0
 
 %post
@@ -186,6 +187,7 @@ exit 0
 %{_bindir}/coredump2packages
 %{python3_sitelib}/retrace/
 %{_datadir}/%{name}/
+%dir %attr(0755,retrace,retrace) %{_sharedstatedir}/retrace/
 %attr(0775,root,retrace) %{_libexecdir}/%{name}/hooks/
 %doc %{_mandir}/man1/%{name}-cleanup.1*
 %doc %{_mandir}/man1/%{name}-interact.1*

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -54,6 +54,7 @@ Requires(preun): /sbin/install-info
 Requires(post): /sbin/install-info
 %endif
 Requires(post): /usr/bin/crontab
+Recommends: podman
 
 Obsoletes: abrt-retrace-server < 2.0.3
 Provides: abrt-retrace-server = 2.0.3

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -142,6 +142,7 @@ then
      echo %{retrace_crontab_entry3}; echo %{retrace_crontab_entry4}; \
      echo %{retrace_crontab_entry5}; echo %{retrace_crontab_entry6};) | crontab -u retrace - 2> /dev/null
 fi
+exit 0
 
 %preun
 if [ "$1" = 0 ]
@@ -152,6 +153,7 @@ then
 #comment entries in retrace's crontab
     (crontab -u retrace -l 2> /dev/null | sed "s,^\([^#].*\)$,#\1,g") | crontab -u retrace - 2> /dev/null
 fi
+exit 0
 
 %files -f %{name}.lang
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}-httpd.conf

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -130,8 +130,8 @@ VmcoreDumpLevel = 0
 # Requires support from ABRT Server
 UseFafPackages = 0
 
-# Where to hardlink faf packages
-FafLinkDir = /var/spool/faf/retrace-tmp
+# Spool directory for FAF packages
+FafLinkDir = /var/spool/faf
 
 # Run the retrace in a Mock chroot (default), or a Podman container
 # (mock|podman)

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -133,6 +133,10 @@ UseFafPackages = 0
 # Where to hardlink faf packages
 FafLinkDir = /var/spool/faf/retrace-tmp
 
+# Run the retrace in a Mock chroot (default), or a Podman container
+# (mock|podman)
+RetraceEnvironment = mock
+
 # Whether to enable e-mail notifications
 EmailNotify = 0
 

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -67,6 +67,7 @@ class Config(object):
             "DBFile": "stats.db",
             "KernelChrootRepo": "http://dl.fedoraproject.org/pub/fedora/linux/releases/16/Everything/$ARCH/os/",
             "UseFafPackages": False,
+            "RetraceEnvironment": "mock",
             "FafLinkDir": "/var/spool/faf/retrace-tmp",
             "AuthGroup": "retrace",
             "EmailNotify": False,

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -68,7 +68,7 @@ class Config(object):
             "KernelChrootRepo": "http://dl.fedoraproject.org/pub/fedora/linux/releases/16/Everything/$ARCH/os/",
             "UseFafPackages": False,
             "RetraceEnvironment": "mock",
-            "FafLinkDir": "/var/spool/faf/retrace-tmp",
+            "FafLinkDir": "/var/spool/faf",
             "AuthGroup": "retrace",
             "EmailNotify": False,
             "EmailNotifyFrom": "retrace@localhost",

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -419,18 +419,17 @@ def run_gdb(savedir, plugin, repopath, fafrepo=None, taskid=None):
                  "retrace-image:%s" % img_cont_id],
                 stdout=DEVNULL, stderr=DEVNULL, encoding='utf-8')
 
-            child = run("/usr/bin/podman exec -it %s bash -c "
-                        "'for PKG in /var/spool/abrt/faf-packages/*; "
-                        "do rpm2cpio $PKG | cpio -muid --quiet; done'"
-                        % img_cont_id, shell=True, stdout=DEVNULL, stderr=DEVNULL, encoding='utf-8')
+            child = run(["/usr/bin/podman", "exec", "-it", "%s" % img_cont_id, "bash", "-c",
+                         "for PKG in /var/spool/abrt/faf-packages/*; "
+                         "do rpm2cpio $PKG | cpio -muid --quiet; done"],
+                        stdout=DEVNULL, stderr=DEVNULL, encoding='utf-8')
             if child.returncode:
                 raise Exception("Unpacking of packages failed")
             child = run(["/usr/bin/podman", "exec", img_cont_id,
                          "/var/spool/abrt/gdb.sh"], stdout=PIPE, encoding='utf-8')
         else:
-            child = run(["/usr/bin/podman", "run", "-it", "--volume=%s:%s:ro" % (repopath, repopath),
-                         "--name=%s" % img_cont_id, "--rm", "retrace-image:%s" % img_cont_id],
-                        stdout=PIPE, encoding='utf-8')
+            child = run(["/usr/bin/podman", "run", "-it", "--name=%s" % img_cont_id,
+                         "--rm", "retrace-image:%s" % img_cont_id], stdout=PIPE, encoding='utf-8')
     else:
         raise Exception("RetraceEnvironment set to invalid value")
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1630,6 +1630,7 @@ class RetraceTask:
     MOCK_DEFAULT_CFG = "default.cfg"
     MOCK_SITE_DEFAULTS_CFG = "site-defaults.cfg"
     MOCK_LOGGING_INI = "logging.ini"
+    DOCKERFILE = "Dockerfile"
 
     def __init__(self, taskid=None):
         """Creates a new task if taskid is None,

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -170,8 +170,8 @@ ARCH_MAP = {
     "aarch64": {"aarch64"},
 }
 
-PYTHON_LABLE_START = "----------PYTHON-START--------"
-PYTHON_LABLE_END = "----------PYTHON--END---------"
+PYTHON_LABEL_START = "----------PYTHON-START--------"
+PYTHON_LABEL_END = "----------PYTHON--END---------"
 
 
 class RetraceError(Exception):
@@ -393,7 +393,7 @@ def run_gdb(savedir, plugin):
                           "-ex 'print (char*)__abort_msg' "
                           "-ex 'print (char*)__glib_assert_msg' "
                           "-ex 'info registers' "
-                          "-ex 'disassemble' " % (executable, PYTHON_LABLE_START, PYTHON_LABLE_END))
+                          "-ex 'disassemble' " % (executable, PYTHON_LABEL_START, PYTHON_LABEL_END))
             if add_exploitable:
                 gdbfile.write("-ex 'echo %s' "
                               "-ex 'abrt-exploitable'" % EXPLOITABLE_SEPARATOR)
@@ -426,7 +426,7 @@ def run_gdb(savedir, plugin):
     if not backtrace:
         raise Exception("An unusable backtrace has been generated")
 
-    python_labels = PYTHON_LABLE_START+'\n'+PYTHON_LABLE_END+'\n'
+    python_labels = PYTHON_LABEL_START+'\n'+PYTHON_LABEL_END+'\n'
     if python_labels in backtrace:
         backtrace = backtrace.replace(python_labels, "")
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1331,8 +1331,8 @@ class KernelVMcore:
             log_debug("Vmcore dump level is %d" % dump_level)
 
         # If dump_level was readable above, then check to see if stripping is worthwhile
-        if (dump_level is not None and
-           (dump_level & CONFIG["VmcoreDumpLevel"]) == CONFIG["VmcoreDumpLevel"]):
+        if (dump_level is not None
+                and (dump_level & CONFIG["VmcoreDumpLevel"]) == CONFIG["VmcoreDumpLevel"]):
             log_info("Stripping to %d would have no effect" % CONFIG["VmcoreDumpLevel"])
             self._has_extra_pages = False
         return self._has_extra_pages
@@ -2078,7 +2078,7 @@ class RetraceTask:
 
         if child.wait():
             log_warn("crash '%s' exited with %d" % (crash_cmdline.replace('\r', '; ').replace('\n', '; '),
-                     child.returncode))
+                                                    child.returncode))
             returncode = child.returncode
 
         return cmd_output, returncode

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -373,24 +373,25 @@ def run_gdb(savedir, plugin, repopath):
 
         batfile = os.path.join(savedir, "gdb.sh")
         with open(batfile, "w") as gdbfile:
-            gdbfile.write("#!/usr/bin/sh\n\n%s -batch " % plugin.gdb_executable)
-            gdbfile.write("-ex 'python exec(open(\"/usr/libexec/abrt-gdb-exploitable\").read())' ")
-            gdbfile.write("-ex 'file %s' "
-                          "-ex 'core-file /var/spool/abrt/crash/coredump' "
-                          "-ex 'echo %s\n' "
-                          "-ex 'py-bt' "
-                          "-ex 'py-list' "
-                          "-ex 'py-locals' "
-                          "-ex 'echo %s\n' "
-                          "-ex 'thread apply all -ascending backtrace full 2048' "
-                          "-ex 'info sharedlib' "
-                          "-ex 'print (char*)__abort_msg' "
-                          "-ex 'print (char*)__glib_assert_msg' "
-                          "-ex 'info registers' "
-                          "-ex 'disassemble' "
-                          "-ex 'echo %s' "
-                          "-ex 'abrt-exploitable'"
-                          % (executable, PYTHON_LABEL_START, PYTHON_LABEL_END, EXPLOITABLE_SEPARATOR))
+            gdbfile.write("#!/usr/bin/sh\n\n%s -batch "
+                          "-ex 'python exec(open(\"/usr/libexec/abrt-gdb-exploitable\").read())' \\\n"
+                          "                    -ex 'file %s' \\\n"
+                          "                    -ex 'core-file /var/spool/abrt/crash/coredump' \\\n"
+                          "                    -ex 'echo %s\\n' \\\n"
+                          "                    -ex 'py-bt' \\\n"
+                          "                    -ex 'py-list' \\\n"
+                          "                    -ex 'py-locals' \\\n"
+                          "                    -ex 'echo %s\\n' \\\n"
+                          "                    -ex 'thread apply all -ascending backtrace full 2048' \\\n"
+                          "                    -ex 'info sharedlib' \\\n"
+                          "                    -ex 'print (char*)__abort_msg' \\\n"
+                          "                    -ex 'print (char*)__glib_assert_msg' \\\n"
+                          "                    -ex 'info registers' \\\n"
+                          "                    -ex 'disassemble' \\\n"
+                          "                    -ex 'echo %s\\n' \\\n"
+                          "                    -ex 'abrt-exploitable'"
+                          % (plugin.gdb_executable, executable, PYTHON_LABEL_START,
+                             PYTHON_LABEL_END, EXPLOITABLE_SEPARATOR))
 
         if CONFIG["RetraceEnvironment"] == "mock":
             copyin = call(["/usr/bin/mock", "--configdir", savedir, "--copyin",

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -497,6 +497,9 @@ class RetraceWorker():
                     dockerfile.write('\n')
                     dockerfile.write('RUN dnf install --assumeyes dnf-plugins-core\n')
                     dockerfile.write('RUN dnf config-manager --add-repo=file://%s\n' % repopath)
+                    if not CONFIG["RequireGPGCheck"]:
+                        dockerfile.write('RUN dnf config-manager --save --setopt=%s*.gpgcheck=0\n'
+                                         % repoid)
                     dockerfile.write('RUN dnf ')
                     dockerfile.write('--releasever=%s ' % version)
                     dockerfile.write('--repo=%s* ' % repoid)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -524,6 +524,10 @@ class RetraceWorker(object):
             except Exception as ex:
                 log_error("Unable to create Dockerfile: %s" % ex)
                 self._fail()
+
+            self.hook.run("post_prepare_environment")
+            self.hook.run("pre_retrace")
+
         try:
             backtrace, exploitable = run_gdb(task.get_savedir(), self.plugin, repopath, self.fafrepo)
         except Exception as ex:

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -808,7 +808,8 @@ class RetraceWorker():
                     raise Exception("Unable to build podman container")
 
                 vmlinux = vmcore.prepare_debuginfo(task, kernelver=kernelver)
-                child = run(["/usr/bin/podman", "run", "--detach", "-it", "retrace-image:%s" % img_cont_id],
+                child = run(["/usr/bin/podman", "run", "--detach", "-it", "--rm",
+                             "retrace-image:%s" % img_cont_id],
                             stdout=PIPE, stderr=PIPE, encoding='utf-8')
                 if child.stderr:
                     log_error(child.stderr)
@@ -868,12 +869,6 @@ class RetraceWorker():
         # If crash sys command exited with non-zero status,
         # we likely have a semi-useful vmcore
         crash_sys, ret = task.run_crash_cmdline(crash_normal, "sys\nquit\n")
-
-        if img_cont_id:
-            if run(["/usr/bin/podman", "stop", img_cont_id], stdout=DEVNULL, stderr=DEVNULL).returncode:
-                log_warn("Couldn't stop container %s" % img_cont_id)
-            if run(["/usr/bin/podman", "rm", img_cont_id], stdout=DEVNULL, stderr=DEVNULL).returncode:
-                log_warn("Couldn't remove container %s" % img_cont_id)
 
         if ret == 0 and crash_sys:
             task.add_results("sys", crash_sys)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -469,8 +469,9 @@ class RetraceWorker(object):
         log_info(STATUS[STATUS_INIT])
 
         if CONFIG["RetraceEnvironment"] == "mock":
-            self._retrace_run(25, ["/usr/bin/mock", "init", "--resultdir", task.get_savedir() + "/log", "--configdir",
-                              task.get_savedir()])
+            self._retrace_run(25, ["/usr/bin/mock", "init", "--resultdir",
+                                   task.get_savedir() + "/log", "--configdir",
+                                   task.get_savedir()])
 
             self.hook.run("post_prepare_environment")
             self.hook.run("pre_retrace")
@@ -491,7 +492,7 @@ class RetraceWorker(object):
             repoid = re.sub('/', '_', CONFIG["RepoDir"][1:])
             try:
                 with open(os.path.join(task.get_savedir(),
-                          RetraceTask.DOCKERFILE), "w") as dockerfile:
+                                       RetraceTask.DOCKERFILE), "w") as dockerfile:
                     dockerfile.write('FROM %s:%s\n\n' % (distribution, version))
                     dockerfile.write('RUN mkdir -p /var/spool/abrt/crash\n')
                     if CONFIG["UseFafPackages"]:

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -44,7 +44,7 @@ sys.path.insert(0, "/usr/share/retrace-server/")
 CONFIG = Config()
 
 
-class RetraceWorker(object):
+class RetraceWorker():
     def __init__(self, task):
         self.plugins = Plugins()
         self.task = task
@@ -896,9 +896,8 @@ class RetraceWorker(object):
                 # If log < 1024 bytes, probably it is not useful so fail task
                 raise Exception("Failing task due to crash exiting with non-zero status and "
                                 "small kernellog size = %d bytes" % len(kernellog))
-            else:
-                # If log is 1024 bytes or above, try 'crash --minimal'
-                task.set_crash_cmd("crash --minimal")
+            # If log is 1024 bytes or above, try 'crash --minimal'
+            task.set_crash_cmd("crash --minimal")
 
         crashrc_lines = []
 
@@ -908,7 +907,7 @@ class RetraceWorker(object):
         results_dir = task.get_results_dir()
         crashrc_lines.append("cd %s" % results_dir)
 
-        if len(crashrc_lines) > 0:
+        if crashrc_lines:
             task.set_crashrc("%s\n" % "\n".join(crashrc_lines))
 
         self.hook.run("post_retrace")

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -798,13 +798,14 @@ class RetraceWorker():
 
                 img_cont_id = str(task.get_taskid())
 
-                if run(["/usr/bin/podman",
-                        "build",
-                        "--file",
-                        os.path.join(savedir, RetraceTask.DOCKERFILE),
-                        "--tag",
-                        "retrace-image:%s" % img_cont_id],
-                        stdout=DEVNULL, stderr=DEVNULL).returncode:
+                child = run(["/usr/bin/podman",
+                             "build",
+                             "--file",
+                             os.path.join(savedir, RetraceTask.DOCKERFILE),
+                             "--tag",
+                             "retrace-image:%s" % img_cont_id],
+                            stdout=DEVNULL, stderr=DEVNULL)
+                if child.returncode:
                     raise Exception("Unable to build podman container")
 
                 vmlinux = vmcore.prepare_debuginfo(task, kernelver=kernelver)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -880,10 +880,10 @@ class RetraceWorker():
         if container_id:
             err = call(["/usr/bin/podman", "stop", container_id], stdout=DEVNULL, stderr=DEVNULL)
             if err:
-                log_warn(err)
+                log_warn("Couldn't stop container %s" % container_id)
             err = call(["/usr/bin/podman", "rm", container_id], stdout=DEVNULL, stderr=DEVNULL)
             if err:
-                log_warn(err)
+                log_warn("Couldn't remove container %s" % container_id)
 
         if ret == 0 and crash_sys:
             task.add_results("sys", crash_sys)


### PR DESCRIPTION
This PR uses the existing mechanisms currently used for mock config to create a Dockerfile in the crash directory. This is then used to create a podman container into which the coredump and metadata and a `gdb.sh` script are copied and where the retrace itself is run. The use of podman is optional and enabled by setting the newly introduced `RetraceEnvironment` config variable to `"podman"`. Changes to the `retrace` user are required during deployment in order to run retrace in a podman container, as described in  DEPLOYING.md.