### PR TITLE
Fix error handling when unknown exception occurs in run_crash_cmd

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -2030,7 +2030,7 @@ class RetraceTask:
             t = 3600
             if CONFIG["ProcessCommunicateTimeout"]:
                 t = CONFIG["ProcessCommunicateTimeout"]
-            child = run(crash_start, stdin=PIPE, stdout=PIPE, stderr=STDOUT,
+            child = run(crash_start, stdout=PIPE, stderr=STDOUT,
                         input=crash_cmdline.encode(), timeout=t)
             cmd_output = child.stdout
         except OSError as err:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -2041,9 +2041,9 @@ class RetraceTask:
             raise Exception("WARNING: crash command: '%s' exceeded " + str(t) +
                             " second timeout - damaged vmcore?" %
                             crash_cmdline.replace('\r', '; ').replace('\n', '; '))
-        except Exception:
+        except Exception as err:
             log_warn("crash command: '%s' triggered Unknown exception %s" %
-                     crash_cmdline.replace('\r', '; ').replace('\n', '; '))
+                     (crash_cmdline.replace('\r', '; ').replace('\n', '; '), err))
             log_warn("  %s" % sys.exc_info()[0])
         try:
             cmd_output.decode('utf-8')


### PR DESCRIPTION
If an unknown error occurs the following cryptic error is thrown:
[2020-01-29 17:11:52] [I] Searching for kernel-debuginfo package for 2.6.32-504.el6.x86_64
[2020-01-29 17:11:52] [E] not enough arguments for format string

The intent was to print out more info about the exception, and
fixing this bug shows better info:
[2020-01-29 17:30:15] [I] Searching for kernel-debuginfo package for 2.6.32-504.el6.x86_64
[2020-01-29 17:30:15] [W] crash command: 'mod; quit' triggered Unknown exception stdin and input arguments may not both be used.
[2020-01-29 17:30:15] [W]   <class 'ValueError'>
[2020-01-29 17:30:15] [E] prepare_debuginfo failed: 'NoneType' object has no attribute 'decode'

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>