### PR TITLE
Fix build error after change of mock.conf to environment.conf

### DIFF
--- a/retrace-server.spec.in
+++ b/retrace-server.spec.in
@@ -158,7 +158,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}-hooks.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/debuginfo.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/fail.conf
-%config(noreplace) %{_sysconfdir}/%{name}/hooks/mock.conf
+%config(noreplace) %{_sysconfdir}/%{name}/hooks/environment.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/retrace.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/start.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/success.conf

--- a/src/config/hooks/Makefile.am
+++ b/src/config/hooks/Makefile.am
@@ -1,6 +1,6 @@
 retracehooks_DATA = debuginfo.conf \
                     fail.conf \
-                    mock.conf \
+                    environment.conf \
                     retrace.conf \
                     start.conf \
                     success.conf \


### PR DESCRIPTION
Commit 83327af missed a couple changes that caused the following build
errors:
make[8]: Entering directory '/root/git/retrace-server/src/config/hooks'
make  distdir-am
make[9]: Entering directory '/root/git/retrace-server/src/config/hooks'
make[9]: *** No rule to make target 'mock.conf', needed by 'distdir-am'.  Stop.
make[9]: Leaving directory '/root/git/retrace-server/src/config/hooks'
make[8]: *** [Makefile:407: distdir] Error 2
make[8]: Leaving directory '/root/git/retrace-server/src/config/hooks'

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>