### PR TITLE
retrace: Change logging format

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -184,27 +184,23 @@ class RetraceWorkerError(RetraceError):
         self.errorcode = errorcode
 
 
-def now():
-    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-
 logger = logging.getLogger(__name__)
 
 
 def log_info(msg):
-    logger.info("%23s %s" % (now(), msg))
+    logger.info(msg)
 
 
 def log_debug(msg):
-    logger.debug("%22s %s" % (now(), msg))
+    logger.debug(msg)
 
 
 def log_warn(msg):
-    logger.warn("%20s %s" % (now(), msg))
+    logger.warn(msg)
 
 
 def log_error(msg):
-    logger.error("%22s %s" % (now(), msg))
+    logger.error(msg)
 
 
 def lock(lockfile):

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -53,6 +53,10 @@ class RetraceWorker(object):
         if self.logging_handler is None:
             self.logging_handler = logging.FileHandler(
                 self.task._get_file_path(RetraceTask.LOG_FILE))
+
+        formatter = logging.Formatter(fmt="[%(asctime)s] [%(levelname)-.1s] %(message)s",
+                                      datefmt="%Y-%m-%d %H:%M:%S")
+        self.logging_handler.setFormatter(formatter)
         logger.addHandler(self.logging_handler)
 
     def end_logging(self):


### PR DESCRIPTION
The old format:
```
    2019-11-25 15:08:43 Analyzing crash data
   2019-11-25 15:08:43 Hook script failed with exit status 1.
    2019-11-25 15:08:44 Preparing environment for backtrace generation
    2019-11-25 15:09:29 Generating backtrace
    2019-11-25 15:09:37 Cleaning environment after backtrace generation
    2019-11-25 15:09:41 Saving crash statistics
    2019-11-25 15:09:41 Retrace took 58 seconds
    2019-11-25 15:09:41 Retrace job finished successfully
```
The new format:
```
[2019-11-25 15:04:56] [I] Analyzing crash data
[2019-11-25 15:04:56] [E] Hook script failed with exit status 1.
[2019-11-25 15:04:57] [I] Preparing environment for backtrace generation
[2019-11-25 15:05:40] [I] Generating backtrace
[2019-11-25 15:05:47] [I] Cleaning environment after backtrace generation
[2019-11-25 15:05:51] [I] Saving crash statistics
[2019-11-25 15:05:51] [I] Retrace took 55 seconds
[2019-11-25 15:05:51] [I] Retrace job finished successfully
```

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>