### PR TITLE
retrace: Fix bytes has no attribute encode

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -784,7 +784,9 @@ def unpack(archive, mime, targetdir=None):
 
 
 def response(start_response, status, body="", extra_headers=[]):
-    body = body.encode()
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+
     start_response(status, [("Content-Type", "text/plain"), ("Content-Length", "%d" % len(body))] + extra_headers)
     return [body]
 


### PR DESCRIPTION
Seems like this 991b9e4a5567eb2f3bd8570087e7d9b42ad1eb91 didn't fix it
properly.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>