### PR TITLE
Change of retrace hooks

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -88,7 +88,7 @@
         There also exist a Web UI for assigning retrace task. It can be found
         under `\manager`, but firstly must be enabled in configuration file.
 
-            open /etc/retrace-server.conf
+            open /etc/retrace-server/retrace-server.conf
 
             set `AllowTaskManager = 1`
 
@@ -194,5 +194,5 @@ how to deploy such a server. Each point corresponds with point from section
 
       * You have not enough space in `/usr/lib/mock`
 
-      * A gpg check failed. Set `RequireGPGCheck = 0` in `/etc/retrace-server.conf`
+      * A gpg check failed. Set `RequireGPGCheck = 0` in `/etc/retrace-server/retrace-server.conf`
         and restart httpd.

--- a/configure.ac
+++ b/configure.ac
@@ -138,9 +138,11 @@ AC_CONFIG_FILES([
 	po/Makefile.in
 	src/Makefile
 	src/config/Makefile
+	src/config/hooks/Makefile
 	src/gpg/Makefile
 	src/plugins/Makefile
 	src/retrace/Makefile
+	src/retrace/hooks/Makefile
 	test/Makefile
 ])
 

--- a/doc/retrace-server.texi
+++ b/doc/retrace-server.texi
@@ -905,7 +905,7 @@ for setting up the base mock environment.
 @chapter Configuration
 
 The following options can be specified in the configuration file
-@file{/etc/retrace-server.conf}:
+@file{/etc/retrace-server/retrace-server.conf}:
 
 @itemize
 @item

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN rm -rf /run/httpd && mkdir /run/httpd && chmod -R a+rwx /run/httpd && \
     sed -i -e"s/Listen\s*80/Listen 8181/i" /etc/httpd/conf/httpd.conf && \
     sed -i -e"s/ErrorLog\s*\"logs\/error_log\"/ErrorLog \"\/var\/log\/retrace-server\/httpd_error_log\"/i" /etc/httpd/conf/httpd.conf && \
     sed -i -e"s/CustomLog\s*\"logs\/access_log\"/CustomLog \"\/var\/log\/retrace-server\/httpd_access_log\"/i" /etc/httpd/conf/httpd.conf && \
-    sed -i -e"s/RequireHTTPS\s*=\s*1/RequireHTTPS = 0/i" /etc/retrace-server.conf && \
+    sed -i -e"s/RequireHTTPS\s*=\s*1/RequireHTTPS = 0/i" /etc/retrace-server/retrace-server.conf && \
     echo "cron =  0 -5 -1 -1 -1 /usr/bin/retrace-server-reposync fedora 28 x86_64" >> /etc/uwsgi.ini && \
     chmod g=u /etc/passwd && \
     mkdir -p /run/uwsgi && \

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -35,8 +35,8 @@ RUN rpm -Uvh noarch/retrace-server-* && \
     /usr/libexec/fix-permissions /retrace-server && \
     /usr/libexec/fix-permissions /var/log/retrace-server && \
     /usr/libexec/fix-permissions /var/spool/retrace-server && \
-    sed -i -e"s/AllowTaskManager\s*=\s*0/AllowTaskManager = 1/i" /etc/retrace-server.conf && \
-    sed -i -e"s/RequireGPGCheck\s*=\s*1/RequireGPGCheck = 0/i" /etc/retrace-server.conf && \
+    sed -i -e"s/AllowTaskManager\s*=\s*0/AllowTaskManager = 1/i" /etc/retrace-server/retrace-server.conf && \
+    sed -i -e"s/RequireGPGCheck\s*=\s*1/RequireGPGCheck = 0/i" /etc/retrace-server/retrace-server.conf && \
     mkdir /var/tmp/local_repo && \
     dnf --releasever=$fedoraversion --enablerepo=\*debuginfo\* -y --installroot=/var/tmp/local_repo/ \
     download --resolve --destdir /var/tmp/local_repo/ abrt-addon-ccpp shadow-utils \

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -87,6 +87,21 @@ mkdir -p %{buildroot}%{_localstatedir}/log/%{name}
 mkdir -p %{buildroot}%{_localstatedir}/spool/%{name}
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}%{_datadir}/%{name}
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_start
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/start
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_prepare_debuginfo
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_prepare_debuginfo
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_prepare_mock
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_prepare_mock
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_retrace
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_retrace
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/success
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/fail
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_remove_task
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_remove_task
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_clean_task
+mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_clean_task
 
 %if 0%{?fedora} >= 29
 %py_byte_compile %{__python3} %{buildroot}%{_datadir}/%{name}/plugins
@@ -148,6 +163,7 @@ fi
 %files -f %{name}.lang
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}-httpd.conf
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}-hooks.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/kernel
@@ -155,6 +171,7 @@ fi
 %dir %attr(0750,retrace,retrace) %{_localstatedir}/log/%{name}
 %dir %attr(0770,retrace,retrace) %{_localstatedir}/spool/%{name}
 %dir %{_sysconfdir}/%{name}
