### PR TITLE
retrace: Move stuff from retrace to util

### DIFF
--- a/src/backtrace.wsgi
+++ b/src/backtrace.wsgi
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 from webob import Request
 
-from retrace.retrace import (URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/checkpackage.wsgi
+++ b/src/checkpackage.wsgi
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 from webob import Request
 
-from retrace.retrace import (INPUT_ARCH_PARSER,
-                             INPUT_PACKAGE_PARSER,
-                             INPUT_RELEASEID_PARSER,
-                             is_package_known,
-                             parse_http_gettext,
-                             response)
+from retrace.retrace import is_package_known
+from retrace.util import (INPUT_ARCH_PARSER,
+                          INPUT_PACKAGE_PARSER,
+                          INPUT_RELEASEID_PARSER,
+                          parse_http_gettext,
+                          response)
 
 
 def application(environ, start_response):

--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -6,25 +6,25 @@ from webob import Request
 from tempfile import NamedTemporaryFile
 
 from retrace.retrace import (ALLOWED_FILES,
-                             HANDLE_ARCHIVE,
                              REQUIRED_FILES,
                              TASK_RETRACE,
                              TASK_RETRACE_INTERACTIVE,
                              TASK_TYPES,
                              TASK_VMCORE,
                              TASK_VMCORE_INTERACTIVE,
-                             free_space,
                              get_active_tasks,
                              get_archive_type,
                              KernelVMcore,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask,
-                             unpack,
-                             unpacked_size)
+                             RetraceTask)
 
 from retrace.config import Config
 from retrace.stats import save_crashstats_reportfull
+from retrace.util import (HANDLE_ARCHIVE,
+                          free_space,
+                          parse_http_gettext,
+                          response,
+                          unpack,
+                          unpacked_size)
 
 CONFIG = Config()
 BUFSIZE = 1 << 20  # 1 MB

--- a/src/delete.wsgi
+++ b/src/delete.wsgi
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 from webob import Request
 
