### PR TITLE
retrace: Split off crashstats related functions

### DIFF
--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -20,11 +20,11 @@ from retrace.retrace import (ALLOWED_FILES,
                              parse_http_gettext,
                              response,
                              RetraceTask,
-                             save_crashstats_reportfull,
                              unpack,
                              unpacked_size)
 
 from retrace.config import Config
+from retrace.stats import save_crashstats_reportfull
 
 CONFIG = Config()
 BUFSIZE = 1 << 20  # 1 MB

--- a/src/retrace/Makefile.am
+++ b/src/retrace/Makefile.am
@@ -5,6 +5,7 @@ retracelib_PYTHON = \
     argparser.py \
     retrace.py \
     retrace_worker.py \
+    stats.py \
     plugins.py
 
 nodist_retracelib_PYTHON = \

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1,4 +1,3 @@
-import datetime
 import errno
 import ftplib
 import gettext
@@ -9,7 +8,6 @@ import re
 import random
 import shutil
 import smtplib
-import sqlite3
 import stat
 import sys
 import time
@@ -886,157 +884,6 @@ def parse_rpm_name(name):
      result["arch"]) = splitFilename(name + ".mockarch.rpm")
 
     return result
-
-
-def init_crashstats_db():
-    # create the database group-writable and world-readable
-    old_umask = os.umask(0o113)
-    con = sqlite3.connect(os.path.join(CONFIG["SaveDir"], CONFIG["DBFile"]))
-    os.umask(old_umask)
-
-    query = con.cursor()
-    query.execute("PRAGMA foreign_keys = ON")
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      tasks(id INTEGER PRIMARY KEY AUTOINCREMENT, taskid, package, version,
-      arch, starttime NOT NULL, duration NOT NULL, coresize, status NOT NULL)
-    """)
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      success(taskid REFERENCES tasks(id), pre NOT NULL, post NOT NULL,
-              rootsize NOT NULL)
-    """)
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      packages(id INTEGER PRIMARY KEY AUTOINCREMENT,
-               name NOT NULL, version NOT NULL)
-    """)
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      packages_tasks(pkgid REFERENCES packages(id),
-                     taskid REFERENCES tasks(id))
-    """)
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      buildids(taskid REFERENCES tasks(id), soname, buildid NOT NULL)
-    """)
-    query.execute("""
-      CREATE TABLE IF NOT EXISTS
-      reportfull(requesttime NOT NULL, ip NOT NULL)
-    """)
-    con.commit()
-
-    return con
-
-
-def save_crashstats(stats, con=None):
-    close = False
-    if con is None:
-        con = init_crashstats_db()
-        close = True
-
-    query = con.cursor()
-    query.execute("""
-      INSERT INTO tasks (taskid, package, version, arch,
-      starttime, duration, coresize, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      """,
-                  (stats["taskid"], stats["package"], stats["version"],
-                   stats["arch"], stats["starttime"], stats["duration"],
-                   stats["coresize"], stats["status"]))
-
-    con.commit()
-    if close:
-        con.close()
-
-    return query.lastrowid
-
-
-def save_crashstats_success(statsid, pre, post, rootsize, con=None):
-    close = False
-    if con is None:
-        con = init_crashstats_db()
-        close = True
-
-    query = con.cursor()
-    query.execute("""
-      INSERT INTO success (taskid, pre, post, rootsize)
-      VALUES (?, ?, ?, ?)
-      """,
-                  (statsid, pre, post, rootsize))
-
-    con.commit()
-    if close:
-        con.close()
-
-
-def save_crashstats_packages(statsid, packages, con=None):
-    close = False
-    if con is None:
-        con = init_crashstats_db()
-        close = True
-
-    query = con.cursor()
-    for package in packages:
-        pkgdata = parse_rpm_name(package)
-        if pkgdata["name"] is None:
-            continue
-
-        ver = "%s-%s" % (pkgdata["version"], pkgdata["release"])
-        query.execute("SELECT id FROM packages WHERE name = ? AND version = ?",
-                      (pkgdata["name"], ver))
-        row = query.fetchone()
-        if row:
-            pkgid = row[0]
-        else:
-            query.execute("INSERT INTO packages (name, version) VALUES (?, ?)",
-                          (pkgdata["name"], ver))
-            pkgid = query.lastrowid
-
-        query.execute("""
-          INSERT INTO packages_tasks (taskid, pkgid) VALUES (?, ?)
-          """, (statsid, pkgid))
-
-    con.commit()
-    if close:
-        con.close()
-
-
-def save_crashstats_build_ids(statsid, buildids, con=None):
-    close = False
-    if con is None:
-        con = init_crashstats_db()
-        close = True
-
-    query = con.cursor()
-    for soname, buildid in buildids:
-        query.execute("""
-          INSERT INTO buildids (taskid, soname, buildid)
-          VALUES (?, ?, ?)
-          """,
-                      (statsid, soname, buildid))
-
-    con.commit()
-    if close:
-        con.close()
-
-
-def save_crashstats_reportfull(ip, con=None):
-    close = False
-    if con is None:
-        con = init_crashstats_db()
-        close = True
-
-    query = con.cursor()
-    query.execute("""
-      INSERT INTO reportfull (requesttime, ip)
-      VALUES (?, ?)
-      """,
-                  (int(time.time()), ip))
-
-    con.commit()
-    if close:
-        con.close()
 
 
 def send_email(frm, to, subject, body):

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -18,7 +18,6 @@ from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED
                       get_active_tasks,
                       get_supported_releases,
                       guess_arch,
-                      init_crashstats_db,
                       is_package_known,
                       human_readable_size,
                       KernelVMcore,
@@ -31,13 +30,14 @@ from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED
                       run_gdb,
                       RetraceTask,
                       RetraceWorkerError,
-                      save_crashstats,
-                      save_crashstats_build_ids,
-                      save_crashstats_packages,
-                      save_crashstats_success,
                       send_email)
 from .config import Config
 from .plugins import Plugins
+from .stats import (init_crashstats_db,
+                    save_crashstats,
+                    save_crashstats_build_ids,
+                    save_crashstats_packages,
+                    save_crashstats_success)
 
 sys.path.insert(0, "/usr/share/retrace-server/")
 

--- a/src/retrace/stats.py
+++ b/src/retrace/stats.py
@@ -1,0 +1,156 @@
+import os
+import sqlite3
+import time
+
+from .retrace import CONFIG, parse_rpm_name
+
+
+def init_crashstats_db():
+    # create the database group-writable and world-readable
+    old_umask = os.umask(0o113)
+    con = sqlite3.connect(os.path.join(CONFIG["SaveDir"], CONFIG["DBFile"]))
+    os.umask(old_umask)
+
+    query = con.cursor()
+    query.execute("PRAGMA foreign_keys = ON")
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      tasks(id INTEGER PRIMARY KEY AUTOINCREMENT, taskid, package, version,
+      arch, starttime NOT NULL, duration NOT NULL, coresize, status NOT NULL)
+    """)
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      success(taskid REFERENCES tasks(id), pre NOT NULL, post NOT NULL,
+              rootsize NOT NULL)
+    """)
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      packages(id INTEGER PRIMARY KEY AUTOINCREMENT,
+               name NOT NULL, version NOT NULL)
+    """)
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      packages_tasks(pkgid REFERENCES packages(id),
+                     taskid REFERENCES tasks(id))
+    """)
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      buildids(taskid REFERENCES tasks(id), soname, buildid NOT NULL)
+    """)
+    query.execute("""
+      CREATE TABLE IF NOT EXISTS
+      reportfull(requesttime NOT NULL, ip NOT NULL)
+    """)
+    con.commit()
+
+    return con
+
+
+def save_crashstats(stats, con=None):
+    close = False
+    if con is None:
+        con = init_crashstats_db()
+        close = True
+
+    query = con.cursor()
+    query.execute("""
+      INSERT INTO tasks (taskid, package, version, arch,
+      starttime, duration, coresize, status)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      """,
+                  (stats["taskid"], stats["package"], stats["version"],
+                   stats["arch"], stats["starttime"], stats["duration"],
+                   stats["coresize"], stats["status"]))
+
+    con.commit()
+    if close:
+        con.close()
+
+    return query.lastrowid
+
+
+def save_crashstats_success(statsid, pre, post, rootsize, con=None):
+    close = False
+    if con is None:
+        con = init_crashstats_db()
+        close = True
+
+    query = con.cursor()
+    query.execute("""
+      INSERT INTO success (taskid, pre, post, rootsize)
+      VALUES (?, ?, ?, ?)
+      """,
+                  (statsid, pre, post, rootsize))
+
+    con.commit()
+    if close:
+        con.close()
+
+
+def save_crashstats_packages(statsid, packages, con=None):
+    close = False
+    if con is None:
+        con = init_crashstats_db()
+        close = True
+
+    query = con.cursor()
+    for package in packages:
+        pkgdata = parse_rpm_name(package)
+        if pkgdata["name"] is None:
+            continue
+
+        ver = "%s-%s" % (pkgdata["version"], pkgdata["release"])
+        query.execute("SELECT id FROM packages WHERE name = ? AND version = ?",
+                      (pkgdata["name"], ver))
+        row = query.fetchone()
+        if row:
+            pkgid = row[0]
+        else:
+            query.execute("INSERT INTO packages (name, version) VALUES (?, ?)",
+                          (pkgdata["name"], ver))
+            pkgid = query.lastrowid
+
+        query.execute("""
+          INSERT INTO packages_tasks (taskid, pkgid) VALUES (?, ?)
+          """, (statsid, pkgid))
+
+    con.commit()
+    if close:
+        con.close()
+
+
+def save_crashstats_build_ids(statsid, buildids, con=None):
+    close = False
+    if con is None:
+        con = init_crashstats_db()
+        close = True
+
+    query = con.cursor()
+    for soname, buildid in buildids:
+        query.execute("""
+          INSERT INTO buildids (taskid, soname, buildid)
+          VALUES (?, ?, ?)
+          """,
+                      (statsid, soname, buildid))
+
+    con.commit()
+    if close:
+        con.close()
+
+
+def save_crashstats_reportfull(ip, con=None):
+    close = False
+    if con is None:
+        con = init_crashstats_db()
+        close = True
+
+    query = con.cursor()
+    query.execute("""
+      INSERT INTO reportfull (requesttime, ip)
+      VALUES (?, ?)
+      """,
+                  (int(time.time()), ip))
+
+    con.commit()
+    if close:
+        con.close()

--- a/src/settings.wsgi
+++ b/src/settings.wsgi
@@ -3,9 +3,9 @@
 from retrace.retrace import (HANDLE_ARCHIVE,
                              get_active_tasks,
                              get_supported_releases,
-                             response,
-                             save_crashstats_reportfull)
+                             response)
 from retrace.config import Config
+from retrace.stats import save_crashstats_reportfull
 
 CONFIG = Config()
 

--- a/src/stats.wsgi
+++ b/src/stats.wsgi
@@ -6,10 +6,10 @@ from webob import Request
 
 from retrace.retrace import (STATUS_FAIL,
                              STATUS_SUCCESS,
-                             init_crashstats_db,
                              parse_http_gettext,
                              response)
 from retrace.plugins import Plugins
+from retrace.stats import init_crashstats_db
 
 sys.path.insert(0, "/usr/share/retrace-server/")
 


### PR DESCRIPTION
Tidies up the retrace.py a little bit.

No reason why to keep the crashstats functions in there.

A step towards issue #89

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>