+%{_sysconfdir}/%{name}/hooks/
 %{_bindir}/%{name}-worker
 %{_bindir}/%{name}-interact
 %{_bindir}/%{name}-cleanup

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -93,8 +93,8 @@ mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_start
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/start
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_prepare_debuginfo
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_prepare_debuginfo
-mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_prepare_mock
-mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_prepare_mock
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_prepare_environment
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_prepare_environment
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_retrace
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_retrace
 mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/success

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -142,15 +142,6 @@ then
      echo %{retrace_crontab_entry5}; echo %{retrace_crontab_entry6};) | crontab -u retrace - 2> /dev/null
 fi
 
-if [ "$1" = 2 ]
-then
-    if [ -f "%{_sysconfdir}/%{name}.conf" ]
-    then
-        mv "%{_sysconfdir}/%{name}/%{name}.conf" "%{_sysconfdir}/%{name}/%{name}.conf.rpmnew"
-        cp -a "%{_sysconfdir}/%{name}.conf" "%{_sysconfdir}/%{name}/%{name}.conf"
-    fi
-fi
-
 %preun
 if [ "$1" = 0 ]
 then

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -87,21 +87,22 @@ mkdir -p %{buildroot}%{_localstatedir}/log/%{name}
 mkdir -p %{buildroot}%{_localstatedir}/spool/%{name}
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}%{_datadir}/%{name}
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_start
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/start
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_prepare_debuginfo
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_prepare_debuginfo
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_prepare_mock
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_prepare_mock
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_retrace
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_retrace
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/success
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/fail
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_remove_task
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_remove_task
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/pre_clean_task
-mkdir -p %{buildroot}%{_datadir}/%{name}/hooks/post_clean_task
+mkdir -p %{buildroot}%{_libexecdir}/%{name}
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_start
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/start
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_prepare_debuginfo
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_prepare_debuginfo
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_prepare_mock
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_prepare_mock
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_retrace
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_retrace
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/success
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/fail
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_remove_task
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_remove_task
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/pre_clean_task
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/hooks/post_clean_task
 
 %if 0%{?fedora} >= 29
 %py_byte_compile %{__python3} %{buildroot}%{_datadir}/%{name}/plugins
@@ -178,7 +179,7 @@ fi
 %dir %attr(0750,retrace,retrace) %{_localstatedir}/log/%{name}
 %dir %attr(0770,retrace,retrace) %{_localstatedir}/spool/%{name}
 %dir %{_sysconfdir}/%{name}
-%dir %{_sysconfdir}/%{name}/hooks/
+%dir %attr(0775,root,retrace) %{_libexecdir}/%{name}
 %{_bindir}/%{name}-worker
 %{_bindir}/%{name}-interact
 %{_bindir}/%{name}-cleanup
@@ -191,6 +192,7 @@ fi
 %{_bindir}/coredump2packages
 %{python3_sitelib}/retrace/
 %{_datadir}/%{name}/
+%attr(0775,root,retrace) %{_libexecdir}/%{name}/hooks/
 %doc %{_mandir}/man1/%{name}-cleanup.1*
 %doc %{_mandir}/man1/%{name}-interact.1*
 %doc %{_mandir}/man1/%{name}-reposync.1*

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -164,6 +164,13 @@ fi
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}-httpd.conf
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}-hooks.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/debuginfo.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/fail.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/mock.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/retrace.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/start.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/success.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/task.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/kernel
@@ -171,7 +178,7 @@ fi
 %dir %attr(0750,retrace,retrace) %{_localstatedir}/log/%{name}
 %dir %attr(0770,retrace,retrace) %{_localstatedir}/spool/%{name}
 %dir %{_sysconfdir}/%{name}
-%{_sysconfdir}/%{name}/hooks/
+%dir %{_sysconfdir}/%{name}/hooks/
 %{_bindir}/%{name}-worker
 %{_bindir}/%{name}-interact
 %{_bindir}/%{name}-cleanup

--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -85,6 +85,7 @@ mkdir -p %{buildroot}%{_localstatedir}/cache/%{name}/kernel
 mkdir -p %{buildroot}%{_localstatedir}/cache/%{name}/download
 mkdir -p %{buildroot}%{_localstatedir}/log/%{name}
 mkdir -p %{buildroot}%{_localstatedir}/spool/%{name}
+mkdir -p %{buildroot}%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}%{_datadir}/%{name}
 
 %if 0%{?fedora} >= 29
@@ -125,6 +126,15 @@ then
      echo %{retrace_crontab_entry5}; echo %{retrace_crontab_entry6};) | crontab -u retrace - 2> /dev/null
 fi
 
+if [ "$1" = 2 ]
+then
+    if [ -f "%{_sysconfdir}/%{name}.conf" ]
+    then
+        mv "%{_sysconfdir}/%{name}/%{name}.conf" "%{_sysconfdir}/%{name}/%{name}.conf.rpmnew"
+        cp -a "%{_sysconfdir}/%{name}.conf" "%{_sysconfdir}/%{name}/%{name}.conf"
+    fi
+fi
+
 %preun
 if [ "$1" = 0 ]
 then
@@ -137,13 +147,14 @@ fi
 
 %files -f %{name}.lang
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}-httpd.conf
-%config(noreplace) %{_sysconfdir}/%{name}.conf
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/kernel
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/download
 %dir %attr(0750,retrace,retrace) %{_localstatedir}/log/%{name}
 %dir %attr(0770,retrace,retrace) %{_localstatedir}/spool/%{name}