-from retrace.retrace import (URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/exploitable.wsgi
+++ b/src/exploitable.wsgi
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 from webob import Request
 
-from retrace.retrace import (URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -5,10 +5,8 @@ import re
 import urllib
 from webob import Request
 
-from retrace.retrace import (ftp_list_dir,
-                             parse_http_gettext,
-                             response)
 from retrace.config import Config
+from retrace.util import ftp_list_dir, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/index.wsgi
+++ b/src/index.wsgi
@@ -2,10 +2,9 @@
 from webob import Request
 
 from retrace.retrace import (get_active_tasks,
-                             get_supported_releases,
-                             parse_http_gettext,
-                             response)
+                             get_supported_releases)
 from retrace.config import Config
+from retrace.util import parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/log.wsgi
+++ b/src/log.wsgi
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 
 from webob import Request
-from retrace.retrace import (URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -7,21 +7,25 @@ import time
 import urllib
 from webob import Request
 
-from retrace.retrace import (FTP_SUPPORTED_EXTENSIONS, STATUS, STATUS_DOWNLOADING, STATUS_FAIL,
+from retrace.retrace import (STATUS, STATUS_DOWNLOADING, STATUS_FAIL,
                              STATUS_SUCCESS, TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE,
                              TASK_VMCORE, TASK_VMCORE_INTERACTIVE,
-                             free_space,
-                             ftp_close,
-                             ftp_init,
-                             ftp_list_dir,
-                             human_readable_size,
                              KernelVer,
-                             parse_http_gettext,
-                             response,
                              RetraceTask)
 from retrace.config import Config
+from retrace.util import (free_space,
+                          ftp_close,
+                          ftp_init,
+                          ftp_list_dir,
+                          human_readable_size,
+                          parse_http_gettext,
+                          response)
 
 CONFIG = Config()
+
+FTP_SUPPORTED_EXTENSIONS = [".tar.gz", ".tgz", ".tarz", ".tar.bz2", ".tar.xz",
+                            ".tar", ".gz", ".bz2", ".xz", ".Z", ".zip"]
+
 
 MANAGER_URL_PARSER = re.compile(r"^(.*/manager)(/(([^/]+)(/(__custom__|start|backtrace|savenotes|caseno|"
                                 r"bugzillano|notify|delete(/(sure/?)?)?|results/([^/]+)/?)?)?)?)?$")

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -15,15 +15,14 @@ from functools import cmp_to_key
 from subprocess import run, DEVNULL, PIPE
 
 from retrace.retrace import (get_canon_arch,
-                             lock,
                              log_debug,
                              log_error,
                              log_info,
-                             log_warn,
-                             parse_rpm_name,
-                             unlock)
+                             log_warn)
+
 from retrace.config import Config
 from retrace.plugins import Plugins
+from retrace.util import lock, unlock, parse_rpm_name
 
 sys.path.insert(0, "/usr/share/retrace-server")
 

--- a/src/retrace/Makefile.am
+++ b/src/retrace/Makefile.am
@@ -18,7 +18,6 @@ EXTRA_DIST = config.py.in
 
 config.py: config.py.in
 	sed -e "s|@DF_BIN@|$(DF)|g" \
-	    -e "s|@DU_BIN@|$(DU)|g" \
 	    -e "s|@GZIP_BIN@|$(GZIP)|g" \
 	    -e "s|@TAR_BIN@|$(TAR)|g" \
 	    -e "s|@XZ_BIN@|$(XZ)|g" \

--- a/src/retrace/Makefile.am
+++ b/src/retrace/Makefile.am
@@ -6,7 +6,8 @@ retracelib_PYTHON = \
     retrace.py \
     retrace_worker.py \
     stats.py \
-    plugins.py
+    plugins.py \
+    util.py
 
 nodist_retracelib_PYTHON = \
     config.py

--- a/src/retrace/__init__.py
+++ b/src/retrace/__init__.py
@@ -1,7 +1,8 @@
-__all__ = ["argparser", "config", "plugins", "retrace", "retrace_worker"]
+__all__ = ["argparser", "config", "plugins", "retrace", "retrace_worker", "util"]
 
 from . import argparser
 from . import config
 from . import plugins
 from . import retrace
 from . import retrace_worker
+from . import util

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -13,7 +13,6 @@ import os
 import configparser
 
 DF_BIN = "@DF_BIN@"
-DU_BIN = "@DU_BIN@"
 GZIP_BIN = "@GZIP_BIN@"
 TAR_BIN = "@TAR_BIN@"
 XZ_BIN = "@XZ_BIN@"

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -637,10 +637,6 @@ def unpack_coredump(path):
             shutil.rmtree(fullpath)
 
 
-def get_task_est_time(taskdir):
-    return 180
-
-
 def run_ps():
     lines = run(["ps", "-eo", "pid,ppid,etime,cmd"],
                 stdout=PIPE, encoding='utf-8').stdout.split("\n")

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -10,7 +10,7 @@ import stat
 from subprocess import PIPE, DEVNULL, STDOUT, run
 
 from retrace.hooks.hooks import RetraceHook
-from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED_FILES,
+from .retrace import (ALLOWED_FILES, REPO_PREFIX, REQUIRED_FILES,
                       STATUS, STATUS_ANALYZE, STATUS_BACKTRACE, STATUS_CLEANUP,
                       STATUS_FAIL, STATUS_INIT, STATUS_STATS, STATUS_SUCCESS,
                       TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE, TASK_VMCORE,
@@ -19,18 +19,15 @@ from .retrace import (ALLOWED_FILES, INPUT_PACKAGE_PARSER, REPO_PREFIX, REQUIRED
                       get_supported_releases,
                       guess_arch,
                       is_package_known,
-                      human_readable_size,
                       KernelVMcore,
                       log_debug,
                       log_error,
                       log_info,
                       log_warn,
                       logger,
-                      parse_rpm_name,
                       run_gdb,
                       RetraceTask,
-                      RetraceWorkerError,
-                      send_email)
+                      RetraceWorkerError)
 from .config import Config
 from .plugins import Plugins
 from .stats import (init_crashstats_db,
@@ -38,6 +35,10 @@ from .stats import (init_crashstats_db,
                     save_crashstats_build_ids,
                     save_crashstats_packages,
                     save_crashstats_success)
+from .util import (INPUT_PACKAGE_PARSER,
+                   human_readable_size,
+                   parse_rpm_name,
+                   send_email)
 
 sys.path.insert(0, "/usr/share/retrace-server/")
 

--- a/src/retrace/stats.py
+++ b/src/retrace/stats.py
@@ -2,7 +2,8 @@ import os
 import sqlite3
 import time
 
-from .retrace import CONFIG, parse_rpm_name
+from .retrace import CONFIG
+from .util import parse_rpm_name
 
 
 def init_crashstats_db():

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -9,12 +9,11 @@ from dnf.subject import Subject
 from hawkey import FORM_NEVRA
 from subprocess import run, PIPE
 
-from .config import Config, DF_BIN, DU_BIN, GZIP_BIN, TAR_BIN, XZ_BIN
+from .config import Config, DF_BIN, GZIP_BIN, TAR_BIN, XZ_BIN
 
 GETTEXT_DOMAIN = "retrace-server"
 
 DF_OUTPUT_PARSER = re.compile(r"^([^ ^\t]*)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+%)[ \t]+(.*)$")
-DU_OUTPUT_PARSER = re.compile(r"^([0-9]+)")
 
 # architecture (i386, x86_64, armv7hl, mips4kec)
 INPUT_ARCH_PARSER = re.compile(r"^[a-zA-Z0-9_]+$")
@@ -77,16 +76,6 @@ def unlock(lockfile):
         return False
 
     return True
-
-
-def dir_size(path):
-    lines = run([DU_BIN, "-sb", path], stdout=PIPE, encoding='utf-8').stdout.split("\n")
-    for line in lines:
-        match = DU_OUTPUT_PARSER.match(line)
-        if match:
-            return int(match.group(1))
-
-    return 0
 
 
 def free_space(path):

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -1,0 +1,245 @@
+import os
+import re
+import errno
+import ftplib
+import gettext
+import smtplib
+
+from dnf.subject import Subject
+from hawkey import FORM_NEVRA
+from subprocess import run, PIPE
+
+from .config import Config, DF_BIN, DU_BIN, GZIP_BIN, TAR_BIN, XZ_BIN
+
+GETTEXT_DOMAIN = "retrace-server"
+
+DF_OUTPUT_PARSER = re.compile(r"^([^ ^\t]*)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+%)[ \t]+(.*)$")
+DU_OUTPUT_PARSER = re.compile(r"^([0-9]+)")
+
+# architecture (i386, x86_64, armv7hl, mips4kec)
+INPUT_ARCH_PARSER = re.compile(r"^[a-zA-Z0-9_]+$")
+# characters, numbers, dash (utf-8, iso-8859-2 etc.)
+INPUT_CHARSET_PARSER = re.compile(r"^([a-zA-Z0-9\-]+)(,.*)?$")
+# en_GB, sk-SK, cs, fr etc.
+INPUT_LANG_PARSER = re.compile(r"^([a-z]{2}([_\-][A-Z]{2})?)(,.*)?$")
+# characters allowed by Fedora Naming Guidelines
+INPUT_PACKAGE_PARSER = re.compile(r"^([1-9][0-9]*:)?[a-zA-Z0-9\-\.\_\+\~]+$")
+# name-version-arch (fedora-16-x86_64, rhel-6.2-i386, opensuse-12.1-x86_64)
+INPUT_RELEASEID_PARSER = re.compile(r"^[a-zA-Z0-9]+\-[0-9a-zA-Z\.]+\-[a-zA-Z0-9_]+$")
+
+UNITS = ["B", "kB", "MB", "GB", "TB", "PB", "EB"]
+URL_PARSER = re.compile(r"^/([0-9]+)/?")
+
+ARCHIVE_UNKNOWN, ARCHIVE_GZ, ARCHIVE_ZIP, \
+  ARCHIVE_BZ2, ARCHIVE_XZ, ARCHIVE_TAR, \
+  ARCHIVE_7Z, ARCHIVE_LZOP = range(8)
+
+HANDLE_ARCHIVE = {
+    "application/x-xz-compressed-tar": {
+        "unpack": [TAR_BIN, "xJf"],
+        "size": ([XZ_BIN, "--list", "--robot"],
+                 re.compile(r"^totals[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+([0-9]+).*")),
+        "type": ARCHIVE_XZ,
+    },
+
+    "application/x-gzip": {
+        "unpack": [TAR_BIN, "xzf"],
+        "size": ([GZIP_BIN, "--list"], re.compile(r"^[^0-9]*[0-9]+[^0-9]+([0-9]+).*$")),
+        "type": ARCHIVE_GZ,
+    },
+
+    "application/x-tar": {
+        "unpack": [TAR_BIN, "xf"],
+        "size": (["ls", "-l"],
+                 re.compile(r"^[ \t]*[^ ^\t]+[ \t]+[^ ^\t]+[ \t]+[^ ^\t]+[ \t]+[^ ^\t]+[ \t]+([0-9]+).*$")),
+        "type": ARCHIVE_TAR,
+    },
+}
+
+
+def lock(lockfile):
+    try:
+        fd = os.open(lockfile, os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as ex:
+        if ex.errno == errno.EEXIST:
+            return False
+        raise ex
+
+    os.close(fd)
+    return True
+
+
+def unlock(lockfile):
+    try:
+        if os.path.getsize(lockfile) == 0:
+            os.unlink(lockfile)
+    except OSError:
+        return False
+
+    return True
+
+
+def dir_size(path):
+    lines = run([DU_BIN, "-sb", path], stdout=PIPE, encoding='utf-8').stdout.split("\n")
+    for line in lines:
+        match = DU_OUTPUT_PARSER.match(line)
+        if match:
+            return int(match.group(1))
+
+    return 0
+
+
+def free_space(path):
+    lines = run([DF_BIN, "-B", "1", path], stdout=PIPE, encoding='utf-8').stdout.split("\n")
+    for line in lines:
+        match = DF_OUTPUT_PARSER.match(line)
+        if match:
+            return int(match.group(4))
+
+    return None
+
+
+def ftp_init():
+    CONFIG = Config()
+    if CONFIG["FTPSSL"]:
+        ftp = ftplib.FTP_TLS(CONFIG["FTPHost"])
+        ftp.prot_p()
+    else:
+        ftp = ftplib.FTP(CONFIG["FTPHost"])
+
+    ftp.login(CONFIG["FTPUser"], CONFIG["FTPPass"])
+    ftp.cwd(CONFIG["FTPDir"])
+
+    return ftp
+
+
+def ftp_close(ftp):
+    try:
+        ftp.quit()
+    except ftplib.all_errors:
+        ftp.close()
+
+
+def ftp_list_dir(ftpdir="/", ftp=None):
+    close = False
+    if ftp is None:
+        ftp = ftp_init()
+        close = True
+
+    result = [f.lstrip("/") for f in ftp.nlst(ftpdir)]
+
+    if close:
+        ftp_close(ftp)
+
+    return result
+
+
+def human_readable_size(bytesize):
+    size = float(bytesize)
+    unit = 0
+    while size > 1024.0 and unit < len(UNITS) - 1:
+        unit += 1
+        size /= 1024.0
+
+    return "%.2f %s" % (size, UNITS[unit])
+
+
+def parse_http_gettext(lang, charset):
+    result = lambda x: x
+    lang_match = INPUT_LANG_PARSER.match(lang)
+    charset_match = INPUT_CHARSET_PARSER.match(charset)
+    if lang_match and charset_match:
+        try:
+            result = gettext.translation(GETTEXT_DOMAIN,
+                                         languages=[lang_match.group(1)],
+                                         codeset=charset_match.group(1)).gettext
+        except OSError:
+            pass
+
+    return result
+
+
+def parse_rpm_name(name):
+    result = {
+        "epoch": 0,
+        "name": None,
+        "version": "",
+        "release": "",
+        "arch": "",
+    }
+    (result["name"],
+     result["version"],
+     result["release"],
+     result["epoch"],
+     result["arch"]) = splitFilename(name + ".mockarch.rpm")
+
+    return result
+
+
+def response(start_response, status, body="", extra_headers=[]):
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+
+    start_response(status, [("Content-Type", "text/plain"), ("Content-Length", "%d" % len(body))] + extra_headers)
+    return [body]
+
+
+def send_email(frm, to, subject, body):
+    if isinstance(to, list):
+        to = ",".join(to)
+
+    if not isinstance(to, str):
+        raise Exception("'to' must be either string or a list of strings")
+
+    msg = "From: %s\n" \
+          "To: %s\n" \
+          "Subject: %s\n" \
+          "\n" \
+          "%s" % (frm, to, subject, body)
+
+    smtp = smtplib.SMTP("localhost")
+    smtp.sendmail(frm, to, msg)
+    smtp.close()
+
+
+def splitFilename(filename):
+    """
+    Pass in a standard style rpm fullname
+
+    Return a name, version, release, epoch, arch, e.g.::
+        foo-1.0-1.i386.rpm returns foo, 1.0, 1, i386
+    """
+
+    if filename[-4:] == '.rpm':
+        filename = filename[:-4]
+
+    subject = Subject(filename)
+    possible_nevra = list(subject.get_nevra_possibilities(forms=FORM_NEVRA))
+    if possible_nevra:
+        nevra = possible_nevra[0]
+    else:
+        return None, None, None, None, None
+
+    return nevra.name, nevra.version, nevra.release, nevra.epoch, nevra.arch
+
+
+def unpack(archive, mime, targetdir=None):
+    cmd = list(HANDLE_ARCHIVE[mime]["unpack"])
+    cmd.append(archive)
+    if targetdir is not None:
+        cmd.append("--directory")
+        cmd.append(targetdir)
+
+    child = run(cmd)
+    return child.returncode
+
+
+def unpacked_size(archive, mime):
+    command, parser = HANDLE_ARCHIVE[mime]["size"]
+    lines = run(command + [archive], stdout=PIPE, encoding='utf-8').stdout.split("\n")
+    for line in lines:
+        match = parser.match(line)
+        if match:
+            return int(match.group(1))
+
+    return None

--- a/src/settings.wsgi
+++ b/src/settings.wsgi
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 
-from retrace.retrace import (HANDLE_ARCHIVE,
-                             get_active_tasks,
-                             get_supported_releases,
-                             response)
+from retrace.retrace import get_active_tasks, get_supported_releases
 from retrace.config import Config
 from retrace.stats import save_crashstats_reportfull
+from retrace.util import HANDLE_ARCHIVE, response
 
 CONFIG = Config()
 

--- a/src/start.wsgi
+++ b/src/start.wsgi
@@ -3,11 +3,9 @@
 import urllib
 from webob import Request
 
-from retrace.retrace import (URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 

--- a/src/stats.wsgi
+++ b/src/stats.wsgi
@@ -4,12 +4,10 @@ import time
 
 from webob import Request
 
-from retrace.retrace import (STATUS_FAIL,
-                             STATUS_SUCCESS,
-                             parse_http_gettext,
-                             response)
+from retrace.retrace import STATUS_FAIL, STATUS_SUCCESS
 from retrace.plugins import Plugins
 from retrace.stats import init_crashstats_db
+from retrace.util import parse_http_gettext, response
 
 sys.path.insert(0, "/usr/share/retrace-server/")
 

--- a/src/status.wsgi
+++ b/src/status.wsgi
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
 from webob import Request
 
-from retrace.retrace import (STATUS,
-                             URL_PARSER,
-                             parse_http_gettext,
-                             response,
-                             RetraceTask)
+from retrace.retrace import STATUS, RetraceTask
 from retrace.config import Config
+from retrace.util import URL_PARSER, parse_http_gettext, response
 
 CONFIG = Config()
 


### PR DESCRIPTION
The goal of this commit is to free `retrace.py` from stuff that
can be placed elsewhere (`util.py`) and make it more structured.

Most of the moved functions in this commit are never used in `retrace.py`.