### PR TITLE
Update regexes for CentOS and RHEL releases

### DIFF
--- a/src/plugins/centos.py
+++ b/src/plugins/centos.py
@@ -2,7 +2,7 @@ import re
 
 distribution = "centos"
 abrtparser = re.compile(r"^CentOS Linux release (\d+)(?:\.(\d+)\.(\d+))? \(([^\)]+)\)$")
-guessparser = re.compile(r"\.el([0-9]+)")
+guessparser = re.compile(r"\.el(\d+)")
 displayrelease = "CentOS release"
 gdb_package = "gdb"
 gdb_executable = "/usr/bin/gdb"

--- a/src/plugins/centos.py
+++ b/src/plugins/centos.py
@@ -1,7 +1,7 @@
 import re
 
 distribution = "centos"
-abrtparser = re.compile(r"^CentOS Linux release ([0-9]+) \(([^\)]+)\)$")
+abrtparser = re.compile(r"^CentOS Linux release (\d+)(?:\.(\d+)\.(\d+))? \(([^\)]+)\)$")
 guessparser = re.compile(r"\.el([0-9]+)")
 displayrelease = "CentOS release"
 gdb_package = "gdb"

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -1,7 +1,7 @@
 import re
 
 distribution = "rhel"
-abrtparser = re.compile(r"^Red Hat Enterprise Linux release ([0-9]+) \(([^\)]+)\)$")
+abrtparser = re.compile(r"^Red Hat Enterprise Linux(?:\s\w+)? release (\d+)(?:\.(\d+))?(?:\s\w+)? \(([^\)]+)\)$")
 guessparser = re.compile(r"\.el([0-9]+)")
 displayrelease = "Red Hat Enterprise Linux release"
 gdb_package = "devtoolset-8-gdb"

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -2,7 +2,7 @@ import re
 
 distribution = "rhel"
 abrtparser = re.compile(r"^Red Hat Enterprise Linux(?:\s\w+)? release (\d+)(?:\.(\d+))?(?:\s\w+)? \(([^\)]+)\)$")
-guessparser = re.compile(r"\.el([0-9]+)")
+guessparser = re.compile(r"\.el(\d+)")
 displayrelease = "Red Hat Enterprise Linux release"
 gdb_package = "devtoolset-8-gdb"
 gdb_executable = "/opt/rh/devtoolset-8/root/usr/bin/gdb"


### PR DESCRIPTION
The release version is no longer just a simple number.

CentOS:
`CentOS Linux release 7 (Core)`
`CentOS Linux release 8.1.1234 (Core)`

RHEL:
`Red Hat Enterprise Linux release 8.1 (Ootpa)`
`Red Hat Enterprise Linux release 8.2 Beta (Ootpa)`
`Red Hat Enterprise Linux Server release 7.8 Beta (Maipo)`


https://regex101.com/