+%dir %{_sysconfdir}/%{name}
 %{_bindir}/%{name}-worker
 %{_bindir}/%{name}-interact
 %{_bindir}/%{name}-cleanup

--- a/src/config/Makefile.am
+++ b/src/config/Makefile.am
@@ -1,5 +1,5 @@
 retraceconf_DATA = retrace-server.conf
-retraceconfdir = ${sysconfdir}
+retraceconfdir = ${sysconfdir}/retrace-server
 
 httpdconf_DATA = retrace-server-httpd.conf
 httpdconfdir = ${sysconfdir}/httpd/conf.d

--- a/src/config/Makefile.am
+++ b/src/config/Makefile.am
@@ -1,4 +1,8 @@
-retraceconf_DATA = retrace-server.conf
+SUBDIRS = hooks
+
+retraceconf_DATA = retrace-server.conf \
+                   retrace-server-hooks.conf
+
 retraceconfdir = ${sysconfdir}/retrace-server
 
 httpdconf_DATA = retrace-server-httpd.conf
@@ -7,4 +11,7 @@ httpdconfdir = ${sysconfdir}/httpd/conf.d
 logrotate_DATA = retrace-server
 logrotatedir = ${sysconfdir}/logrotate.d
 
-EXTRA_DIST = retrace-server.conf retrace-server-httpd.conf retrace-server
+EXTRA_DIST = retrace-server.conf \
+             retrace-server-hooks.conf \
+             retrace-server-httpd.conf \
+             retrace-server

--- a/src/config/hooks/Makefile.am
+++ b/src/config/hooks/Makefile.am
@@ -1,0 +1,11 @@
+retracehooks_DATA = debuginfo.conf \
+                    fail.conf \
+                    mock.conf \
+                    retrace.conf \
+                    start.conf \
+                    success.conf \
+                    task.conf
+
+retracehooksdir = ${sysconfdir}/retrace-server/hooks
+
+EXTRA_DIST = $(retracehooks_DATA)

--- a/src/config/hooks/debuginfo.conf
+++ b/src/config/hooks/debuginfo.conf
@@ -1,0 +1,10 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# Before the preparation of debuginfo packages
+# [pre_prepare_debuginfo]
+
+# After the preparation of debuginfo packages
+# [post_prepare_debuginfo]

--- a/src/config/hooks/environment.conf
+++ b/src/config/hooks/environment.conf
@@ -4,7 +4,7 @@
 # cmdline = {hook_name} {taskid} {task_results_dir}
 #
 # Before the preparation of retrace environment
-# [pre_prepare_mock]
+# [pre_prepare_environment]
 
 # After the preparation of retrace environment
-# [post_prepare_mock]
+# [post_prepare_environment]

--- a/src/config/hooks/fail.conf
+++ b/src/config/hooks/fail.conf
@@ -1,0 +1,7 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# After retracing fails
+# [fail]

--- a/src/config/hooks/mock.conf
+++ b/src/config/hooks/mock.conf
@@ -1,0 +1,10 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# Before the preparation of retrace environment
+# [pre_prepare_mock]
+
+# After the preparation of retrace environment
+# [post_prepare_mock]

--- a/src/config/hooks/retrace.conf
+++ b/src/config/hooks/retrace.conf
@@ -1,0 +1,10 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# Before starting of the retracing itself
+# [pre_retrace]
+
+# After retracing is done
+# [post_retrace]

--- a/src/config/hooks/start.conf
+++ b/src/config/hooks/start.conf
@@ -1,0 +1,10 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# When worker.start() is called
+# [pre_start]
+
+# When task type is determined and the main task starts
+# [start]

--- a/src/config/hooks/success.conf
+++ b/src/config/hooks/success.conf
@@ -1,0 +1,7 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# After retracing success
+# [success]

--- a/src/config/hooks/task.conf
+++ b/src/config/hooks/task.conf
@@ -1,0 +1,16 @@
+# Parameters are replaced using python's format.
+# Available parameters for cmdline: hook_name, taskid, task_results_dir
+# Example:
+# cmdline = {hook_name} {taskid} {task_results_dir}
+#
+# Before removing task
+# [pre_remove_task]
+
+# After removing task
+# [post_remove_task]
+
+# Before cleaning task
+# [pre_clean_task]
+
+# After cleaning task
+# [post_clean_task]

--- a/src/config/retrace-server-hooks.conf
+++ b/src/config/retrace-server-hooks.conf
@@ -1,0 +1,6 @@
+[main]
+# Path to the executable hook scripts
+# HookDir = /usr/share/retrace-server/hooks/
+#
+# Global time limit for hook scripts (in seconds)
+# Timeout = 300

--- a/src/config/retrace-server-hooks.conf
+++ b/src/config/retrace-server-hooks.conf
@@ -1,6 +1,6 @@
 [main]
 # Path to the executable hook scripts
-# HookDir = /usr/share/retrace-server/hooks/
+# HookDir = /usr/libexec/retrace-server/hooks/
 #
 # Global time limit for hook scripts (in seconds)
 # Timeout = 300

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -172,36 +172,3 @@ x86_64 =
 ppc64 =
 armhfp =
 s390x =
-
-[hookscripts]
-# Parameters are replaced using python's format.
-# Available parameters: hook_name, task_id, task_results_dir
-# Example: pre_start = /bin/echo {hook_name} {task_id} {task_results_dir}
-# When worker.start() is called
-pre_start = 
-# When task type is determined and the main task starts
-start =
-# Before the preparation of debuginfo packages 
-pre_prepare_debuginfo = 
-# After the preparation of debuginfo packages
-post_prepare_debuginfo = 
-# Before the preparation of mock environment
-pre_prepare_mock = 
-# After the preparation of mock environment
-post_prepare_mock = 
-# Before starting of the retracing itself
-pre_retrace = 
-# After retracing is done
-post_retrace = 
-# After retracing success
-success = 
-# After retracing fails
-fail = 
-# Before removing task
-pre_remove_task = 
-# After removing task
-post_remove_task = 
-# Before cleaning task
-pre_clean_task = 
-# After cleaning task
-post_clean_task = 

--- a/src/retrace/Makefile.am
+++ b/src/retrace/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = hooks
+
 retracelib_PYTHON = \
     __init__.py \
     argparser.py \

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -25,7 +25,6 @@ class Config(object):
         def __init__(self):
             self.conf_file_read = False
 
-        HOOK_SCRIPTS = {}
         ARCH_HOSTS = {}
 
         GLOBAL = {
@@ -121,15 +120,6 @@ class Config(object):
                     host = host.strip()
                     if host:
                         self.ARCH_HOSTS[arch] = host
-
-            if "hookscripts" in parser.sections():
-                for hook, script in parser.items("hookscripts"):
-                    script = script.strip()
-                    if script:
-                        self.HOOK_SCRIPTS[hook] = script
-
-        def get_hook_scripts(self):
-            return self.HOOK_SCRIPTS
 
         def get_arch_hosts(self):
             return self.ARCH_HOSTS

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -90,7 +90,7 @@ class Config(object):
                 self.load()
             return self.GLOBAL[key]
 
-        def load(self, filepath="/etc/retrace-server.conf"):
+        def load(self, filepath="/etc/retrace-server/retrace-server.conf"):
             self.conf_file_read = True
             # if environment variable set, use rather that
             env_config_path = os.environ.get('RETRACE_SERVER_CONFIG_PATH')

--- a/src/retrace/hooks/Makefile.am
+++ b/src/retrace/hooks/Makefile.am
@@ -1,0 +1,5 @@
+hooks_PYTHON = hooks.py config.py __init__.py
+
+hooksdir = $(pythondir)/retrace/hooks
+
+EXTRA_DIST = $(hooks_DATA)

--- a/src/retrace/hooks/__init__.py
+++ b/src/retrace/hooks/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ["config", "hooks"]
+
+from . import hooks
+from . import config

--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -1,10 +1,13 @@
 #!/bin/python3
 import os
 import configparser
+from pathlib import Path
 
 MAIN_CONFIG_PATH = "/etc/retrace-server/"
 MAIN_HOOK_CONFIG_FILE = "retrace-server-hooks.conf"
 MAIN_HOOK_CONFIGS_PATH = "/etc/retrace-server/hooks"
+USER_CONFIG_PATH = Path.home() / ".config/retrace-server/"
+USER_HOOK_CONFIGS_PATH = Path.home() / ".config/retrace-server/hooks"
 HOOK_PATH = "/usr/libexec/retrace-server/hooks/"
 HOOK_TIMEOUT = 300
 
@@ -28,9 +31,19 @@ def load_config_files(config_files):
 
 
 def load_hook_config():
-    main_hook_config_file = [os.path.join(MAIN_CONFIG_PATH, MAIN_HOOK_CONFIG_FILE)]
-    hook_configs = get_config_files(MAIN_HOOK_CONFIGS_PATH)
-    cfgs = load_config_files(hook_configs + main_hook_config_file)
+    hook_configs = []
+    hook_configs += get_config_files(MAIN_HOOK_CONFIGS_PATH)
+
+    main_hook_config_file = Path(MAIN_CONFIG_PATH, MAIN_HOOK_CONFIG_FILE)
+    hook_configs.append(str(main_hook_config_file))
+
+    if USER_HOOK_CONFIGS_PATH.exists():
+        hook_configs += get_config_files(USER_HOOK_CONFIGS_PATH)
+
+    if USER_CONFIG_PATH.exists():
+        hook_configs.append(str(USER_CONFIG_PATH))
+
+    cfgs = load_config_files(hook_configs)
 
     return cfgs
 

--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -1,0 +1,37 @@
+#!/bin/python3
+import os
+import configparser
+
+MAIN_CONFIG_PATH = "/etc/retrace-server/"
+MAIN_HOOK_CONFIG_FILE = "retrace-server-hooks.conf"
+MAIN_HOOK_CONFIGS_PATH = "/etc/retrace-server/hooks"
+HOOK_PATH = "/usr/share/retrace-server/hooks/"
+HOOK_TIMEOUT = 300
+
+def get_config_files(directory):
+    return [fname for fname in [os.path.abspath(os.path.join(directory, filename.name))
+                                for filename in os.scandir(directory) if filename.name.endswith(".conf")]]
+
+
+def load_config_files(config_files):
+    result = {}
+    cfg_parser = configparser.ConfigParser()
+    cfg_parser.read(config_files)
+
+    for section in cfg_parser.sections():
+        for option in cfg_parser.options(section):
+            key = f"{section.lower()}.{option.lower()}"
+            result[key] = cfg_parser.get(section, option)
+
+    return result
+
+
+def load_hook_config():
+    main_hook_config_file = [os.path.join(MAIN_CONFIG_PATH, MAIN_HOOK_CONFIG_FILE)]
+    hook_configs = get_config_files(MAIN_HOOK_CONFIGS_PATH)
+    cfgs = load_config_files(hook_configs + main_hook_config_file)
+
+    return cfgs
+
+
+hooks_config = load_hook_config()

--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -5,8 +5,9 @@ import configparser
 MAIN_CONFIG_PATH = "/etc/retrace-server/"
 MAIN_HOOK_CONFIG_FILE = "retrace-server-hooks.conf"
 MAIN_HOOK_CONFIGS_PATH = "/etc/retrace-server/hooks"
-HOOK_PATH = "/usr/share/retrace-server/hooks/"
+HOOK_PATH = "/usr/libexec/retrace-server/hooks/"
 HOOK_TIMEOUT = 300
+
 
 def get_config_files(directory):
     return [fname for fname in [os.path.abspath(os.path.join(directory, filename.name))

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python3
+
+import os
+import shlex
+from subprocess import PIPE, CalledProcessError, run, TimeoutExpired
+
+from retrace.retrace import log_info, log_error, log_debug
+from .config import HOOK_PATH, HOOK_TIMEOUT, hooks_config
+
+"""
+    Hooks description:
+    pre_start -- When self.start() is called
+    start -- When task type is determined and the main task starts
+    pre_prepare_debuginfo -- Before the preparation of debuginfo packages
+    post_prepare_debuginfo -- After the preparation of debuginfo packages
+    pre_prepare_mock -- Before the preparation of mock environment
+    post_prepare_mock -- After the preparation of mock environment
+    pre_retrace -- Before starting of the retracing itself
+    post_retrace -- After retracing is done
+    success -- After retracing success
+    fail -- After retracing fails
+    pre_remove_task -- Before removing task
+    post_remove_task -- After removing task
+    pre_clean_task -- Before cleaning task
+    post_clean_task -- After cleaning task
+"""
+
+
+def get_executables(path):
+    """ Scan `path` and return list of found executable scripts.
+    """
+    def _getname(entry):
+        return entry.name
+
+    script_list = []
+
+    if not os.path.isdir(path):
+        return script_list
+
+    with os.scandir(path) as dirls:
+        for entry in sorted(dirls, key=_getname):
+            if entry.is_file() and os.access(entry.path, os.X_OK):
+                script_list.append(entry)
+
+    return script_list
+
+
+class RetraceHook:
+
+    def __init__(self, task):
+        self.taskid = task.get_taskid()
+        self.task_results_dir = task.get_results_dir()
+
+    def _get_cmdline(self, hook, exc=None):
+        if exc:
+            cmdline = hooks_config.get(f"{hook}.{exc}.cmdline", None)
+
+        if not cmdline:
+            cmdline = hooks_config.get(f"{hook}.cmdline", None)
+
+        if cmdline:
+            cmdline = cmdline.format(hook_name=hook,
+                                     taskid=self.taskid,
+                                     task_results_dir=self.task_results_dir)
+
+        return cmdline
+
+    def _get_hookdir(self):
+        hooks_path = hooks_config.get("main.hookdir", HOOK_PATH)
+
+        return hooks_path
+
+    def _get_timeout(self, hook):
+        timeout = hooks_config.get("main.timeout", HOOK_TIMEOUT)
+
+        if f"{hook}.timeout" in hooks_config:
+            timeout = hooks_config.get(f"{hook}.timeout", timeout)
+
+        return int(timeout)
+
+    def run(self, hook):
+        """Called by the default hook implementations"""
+        hook_path = os.path.join(self._get_hookdir(), hook)
+        executables = get_executables(hook_path)
+        timeout = self._get_timeout(hook)
+
+        for exc in executables:
+            log_debug(f"Running '{hook}' hook - script '{exc.name}'")
+            script = exc.path
+            hook_cmdline = self._get_cmdline(hook, exc.name)
+
+            if hook_cmdline:
+                script = shlex.quote(f"{script} {hook_cmdline}")
+
+            script = shlex.split(script)
+            child = run(script, shell=True, timeout=timeout, stdout=PIPE, stderr=PIPE, encoding='utf-8')
+
+            try:
+                child.check_returncode()
+            except TimeoutExpired:
+                log_error(f"Hook script '{exc.name}' timed out ({timeout}s).")
+            except CalledProcessError:
+                log_error(f"Hook script failed with exit status {child.returncode}.")
+
+            if child.stdout:
+                log_info(child.stdout)
+            if child.stderr:
+                log_error(child.stderr)

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -16,8 +16,8 @@ from .config import HOOK_PATH, HOOK_TIMEOUT, hooks_config
     start -- When task type is determined and the main task starts
     pre_prepare_debuginfo -- Before the preparation of debuginfo packages
     post_prepare_debuginfo -- After the preparation of debuginfo packages
-    pre_prepare_mock -- Before the preparation of mock environment
-    post_prepare_mock -- After the preparation of mock environment
+    pre_prepare_environment -- Before the preparation of retrace environment
+    post_prepare_environment -- After the preparation of retrace environment
     pre_retrace -- Before starting of the retracing itself
     post_retrace -- After retracing is done
     success -- After retracing success

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -93,15 +93,15 @@ class RetraceHook:
                 script = shlex.quote(f"{script} {hook_cmdline}")
 
             script = shlex.split(script)
-            child = run(script, shell=True, timeout=timeout, cwd=hook_path,
-                        stdout=PIPE, stderr=PIPE, encoding='utf-8')
 
             try:
+                child = run(script, shell=True, timeout=timeout, cwd=hook_path,
+                            stdout=PIPE, stderr=PIPE, encoding='utf-8')
                 child.check_returncode()
             except TimeoutExpired:
-                log_error(f"Hook script '{exc.name}' timed out ({timeout}s).")
+                log_error(f"Hook script '{exc.name}' timed out in {timeout} seconds.")
             except CalledProcessError:
-                log_error(f"Hook script failed with exit status {child.returncode}.")
+                log_error(f"Hook script '{exc.name}' failed with exit status {child.returncode}.")
 
             if child.stdout:
                 log_info(child.stdout)

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -97,15 +97,23 @@ class RetraceHook:
             child = run(script, shell=True, timeout=timeout, cwd=hook_path,
                         stdout=PIPE, stderr=PIPE, encoding='utf-8')
             child.check_returncode()
-        except TimeoutExpired:
-            log_error(f"Hook script '{exc}' timed out in {timeout} seconds.")
-        except CalledProcessError:
-            log_error(f"Hook script '{exc}' failed with exit status {child.returncode}.")
-
-        if child.stdout:
-            log_info(child.stdout)
-        if child.stderr:
-            log_error(child.stderr)
+        except TimeoutExpired as ex:
+            if ex.stdout:
+                log_info(ex.stdout)
+            if ex.stderr:
+                log_error(ex.stderr)
+            log_error(f"Hook script '{exc}' timed out in {ex.timeout} seconds.")
+        except CalledProcessError as ex:
+            if ex.stdout:
+                log_info(ex.stdout)
+            if ex.stderr:
+                log_error(ex.stderr)
+            log_error(f"Hook script '{exc}' failed with exit status {ex.returncode}.")
+        else:
+            if child.stdout:
+                log_info(child.stdout)
+            if child.stderr:
+                log_error(child.stderr)
 
     def run(self, hook):
         """Called by the default hook implementations"""

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -93,7 +93,8 @@ class RetraceHook:
                 script = shlex.quote(f"{script} {hook_cmdline}")
 
             script = shlex.split(script)
-            child = run(script, shell=True, timeout=timeout, stdout=PIPE, stderr=PIPE, encoding='utf-8')
+            child = run(script, shell=True, timeout=timeout, cwd=hook_path,
+                        stdout=PIPE, stderr=PIPE, encoding='utf-8')
 
             try:
                 child.check_returncode()

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 from subprocess import Popen, PIPE, STDOUT
 
+from retrace.hooks.hooks import RetraceHook
 from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED_FILES,
                       STATUS, STATUS_ANALYZE, STATUS_BACKTRACE, STATUS_CLEANUP,
                       STATUS_FAIL, STATUS_INIT, STATUS_STATS, STATUS_SUCCESS,
@@ -37,6 +38,7 @@ from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED
                       send_email)
 from .config import Config
 from .plugins import Plugins
+
 sys.path.insert(0, "/usr/share/retrace-server/")
 
 CONFIG = Config()
@@ -48,6 +50,7 @@ class RetraceWorker(object):
         self.task = task
         self.logging_handler = None
         self.fafrepo = None
+        self.hook = RetraceHook(task)
 
     def begin_logging(self):
         if self.logging_handler is None:
@@ -63,78 +66,6 @@ class RetraceWorker(object):
         if self.logging_handler is not None:
             logger.removeHandler(self.logging_handler)
 
-    def hook_universal(self, hook):
-        """Called by the default hook implementations"""
-        HOOK_SCRIPTS = CONFIG.get_hook_scripts()
-        if hook in HOOK_SCRIPTS:
-            results_dir = self.task.get_results_dir()
-            script = HOOK_SCRIPTS[hook].format(
-                hook_name=hook, task_id=self.task.get_taskid(),
-                task_results_dir=results_dir)
-            log_info("Running hook {0} '{1}'".format(hook, script))
-            child = Popen(script, shell=True, stdout=PIPE, stderr=PIPE, encoding='utf-8')
-            (out, err) = child.communicate()
-            if out:
-                log_info(out)
-            if err:
-                log_error(err)
-            child.wait()
-
-    def hook_pre_start(self):
-        """When self.start() is called"""
-        self.hook_universal("pre_start")
-
-    def hook_start(self):
-        """When task type is determined and the main task starts"""
-        self.hook_universal("start")
-
-    def hook_pre_prepare_debuginfo(self):
-        """Before the preparation of debuginfo packages"""
-        self.hook_universal("pre_prepare_debuginfo")
-
-    def hook_post_prepare_debuginfo(self):
-        """After the preparation of debuginfo packages"""
-        self.hook_universal("post_prepare_debuginfo")
-
-    def hook_pre_prepare_mock(self):
-        """Before the preparation of mock environment"""
-        self.hook_universal("pre_prepare_mock")
-
-    def hook_post_prepare_mock(self):
-        """After the preparation of mock environment"""
-        self.hook_universal("post_prepare_mock")
-
-    def hook_pre_retrace(self):
-        """Before starting of the retracing itself"""
-        self.hook_universal("pre_retrace")
-
-    def hook_post_retrace(self):
-        """After retracing is done"""
-        self.hook_universal("post_retrace")
-
-    def hook_success(self):
-        """After retracing success"""
-        self.hook_universal("success")
-
-    def hook_fail(self, errorcode):
-        """After retracing fails"""
-        self.hook_universal("fail")
-
-    def hook_pre_remove_task(self):
-        """Before removing task"""
-        self.hook_universal("pre_remove_task")
-
-    def hook_post_remove_task(self):
-        """After removing task"""
-        self.hook_universal("post_remove_task")
-
-    def hook_pre_clean_task(self):
-        """Before cleaning task"""
-        self.hook_universal("pre_clean_task")
-
-    def hook_post_clean_task(self):
-        """After cleaning task"""
-        self.hook_universal("post_clean_task")
 
     def notify_email(self):
         task = self.task
@@ -234,7 +165,7 @@ class RetraceWorker(object):
         if not task.get_type() in [TASK_DEBUG, TASK_RETRACE_INTERACTIVE, TASK_VMCORE_INTERACTIVE]:
             self.clean_task()
 
-        self.hook_fail(errorcode)
+        self.hook.run("fail")
 
         raise RetraceWorkerError(errorcode=errorcode)
 
@@ -434,7 +365,7 @@ class RetraceWorker(object):
         return (packages, missing, fafrepo)
 
     def start_retrace(self, custom_arch=None):
-        self.hook_start()
+        self.hook.run("start")
 
         task = self.task
         crashdir = os.path.join(task.get_savedir(), "crash")
@@ -466,12 +397,12 @@ class RetraceWorker(object):
             log_error("Package '%s.%s' was not recognized.\nIs it a part of "
                       "official %s repositories?" % (crash_package, arch, release))
             self._fail()
-        self.hook_pre_prepare_debuginfo()
+        self.hook.run("pre_prepare_debuginfo")
 
         packages, missing, self.fafrepo = self.read_packages(crashdir, releaseid, crash_package, distribution)
 
-        self.hook_post_prepare_debuginfo()
-        self.hook_pre_prepare_mock()
+        self.hook.run("post_prepare_debuginfo")
+        self.hook.run("pre_prepare_mock")
 
         # create mock config file
         try:
@@ -538,8 +469,8 @@ class RetraceWorker(object):
         self._retrace_run(25, ["/usr/bin/mock", "init", "--resultdir", task.get_savedir() + "/log", "--configdir",
                           task.get_savedir()])
 
-        self.hook_post_prepare_mock()
-        self.hook_pre_retrace()
+        self.hook.run("post_prepare_mock")
+        self.hook.run("pre_retrace")
 
         if CONFIG["UseFafPackages"]:
             self._retrace_run(26, ["/usr/bin/mock", "--configdir", task.get_savedir(), "shell", "--",
@@ -562,7 +493,7 @@ class RetraceWorker(object):
         if exploitable is not None:
             task.add_results("exploitable", exploitable, mode="w")
 
-        self.hook_post_retrace()
+        self.hook.run("post_retrace")
 
         # does not work at the moment
         rootsize = 0
@@ -599,7 +530,7 @@ class RetraceWorker(object):
         log_info(STATUS[STATUS_SUCCESS])
         task.set_status(STATUS_SUCCESS)
 
-        self.hook_success()
+        self.hook.run("success")
 
         return True
 
@@ -655,7 +586,7 @@ class RetraceWorker(object):
         return s1.st_size
 
     def start_vmcore(self, custom_kernelver=None):
-        self.hook_start()
+        self.hook.run("start")
 
         task = self.task
         vmcore_path = os.path.join(task.get_savedir(), "crash", "vmcore")
@@ -702,7 +633,7 @@ class RetraceWorker(object):
         vmlinux = ""
 
         if task.get_mock():
-            self.hook_post_prepare_mock()
+            self.hook.run("post_prepare_mock")
 
             # we don't save config into task.get_savedir() because it is only
             # readable by user/group retrace/CONFIG["AuthGroup"].
@@ -776,17 +707,17 @@ class RetraceWorker(object):
             if child.wait():
                 raise Exception("mock exited with %d:\n%s" % (child.returncode, stdout))
 
-            self.hook_post_prepare_mock()
+            self.hook.run("post_prepare_mock")
 
             # no locks required, mock locks itself
             try:
-                self.hook_pre_prepare_debuginfo()
+                self.hook.run("pre_prepare_debuginfo")
                 vmlinux = vmcore.prepare_debuginfo(task, cfgdir, kernelver=kernelver)
-                self.hook_post_prepare_debuginfo()
+                self.hook.run("post_prepare_debuginfo")
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))
 
-            self.hook_pre_retrace()
+            self.hook.run("pre_retrace")
             crash_normal = ["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
                             task.get_crash_cmd() + " -s %s %s" % (vmcore_path, vmlinux)]
             crash_minimal = ["/usr/bin/mock", "--configdir", cfgdir, "shell", "--",
@@ -794,13 +725,13 @@ class RetraceWorker(object):
 
         else:
             try:
-                self.hook_pre_prepare_debuginfo()
+                self.hook.run("pre_prepare_debuginfo")
                 vmlinux = vmcore.prepare_debuginfo(task, kernelver=kernelver)
-                self.hook_post_prepare_debuginfo()
+                self.hook.run("post_prepare_debuginfo")
             except Exception as ex:
                 raise Exception("prepare_debuginfo failed: %s" % str(ex))
 
-            self.hook_pre_retrace()
+            self.hook.run("pre_retrace")
             task.set_status(STATUS_BACKTRACE)
             log_info(STATUS[STATUS_BACKTRACE])
 
@@ -860,7 +791,7 @@ class RetraceWorker(object):
         if len(crashrc_lines) > 0:
             task.set_crashrc("%s\n" % "\n".join(crashrc_lines))
 
-        self.hook_post_retrace()
+        self.hook.run("post_retrace")
 
         task.set_finished_time(int(time.time()))
         self.stats["duration"] = int(time.time()) - self.stats["starttime"]
@@ -887,10 +818,10 @@ class RetraceWorker(object):
 
         task.set_status(STATUS_SUCCESS)
         self.notify_email()
-        self.hook_success()
+        self.hook.run("success")
 
     def start(self, kernelver=None, arch=None):
-        self.hook_pre_start()
+        self.hook.run("pre_start")
         self.stats = {
             "taskid": self.task.get_taskid(),
             "package": None,
@@ -945,15 +876,15 @@ class RetraceWorker(object):
             self._fail()
 
     def clean_task(self):
-        self.hook_pre_clean_task()
+        self.hook.run("pre_clean_task")
         if CONFIG["UseFafPackages"] and self.fafrepo:
             shutil.rmtree(self.fafrepo)
         ret = self.task.clean()
-        self.hook_post_clean_task()
+        self.hook.run("post_clean_task")
         return ret
 
     def remove_task(self):
-        self.hook_pre_remove_task()
+        self.hook.run("pre_remove_task")
         ret = self.task.remove()
-        self.hook_post_remove_task()
+        self.hook.run("post_remove_task")
         return ret

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -402,7 +402,7 @@ class RetraceWorker(object):
         packages, missing, self.fafrepo = self.read_packages(crashdir, releaseid, crash_package, distribution)
 
         self.hook.run("post_prepare_debuginfo")
-        self.hook.run("pre_prepare_mock")
+        self.hook.run("pre_prepare_environment")
 
         # create mock config file
         try:
@@ -469,7 +469,7 @@ class RetraceWorker(object):
         self._retrace_run(25, ["/usr/bin/mock", "init", "--resultdir", task.get_savedir() + "/log", "--configdir",
                           task.get_savedir()])
 
-        self.hook.run("post_prepare_mock")
+        self.hook.run("post_prepare_environment")
         self.hook.run("pre_retrace")
 
         if CONFIG["UseFafPackages"]:
@@ -633,7 +633,7 @@ class RetraceWorker(object):
         vmlinux = ""
 
         if task.get_mock():
-            self.hook.run("post_prepare_mock")
+            self.hook.run("post_prepare_environment")
 
             # we don't save config into task.get_savedir() because it is only
             # readable by user/group retrace/CONFIG["AuthGroup"].
@@ -707,7 +707,7 @@ class RetraceWorker(object):
             if child.wait():
                 raise Exception("mock exited with %d:\n%s" % (child.returncode, stdout))
 
-            self.hook.run("post_prepare_mock")
+            self.hook.run("post_prepare_environment")
 
             # no locks required, mock locks itself
             try:


### PR DESCRIPTION
Instead of specifying what to run for certain a hook in `/etc/retrace-server.conf`
you will be able to put executable scripts into one of the hook directories in
`/usr/share/retrace-server/hooks/{start,fail,success,...}` and
retrace-server worker will run all the executable scripts it finds.

The directory can be changed with HookDir in `/etc/retrace-server/retrace-server-hooks.conf`.

For now you can configure `timeout` and `cmdline` options for the hooks.

Example for a `success` hook:
$ ls /usr/share/retrace-server/hooks/success/
/usr/share/retrace-server/hooks/success/echo

$ cat /etc/retrace-server/hooks/success.conf
```
[success]
timeout = 42

[success.echo]
cmdline = {taskid}
```
retrace-server worker will now run `echo 4321` with timeout of 42 seconds
once some retrace task finishes successfuly.