### PR TITLE
Replace os.path functions with their pathlib equivalents

### DIFF
--- a/po/retrace-server.pot
+++ b/po/retrace-server.pot
@@ -8,145 +8,165 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-01-02 11:31+0100\n"
+"POT-Creation-Date: 2020-05-27 21:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/backtrace.wsgi:11 ../src/create.wsgi:14 ../src/log.wsgi:11
-#: ../src/status.wsgi:11
+#: ../src/backtrace.wsgi:18 ../src/create.wsgi:55 ../src/log.wsgi:19
+#: ../src/status.wsgi:19
 msgid "You must use HTTPS"
 msgstr ""
 
-#: ../src/backtrace.wsgi:16 ../src/log.wsgi:16 ../src/status.wsgi:16
+#: ../src/backtrace.wsgi:23 ../src/log.wsgi:24 ../src/status.wsgi:24
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/backtrace.wsgi:22 ../src/log.wsgi:21 ../src/status.wsgi:22
+#: ../src/backtrace.wsgi:29 ../src/log.wsgi:29 ../src/status.wsgi:30
 msgid "There is no such task"
 msgstr ""
 
-#: ../src/backtrace.wsgi:27 ../src/log.wsgi:26 ../src/status.wsgi:27
+#: ../src/backtrace.wsgi:34 ../src/log.wsgi:34 ../src/status.wsgi:35
 msgid "Invalid password"
 msgstr ""
 
-#: ../src/backtrace.wsgi:31
+#: ../src/backtrace.wsgi:38
 msgid "There is no backtrace for the specified task"
 msgstr ""
 
-#: ../src/create.wsgi:19 ../src/create.wsgi:70
+#: ../src/create.wsgi:60 ../src/create.wsgi:116
 msgid "Retrace server is fully loaded at the moment"
 msgstr ""
 
-#: ../src/create.wsgi:23
+#: ../src/create.wsgi:64
 msgid "You must use POST method"
 msgstr ""
 
-#: ../src/create.wsgi:27
+#: ../src/create.wsgi:68
 msgid "Specified archive format is not supported"
 msgstr ""
 
-#: ../src/create.wsgi:31
+#: ../src/create.wsgi:72
 msgid "You need to set Content-Length header properly"
 msgstr ""
 
-#: ../src/create.wsgi:35
+#: ../src/create.wsgi:76
 msgid "Specified archive is too large"
 msgstr ""
 
-#: ../src/create.wsgi:47
+#: ../src/create.wsgi:81
+msgid "X-CoreFileDirectory header has been disabled by server administrator"
+msgstr ""
+
+#: ../src/create.wsgi:91
 msgid "Unable to create working directory"
 msgstr ""
 
-#: ../src/create.wsgi:53
+#: ../src/create.wsgi:97
 msgid "Unable to obtain disk free space"
 msgstr ""
 
-#: ../src/create.wsgi:57 ../src/create.wsgi:99
+#: ../src/create.wsgi:101 ../src/create.wsgi:172
 msgid "There is not enough storage space on the server"
 msgstr ""
 
-#: ../src/create.wsgi:63
+#: ../src/create.wsgi:109
 msgid "Unable to create new task"
 msgstr ""
 
-#: ../src/create.wsgi:83
+#: ../src/create.wsgi:121
+msgid "The directory specified in 'X-CoreFileDirectory' does not exist"
+msgstr ""
+
+#: ../src/create.wsgi:127
+#, c-format
+msgid ""
+"There are %d files in the '%s' directory. Only a single archive is supported "
+"at the moment"
+msgstr ""
+
+#: ../src/create.wsgi:136
+#, c-format
+msgid "You header specifies '%s' type, but the file type does not match"
+msgstr ""
+
+#: ../src/create.wsgi:154
 msgid "Unable to save archive"
 msgstr ""
 
-#: ../src/create.wsgi:89
+#: ../src/create.wsgi:162
 msgid "Unable to obtain unpacked size"
 msgstr ""
 
-#: ../src/create.wsgi:94
+#: ../src/create.wsgi:167
 msgid "Specified archive's content is too large"
 msgstr ""
 
-#: ../src/create.wsgi:111
+#: ../src/create.wsgi:184
 msgid "Unable to unpack archive"
 msgstr ""
 
-#: ../src/create.wsgi:123
+#: ../src/create.wsgi:197
 msgid "Symlinks are not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:131
+#: ../src/create.wsgi:204
 #, c-format
 msgid "The '%s' file is larger than expected"
 msgstr ""
 
-#: ../src/create.wsgi:135
+#: ../src/create.wsgi:208
 #, c-format
 msgid "File '%s' is not allowed to be in the archive"
 msgstr ""
 
-#: ../src/create.wsgi:147
+#: ../src/create.wsgi:223
+msgid "Interactive tasks were disabled by server administrator"
+msgstr ""
+
+#: ../src/create.wsgi:232
 #, c-format
 msgid "Required file '%s' is missing"
 msgstr ""
 
-#: ../src/index.wsgi:12
+#: ../src/index.wsgi:20
 msgid "Retrace Server"
 msgstr ""
 
-#: ../src/index.wsgi:13
+#: ../src/index.wsgi:21
 msgid "Welcome to Retrace Server"
 msgstr ""
 
-#: ../src/index.wsgi:15
+#: ../src/index.wsgi:23
 msgid ""
 "Retrace Server is a service that provides the possibility to analyze "
 "coredump and generate backtrace over network. You can find further "
-"information at Retrace Server&apos;s wiki:"
+"information at Retrace Server&apos;s github:"
 msgstr ""
 
-#: ../src/index.wsgi:21
+#: ../src/index.wsgi:29
 msgid ""
 "Only the secure HTTPS connection is now allowed by the server. HTTP requests "
 "will be denied."
 msgstr ""
 
-#: ../src/index.wsgi:23
+#: ../src/index.wsgi:31
 msgid ""
 "Both HTTP and HTTPS are allowed. Using HTTPS is strictly recommended because "
 "of security reasons."
 msgstr ""
 
-#: ../src/index.wsgi:24
+#: ../src/index.wsgi:32
 #, c-format
 msgid "The following releases are supported: %s"
 msgstr ""
 
-#: ../src/index.wsgi:26
-#, c-format
-msgid ""
-"At the moment the server is loaded for %d%% (running %d out of %d jobs)."
-msgstr ""
-
-#: ../src/index.wsgi:27
+#. CONFIG["MaxParallelTasks"], active, CONFIG["MaxParallelTasks"]))
+#: ../src/index.wsgi:36
 #, c-format
 msgid ""
 "Your coredump is only kept on the server while the retrace job is running. "
@@ -158,7 +178,7 @@ msgid ""
 "private data are kept on the server any longer."
 msgstr ""
 
-#: ../src/index.wsgi:33
+#: ../src/index.wsgi:43
 msgid ""
 "Your coredump is only used for retrace purposes. Server administrators are "
 "not trying to get your private data from coredumps or backtraces. Using a "
@@ -167,82 +187,88 @@ msgid ""
 "an insecure channel (such as HTTP)."
 msgstr ""
 
-#: ../src/log.wsgi:30
+#: ../src/index.wsgi:34
+#, c-format
+msgid ""
+"At the moment the server is loaded for %d%% (running %d out of %d jobs)."
+msgstr ""
+
+#: ../src/log.wsgi:38
 msgid "There is no log for the specified task"
 msgstr ""
 
-#: ../src/stats.wsgi:10
+#: ../src/stats.wsgi:36
 msgid "Architecture"
 msgstr ""
 
-#: ../src/stats.wsgi:11
+#: ../src/stats.wsgi:37
 msgid "Architectures"
 msgstr ""
 
-#: ../src/stats.wsgi:12
+#: ../src/stats.wsgi:38
 msgid "Build-id"
 msgstr ""
 
-#: ../src/stats.wsgi:13
+#: ../src/stats.wsgi:39
 msgid "Count"
 msgstr ""
 
-#: ../src/stats.wsgi:14
+#: ../src/stats.wsgi:40
 msgid "Denied jobs"
 msgstr ""
 
-#: ../src/stats.wsgi:15
+#: ../src/stats.wsgi:41
 msgid "Failed"
 msgstr ""
 
-#: ../src/stats.wsgi:16
+#: ../src/stats.wsgi:42
 msgid "First retrace"
 msgstr ""
 
-#: ../src/stats.wsgi:17
+#: ../src/stats.wsgi:43
 msgid "Global statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:18
+#: ../src/stats.wsgi:44
 msgid "Missing build-ids"
 msgstr ""
 
-#: ../src/stats.wsgi:19
+#: ../src/stats.wsgi:45
 msgid "Name"
 msgstr ""
 
-#: ../src/stats.wsgi:20
+#: ../src/stats.wsgi:46
 msgid "Release"
 msgstr ""
 
-#: ../src/stats.wsgi:21
+#: ../src/stats.wsgi:47
 msgid "Releases"
 msgstr ""
 
-#: ../src/stats.wsgi:22
+#: ../src/stats.wsgi:48
 msgid "Required packages"
 msgstr ""
 
-#: ../src/stats.wsgi:23
+#: ../src/stats.wsgi:49
 msgid "Retraced packages"
 msgstr ""
 
-#: ../src/stats.wsgi:24
+#: ../src/stats.wsgi:50
 msgid "Retrace Server statistics"
 msgstr ""
 
-#: ../src/stats.wsgi:25
+#: ../src/stats.wsgi:51
 msgid "Shared object name"
 msgstr ""
 
-#: ../src/stats.wsgi:26
+#: ../src/stats.wsgi:52
 msgid "Successful"
 msgstr ""
 
-#: ../src/stats.wsgi:27
+#: ../src/stats.wsgi:53
 msgid "Total"
 msgstr ""
 
-#: ../src/stats.wsgi:28
+#: ../src/stats.wsgi:54
 msgid "Versions"
 msgstr ""

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
-import os
 import datetime
 import fnmatch
 import re
 import time
 import urllib
 from webob import Request
+from pathlib import Path
 
 from retrace.retrace import (STATUS, STATUS_DOWNLOADING, STATUS_FAIL,
                              STATUS_SUCCESS, TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE,
@@ -602,12 +602,12 @@ def application(environ, start_response):
     available = []
     running = []
     finished = []
-    for taskid in sorted(os.listdir(CONFIG["SaveDir"])):
-        if not os.path.isdir(os.path.join(CONFIG["SaveDir"], taskid)):
+    for taskdir in sorted(Path(CONFIG["SaveDir"]).iterdir()):
+        if not taskdir.is_dir():
             continue
 
         try:
-            task = RetraceTask(taskid)
+            task = RetraceTask(taskdir.name)
         except:
             continue
 
@@ -661,7 +661,7 @@ def application(environ, start_response):
                       "  <td>%s</td>" \
                       "  <td>%s</td>" \
                       "  <td>%s</td>" \
-                      "</tr>" % (status, baseurl, taskid, taskid, caseno, bugzillano, files,
+                      "</tr>" % (status, baseurl, taskdir.name, taskdir.name, caseno, bugzillano, files,
                                  finishtime_str)
 
                 if filterexp and not fnmatch.fnmatch(row, filterexp):
@@ -714,7 +714,7 @@ def application(environ, start_response):
                       "  <td>%s</td>" \
                       "  <td>%s</td>" \
                       "  <td>%s</td>" \
-                      "</tr>" % (baseurl, taskid, taskid, caseno, bugzillano, files, starttime_str,
+                      "</tr>" % (baseurl, taskdir.name, taskdir.name, caseno, bugzillano, files, starttime_str,
                                  status)
 
                 if filterexp and not fnmatch.fnmatch(row, filterexp):
@@ -726,7 +726,7 @@ def application(environ, start_response):
                   "  <td>" \
                   "    <a href=\"%s%s\">%s</a>" \
                   "  </td>" \
-                  "</tr>" % (baseurl, taskid, taskid)
+                  "</tr>" % (baseurl, taskdir.name, taskdir.name)
 
             if filterexp and not fnmatch.fnmatch(row, filterexp):
                 continue

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -4,11 +4,13 @@ Query bugzilla for component bugs and search through comments for trigger words.
 to a log and for tasks found in the comments set bugzillano field with bugzilla ids.
 """
 
-import os
 import sys
 import re
 import time
 import bugzilla
+
+from pathlib import Path
+
 from retrace.retrace import BUGZILLA_STATUS, RetraceTask
 from retrace.config import Config
 
@@ -16,9 +18,9 @@ CONFIG = Config()
 
 if __name__ == "__main__":
 
-    logfile = os.path.join(CONFIG["LogDir"], "bugzilla-query.log")
+    logfile = Path(CONFIG["LogDir"], "bugzilla-query.log")
 
-    with open(logfile, "a") as log:
+    with logfile.open("a") as log:
         log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running bugzilla query\n"))
 
         # connect to bugzilla
@@ -87,18 +89,18 @@ if __name__ == "__main__":
                         found_tasks[f] = [str(bug.bug_id)]
 
         try:
-            files = sorted(os.listdir(CONFIG["SaveDir"]))
+            files = sorted(Path(CONFIG["SaveDir"]).iterdir())
         except OSError as ex:
             files = []
             log.write("Error listing task directory: %s\n" % ex)
 
         # Find all tasks
         existing_tasks = []
-        for taskid in files:
-            if not os.path.isdir(os.path.join(CONFIG["SaveDir"], taskid)):
+        for taskdir in files:
+            if not taskdir.is_dir():
                 continue
 
-            existing_tasks.append(taskid)
+            existing_tasks.append(taskdir.name)
 
         log.write("------------Existing tasks with found bugzillas-----------\n")
         for taskid in found_tasks.keys():

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -4,9 +4,10 @@ Refresh tasks that have bugzilla bugs in an open state to prevent them from gett
 retrace-server-cleanup tool.
 """
 
-import os
 import time
 import bugzilla
+
+from pathlib import Path
 
 from retrace.retrace import RetraceTask
 from retrace.config import Config
@@ -15,9 +16,9 @@ CONFIG = Config()
 
 if __name__ == "__main__":
 
-    logfile = os.path.join(CONFIG["LogDir"], "bugzilla-refresh.log")
+    logfile = Path(CONFIG["LogDir"], "bugzilla-refresh.log")
 
-    with open(logfile, "a") as log:
+    with logfile.open("a") as log:
         log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running bugzilla refresh\n"))
 
         # connect to bugzilla
@@ -44,14 +45,14 @@ if __name__ == "__main__":
             log.write("Not logged in. Continue as anonymous user.\n")
 
         try:
-            files = os.listdir(CONFIG["SaveDir"])
+            files = list(Path(CONFIG["SaveDir"]).iterdir())
         except OSError as ex:
             files = []
             log.write("Error listing task directory: %s\n" % ex)
 
-        for filename in files:
+        for filepath in files:
             try:
-                task = RetraceTask(filename)
+                task = RetraceTask(filepath.name)
             except Exception:
                 continue
 
@@ -64,6 +65,6 @@ if __name__ == "__main__":
 
                 for bgz in bz_list:
                     if bgz and bgz.status not in bz_status_list:
-                        log.write("Modifying time of the task %s\n" % filename)
+                        log.write("Modifying time of the task %s\n" % filepath.name)
                         task.reset_age()
                         break

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -5,6 +5,7 @@ import re
 import time
 
 from subprocess import run, PIPE, STDOUT
+from pathlib import Path
 
 from retrace.retrace import (STATUS_FAIL,
                              get_active_tasks,
@@ -53,7 +54,7 @@ def check_open_crash_file(task):
     if task.has_vmcore():
         crash_path = task.get_vmcore_path()
     elif task.has_coredump():
-        crash_path = os.path.join(task.get_crashdir(), task.COREDUMP_FILE)
+        crash_path = task.get_crashdir() / task.COREDUMP_FILE
     else:
         return False
 
@@ -93,9 +94,9 @@ def check_config():
 if __name__ == "__main__":
     check_config()
 
-    logfile = os.path.join(CONFIG["LogDir"], "cleanup.log")
+    logfile = Path(CONFIG["LogDir"], "cleanup.log")
 
-    with open(logfile, "a") as log:
+    with logfile.open("a") as log:
         log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running cleanup\n"))
 
         # kill tasks running > 1 hour
@@ -152,24 +153,24 @@ if __name__ == "__main__":
         if CONFIG["ArchiveTaskAfter"] > 0:
             # archive old tasks
             try:
-                files = os.listdir(CONFIG["SaveDir"])
+                files = list(Path(CONFIG["SaveDir"]).iterdir())
             except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 
-            for filename in files:
+            for filepath in files:
                 try:
-                    task = RetraceTask(filename)
+                    task = RetraceTask(filepath.name)
                 except Exception:
                     continue
 
                 if task.get_age() >= CONFIG["ArchiveTaskAfter"]:
-                    log.write("Archiving task %s\n" % filename)
-                    if not os.path.isdir(CONFIG["DropDir"]):
-                        os.makedirs(CONFIG["DropDir"])
+                    log.write("Archiving task %s\n" % filepath.name)
+                    dropdir = Path(CONFIG["DropDir"])
+                    if not dropdir.is_dir():
+                        dropdir.mkdir(parents=True)
 
-                    targetfile = os.path.join(CONFIG["DropDir"],
-                                              "%s-%s.tar.gz" % (filename, time.strftime("%Y%m%d%H%M%S")))
+                    targetfile = dropdir / "%s-%s.tar.gz" % (filepath.name, time.strftime("%Y%m%d%H%M%S"))
 
                     child = run(["tar", "czf", targetfile, task.get_savedir()],
                                 stdout=PIPE, stderr=STDOUT)
@@ -177,7 +178,7 @@ if __name__ == "__main__":
                     if child.returncode:
                         log += "Error: tar exited with %d: %s\n" % (child.returncode, stdout)
                         try:
-                            os.unlink(targetfile)
+                            targetfile.unlink()
                         except OSError:
                             pass
 
@@ -188,14 +189,14 @@ if __name__ == "__main__":
         if CONFIG["DeleteTaskAfter"] > 0:
             # clean up old tasks
             try:
-                files = os.listdir(CONFIG["SaveDir"])
+                files = list(Path(CONFIG["SaveDir"]).iterdir())
             except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 
-            for filename in files:
+            for filepath.name in files:
                 try:
-                    task = RetraceTask(filename)
+                    task = RetraceTask(filepath.name)
                 except Exception:
                     continue
 
@@ -204,20 +205,20 @@ if __name__ == "__main__":
                         log.write("Deletion of task %d skipped - crash file is opened.\n" % task.get_taskid())
                         continue
 
-                    log.write("Deleting old task %s\n" % filename)
+                    log.write("Deleting old task %s\n" % filepath.name)
                     task.create_worker().remove_task()
 
         if CONFIG["DeleteFailedTaskAfter"] > 0:
             # clean up old failed tasks
             try:
-                files = os.listdir(CONFIG["SaveDir"])
+                files = list(Path(CONFIG["SaveDir"]).iterdir())
             except OSError as ex:
                 files = []
                 log.write("Error listing task directory: %s\n" % ex)
 
-            for filename in files:
+            for filepath.name in files:
                 try:
-                    task = RetraceTask(filename)
+                    task = RetraceTask(filepath.name)
                 except Exception:
                     continue
 
@@ -226,5 +227,5 @@ if __name__ == "__main__":
                         log.write("Deletion of task %d skipped - crash file is opened.\n" % task.get_taskid())
                         continue
 
-                    log.write("Deleting old failed task %s\n" % filename)
+                    log.write("Deleting old failed task %s\n" % filepath.name)
                     task.create_worker().remove_task()

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -5,6 +5,7 @@ import os
 import pwd
 import sys
 import time
+from pathlib import Path
 from subprocess import list2cmdline
 
 from retrace.retrace import (ALLOWED_FILES,
@@ -98,7 +99,7 @@ if __name__ == "__main__":
             print_cmdline(cmdline)
             os.execvp(cmdline[0], cmdline)
         if args.action == "gdb":
-            with open(os.path.join(task.get_savedir(), "crash", "executable"), "r") as exec_file:
+            with Path(task.get_savedir(), "crash", "executable").open() as exec_file:
                 executable = exec_file.read(ALLOWED_FILES["executable"])
             if "'" in executable or '"' in executable:
                 sys.stderr.write("executable contains forbidden characters.\n")
@@ -154,7 +155,7 @@ if __name__ == "__main__":
                 else:
                     cmdline = task.get_crash_cmd().split() + [vmcore_path, vmlinux]
             else:
-                cfgdir = os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
+                cfgdir = Path(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
                                "shell", "crash -i %s %s %s" % (task.get_crashrc_path(), vmcore_path, vmlinux)]
@@ -168,7 +169,7 @@ if __name__ == "__main__":
         if args.action == "shell":
             if task.has_mock():
                 cmdline = ["/usr/bin/mock", "--configdir",
-                           os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid()), "shell"]
+                           Path(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid()), "shell"]
 
                 print_cmdline(cmdline)
                 os.execvp(cmdline[0], cmdline)

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import sys
-import os
+from pathlib import Path
 from subprocess import run, DEVNULL
 import argparse
 import urllib
@@ -41,7 +41,7 @@ for i, r in enumerate(plugin.repos):
     repo_ok = False
     for p in r:
         path_ok = False
-        mirror_path = p.replace("$VER", args.VERSION).replace("$ARCH", args.ARCHITECTURE)
+        mirror_path = Path(p.replace("$VER", args.VERSION).replace("$ARCH", args.ARCHITECTURE))
         if p.startswith("http:") or p.startswith("https:") or p.startswith("ftp:"):
             try:
                 urllib.request.urlopen(mirror_path)
@@ -52,7 +52,7 @@ for i, r in enumerate(plugin.repos):
             rsync = run(['rsync', '--list-only', mirror_path], stdout=DEVNULL, stderr=DEVNULL)
             path_ok = not rsync.returncode
         else:
-            path_ok = os.path.exists(mirror_path)
+            path_ok = mirror_path.exists()
 
         repo_ok = repo_ok or path_ok
         if verbose:

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -14,6 +14,7 @@ import rpm
 import dnf
 
 from functools import cmp_to_key
+from pathlib import Path
 from subprocess import run, DEVNULL, PIPE
 
 from retrace.retrace import (get_canon_arch,
@@ -51,13 +52,13 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
     with open(dnftmp.name, "r") as f:
         log_debug("Using dnf config from %s\n%s" % (dnftmp.name, f.read()))
 
-    pkgdir = os.path.join(CONFIG["RepoDir"], targetid, "Packages")
-    tmpdir = os.path.join(CONFIG["RepoDir"], "temp", targetid)
-    if not os.path.isdir(tmpdir):
-        os.makedirs(tmpdir)
+    pkgdir = Path(CONFIG["RepoDir"]) / targetid / "Packages"
+    tmpdir = Path(CONFIG["RepoDir"]) / "temp" / targetid
+    if not tmpdir.is_dir():
+        tmpdir.mkdir(parents=True)
 
     try:
-        with open(os.path.join(CONFIG["LogDir"], "reposync_dnf.log"), "a") as dnflog:
+        with open(Path(CONFIG["LogDir"]) / "reposync_dnf.log", "a") as dnflog:
             old_stderr = sys.stderr
             sys.stderr = dnflog
 
@@ -69,8 +70,8 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
                 log_error("Unable to initialize DNF cache")
                 return -1
 
-            cachedir = os.path.join(dnfbase.conf.cachedir, targetid)
-            if os.path.isdir(cachedir):
+            cachedir = Path(dnfbase.conf.cachedir) / targetid
+            if cachedir.is_dir():
                 shutil.rmtree(cachedir)
             dnfbase.read_all_repos()
 
@@ -92,9 +93,9 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
             download = []
 
             for package in packages:
-                rpmname = package.location.rsplit("/", 1)[1]
-                pkgpath = os.path.join(pkgdir, rpmname)
-                if not os.path.isfile(pkgpath) or os.path.getsize(pkgpath) != package.size:
+                rpmname = Path(package.location).name
+                pkgpath = pkgdir / rpmname
+                if not pkgpath.is_file() or pkgpath.stat().st_size != package.size:
                     log_info("%s will be downloaded" % rpmname)
                     download.append(package)
                 else:
@@ -109,30 +110,30 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
                 old_stderr.write("An error occured during download\n%s: %s" % (error, errors[error]))
 
             for package in download:
-                downloadpath = package.localPkg()
-                pkgname = os.path.basename(downloadpath)
-                targetpath = os.path.join(pkgdir, pkgname)
+                downloadpath = Path(package.localPkg())
+                pkgname = downloadpath.name
+                targetpath = pkgdir / pkgname
 
-                if not os.path.isfile(downloadpath):
+                if not downloadpath.is_file():
                     # error message should be listed in errors
                     continue
 
-                if os.path.isfile(targetpath):
-                    os.unlink(targetpath)
+                if targetpath.is_file():
+                    targetpath.unlink()
 
                 try:
-                    os.rename(downloadpath, targetpath)
+                    downloadpath.rename(targetpath)
                 except OSError as ex:
                     if ex.errno != errno.EXDEV:
                         raise
 
                     shutil.copy2(downloadpath, targetpath)
-                    os.unlink(downloadpath)
+                    downloadpath.unlink()
             # END DNF
     finally:
         sys.stderr = old_stderr
         try:
-            os.unlink(dnftmp.name)
+            Path(dnftmp.name).unlink()
             repo = dnfbase.repos[targetid]
             cachedir = Path(repo.basecachedir) / targetid
             shutil.rmtree(cachedir)
@@ -153,26 +154,26 @@ def vercmp(ver1, ver2):
 
 def clean_rawhide_repo(release):
     packages = {}
-    pkgdir = os.path.join(CONFIG["RepoDir"], release, "Packages")
-    for f in os.listdir(pkgdir):
-        if not f.endswith(".rpm"):
+    pkgdir = Path(CONFIG["RepoDir"]) / release / "Packages"
+    for f in pkgdir.iterdir():
+        if f.suffix != ".rpm":
             continue
 
-        pkgdata = parse_rpm_name(f)
+        pkgdata = parse_rpm_name(f.name)
         if not pkgdata["name"]:
             continue
 
         ver = "%s-%s" % (pkgdata["version"], pkgdata["release"])
 
         if not pkgdata["name"] in packages:
-            packages[pkgdata["name"]] = {ver: [f]}
+            packages[pkgdata["name"]] = {ver: [f.name]}
             continue
 
         if ver in packages[pkgdata["name"]]:
-            packages[pkgdata["name"]][ver].append(f)
+            packages[pkgdata["name"]][ver].append(f.name)
             continue
 
-        packages[pkgdata["name"]][ver] = [f]
+        packages[pkgdata["name"]][ver] = [f.name]
 
     for package in packages:
         pkgcnt = len(packages[package])
@@ -183,7 +184,7 @@ def clean_rawhide_repo(release):
                 for filename in packages[package][ver]:
                     if i < pkgcnt - CONFIG["KeepRawhideLatest"]:
                         log_info("Removing %s" % filename)
-                        os.unlink(os.path.join(pkgdir, filename))
+                        (pkgdir / filename).unlink()
                 i += 1
 
 if __name__ == "__main__":
@@ -207,11 +208,11 @@ if __name__ == "__main__":
 
     if CONFIG["UseFafPackages"]:
         log_info("Creating repo from faf")
-        targetid = "%s-%s-%s" % (distribution, version, arch)
-        targetdir = os.path.join(CONFIG["RepoDir"], targetid)
+        targetid = Path("%s-%s-%s" % (distribution, version, arch))
+        targetdir = CONFIG["RepoDir"] / targetid
 
-        if not os.path.isdir(targetdir):
-            os.makedirs(targetdir)
+        if not targetdir.is_dir():
+            targetdir.mkdir(parents=True)
 
         cmd_line = ["retrace-server-reposync-faf", distribution, version, arch,
                     "--outputdir", targetdir]
@@ -246,10 +247,10 @@ if __name__ == "__main__":
         log_error("Unknown distribution: '%s'" % distribution)
         sys.exit(1)
 
-    targetid = "%s-%s-%s" % (distribution, version, arch)
-    lockfile = "/tmp/retrace-reposync-lock-%s" % targetid
+    targetid = Path("%s-%s-%s" % (distribution, version, arch))
+    lockfile = Path("/tmp/retrace-reposync-lock-%s" % targetid)
 
-    if os.path.isfile(lockfile):
+    if lockfile.is_file():
         log_error("Another process with repository download is running")
         sys.exit(2)
 
@@ -263,15 +264,15 @@ if __name__ == "__main__":
         null = DEVNULL
 
     try:
-        targetdir = os.path.join(CONFIG["RepoDir"], targetid)
-        pkgdir = os.path.join(targetdir, "Packages")
+        targetdir = CONFIG["RepoDir"] / targetid
+        pkgdir = targetdir / "Packages"
 
-        if not os.path.isdir(pkgdir):
-            os.makedirs(pkgdir)
+        if not pkgdir.is_dir():
+            pkgdir.mkdir(parents=True)
 
-        for filename in os.listdir(targetdir):
-            if filename.endswith(".rpm"):
-                os.rename(os.path.join(targetdir, filename), os.path.join(pkgdir, filename))
+        for filepath in targetdir.iterdir():
+            if filepath.suffix == ".rpm":
+                filepath.rename(pkgdir / filepath.name)
 
         globaldnfcfg = ""
         if hasattr(plugin, "dnfcfg"):
@@ -304,8 +305,8 @@ if __name__ == "__main__":
                         # folder in FS
                         files = []
                         try:
-                            for package in os.listdir(repourl):
-                                files.append(os.path.join(repourl, package))
+                            for package in Path(repourl).iterdir():
+                                files.append(package)
                         except Exception as ex:
                             log_warn("Download failed: %s" % ex)
                             log_info("Trying another mirror")

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -49,16 +49,16 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
     dnftmp.write(localdnfcfg)
     dnftmp.close()
 
-    with open(dnftmp.name, "r") as f:
+    with Path(dnftmp.name).open("r") as f:
         log_debug("Using dnf config from %s\n%s" % (dnftmp.name, f.read()))
 
-    pkgdir = Path(CONFIG["RepoDir"]) / targetid / "Packages"
-    tmpdir = Path(CONFIG["RepoDir"]) / "temp" / targetid
+    pkgdir = Path(CONFIG["RepoDir"], targetid, "Packages")
+    tmpdir = Path(CONFIG["RepoDir"], "temp", targetid)
     if not tmpdir.is_dir():
         tmpdir.mkdir(parents=True)
 
     try:
-        with open(Path(CONFIG["LogDir"]) / "reposync_dnf.log", "a") as dnflog:
+        with Path(CONFIG["LogDir"], "reposync_dnf.log").open(mode="a") as dnflog:
             old_stderr = sys.stderr
             sys.stderr = dnflog
 
@@ -70,7 +70,7 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
                 log_error("Unable to initialize DNF cache")
                 return -1
 
-            cachedir = Path(dnfbase.conf.cachedir) / targetid
+            cachedir = Path(dnfbase.conf.cachedir, targetid)
             if cachedir.is_dir():
                 shutil.rmtree(cachedir)
             dnfbase.read_all_repos()
@@ -154,7 +154,7 @@ def vercmp(ver1, ver2):
 
 def clean_rawhide_repo(release):
     packages = {}
-    pkgdir = Path(CONFIG["RepoDir"]) / release / "Packages"
+    pkgdir = Path(CONFIG["RepoDir"], release, "Packages")
     for f in pkgdir.iterdir():
         if f.suffix != ".rpm":
             continue

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
-import os
 import createrepo_c as cr
 import shutil
 from argparse import ArgumentParser
+from os.path import relpath
+from pathlib import Path
 from pyfaf.storage import getDatabase
 from pyfaf.queries import get_packages_by_osrelease
 
@@ -19,26 +20,26 @@ def get_pkglist(db, opsys, release, arch):
     for pkg in q:
         if pkg.has_lob("package"):
             print("Adding package: %s-%s-%s" % (pkg.name, pkg.build.version, pkg.build.release))
-            yield os.path.abspath(pkg.get_lob_path("package"))
+            yield Path(pkg.get_lob_path("package")).resolve()
 
 
-def generate_repo(db, outputdir, opsys, release, arch):
+def generate_repo(db, outputdir: Path, opsys, release, arch):
 
-    repodata_path = os.path.join(outputdir, "repodata")
+    repodata_path = outputdir / "repodata"
 
-    if os.path.exists(repodata_path):
+    if repodata_path.exists():
         shutil.rmtree(repodata_path)
 
-    os.makedirs(repodata_path)
+    repodata_path.mkdir(parents=True)
 
     # Prepare metadata files
-    repomd_path = os.path.join(repodata_path, "repomd.xml")
-    pri_xml_path = os.path.join(repodata_path, "primary.xml.gz")
-    fil_xml_path = os.path.join(repodata_path, "filelists.xml.gz")
-    oth_xml_path = os.path.join(repodata_path, "other.xml.gz")
-    pri_db_path = os.path.join(repodata_path, "primary.sqlite")
-    fil_db_path = os.path.join(repodata_path, "filelists.sqlite")
-    oth_db_path = os.path.join(repodata_path, "other.sqlite")
+    repomd_path = repodata_path / "repomd.xml"
+    pri_xml_path = repodata_path / "primary.xml.gz"
+    fil_xml_path = repodata_path / "filelists.xml.gz"
+    oth_xml_path = repodata_path / "other.xml.gz"
+    pri_db_path = repodata_path / "primary.sqlite"
+    fil_db_path = repodata_path / "filelists.sqlite"
+    oth_db_path = repodata_path / "other.sqlite"
 
     pri_xml = cr.PrimaryXmlFile(pri_xml_path)
     fil_xml = cr.FilelistsXmlFile(fil_xml_path)
@@ -58,7 +59,7 @@ def generate_repo(db, outputdir, opsys, release, arch):
     # Process all packages
     for filename in pkg_list:
         pkg = cr.package_from_rpm(filename)
-        pkg.location_href = os.path.relpath(filename, outputdir)
+        pkg.location_href = Path(relpath(filename, outputdir))
         pri_xml.add_pkg(pkg)
         fil_xml.add_pkg(pkg)
         oth_xml.add_pkg(pkg)
@@ -86,7 +87,7 @@ def generate_repo(db, outputdir, opsys, release, arch):
         if path.endswith('.sqlite'):
             new_path = '%s.bz2' % path
             cr.compress_file(path, new_path, cr.BZ2)
-            os.unlink(path)
+            Path(path).unlink()
             path = new_path
 
         record = cr.RepomdRecord(name, path)
@@ -106,7 +107,7 @@ if __name__ == "__main__":
     parser.add_argument("OPSYS")
     parser.add_argument("RELEASE")
     parser.add_argument("ARCHITECTURE")
-    parser.add_argument("--outputdir", default=os.getcwd())
+    parser.add_argument("--outputdir", default=Path.cwd())
     args = parser.parse_args()
 
     print("Creating repo in '%s'" % (args.outputdir))

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -12,6 +12,7 @@ import logging
 import argparse
 import tempfile
 import requests
+from pathlib import Path
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 
@@ -30,20 +31,20 @@ def ticket_check():
 def prepare_tar(args):
     """Create tar file containg all necessary files."""
     LOGGER.info("Preparing tar")
-    corefile = args['COREFILE']
-    tmpdir = tempfile.mkdtemp()
-    tar_name = os.path.join(tmpdir, "archive.tar.gz")
+    corefile = Path(args['COREFILE'])
+    tmpdir = Path(tempfile.mkdtemp())
+    tar_name = tmpdir / "archive.tar.gz"
     tar_file = tarfile.open(tar_name, "w:gz")
     for itm in ["vra", "os_release", "package", "executable"]:
         if itm in args.keys() and args[itm]:
             LOGGER.info("Adding '%s' into tar", format(itm))
-            fl_name = os.path.join(tmpdir, itm)
+            fl_name = tmpdir / itm
             with open(fl_name, "w") as fld:
                 fld.write(args[itm])
             tar_file.add(fl_name, arcname=itm)
 
     LOGGER.info("Adding '%s' as '%s' into tar", corefile, args['task_type'])
-    if not os.path.isfile(corefile):
+    if not corefile.is_file():
         print("'{0}' does not exists".format(corefile))
         sys.exit(1)
 
@@ -51,11 +52,11 @@ def prepare_tar(args):
     tar_file.add(corefile, arcname=file_name)
 
     if args['vmem']:
-        vmem = args['vmem']
+        vmem = Path(args['vmem'])
         vmem_file = args['task_type'] + ".vmem"
         LOGGER.info("Adding '%s' as '%s' into tar", vmem, vmem_file)
 
-        if not os.path.isfile(vmem):
+        if not vmem.is_file():
             print("'{0}' does not exists".format(vmem))
             sys.exit(1)
 
@@ -170,8 +171,8 @@ def create_new_task(args):
 
         LOGGER.info("Task_type: %s", task_type)
 
-        tar_name = prepare_tar(args)
-        tar_size = os.path.getsize(tar_name)
+        tar_name = Path(prepare_tar(args))
+        tar_size = tar_name.stat().st_size
         LOGGER.info("Tar size: %s", tar_size)
 
         headers = {'Content-Type': 'application/x-tar',
@@ -195,7 +196,7 @@ def create_new_task(args):
                            stream=True,
                            verify=(not args['no_verify']))
 
-        shutil.rmtree(os.path.dirname(tar_name))
+        shutil.rmtree(tar_name.parent)
 
         check_response(res)
 
@@ -208,9 +209,9 @@ def create_new_task(args):
         return (task_id, task_password)
 
     elif args['task_input'] == "manager":
-        args['COREFILE'] = "file://" + os.path.abspath(args['COREFILE'])
+        args['COREFILE'] = Path(args['COREFILE']).resolve().as_uri()
         if args['vmem']:
-            args['vmem'] = "file://" + os.path.abspath(args['vmem'])
+            args['vmem'] = Path(args['vmem']).resolve().as_uri()
 
         LOGGER.info("Starting new manager task")
         server = args['server'] + "/manager/"
@@ -621,7 +622,7 @@ if __name__ == "__main__":
     # Try guessing type of task if no specified
     if ARGS['task_action'] in ['create', 'batch'] and not ARGS['task_input']:
         # If the file does not exist locally
-        if not os.path.isfile(ARGS['COREFILE']):
+        if not Path(ARGS['COREFILE']).is_file():
             # and server not know
             if not ARGS['server']:
                 LOGGER.info("Defaulting to ftp task")

--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -1,20 +1,18 @@
 #!/bin/python3
-import os
 import configparser
 from pathlib import Path
 
-MAIN_CONFIG_PATH = "/etc/retrace-server/"
-MAIN_HOOK_CONFIG_FILE = "retrace-server-hooks.conf"
-MAIN_HOOK_CONFIGS_PATH = "/etc/retrace-server/hooks"
+MAIN_CONFIG_PATH = Path("/etc/retrace-server/")
+MAIN_HOOK_CONFIG_FILE = Path("retrace-server-hooks.conf")
+MAIN_HOOK_CONFIGS_PATH = Path("/etc/retrace-server/hooks")
 USER_CONFIG_PATH = Path.home() / ".config/retrace-server/"
 USER_HOOK_CONFIGS_PATH = Path.home() / ".config/retrace-server/hooks"
-HOOK_PATH = "/usr/libexec/retrace-server/hooks/"
+HOOK_PATH = Path("/usr/libexec/retrace-server/hooks/")
 HOOK_TIMEOUT = 300
 
 
-def get_config_files(directory):
-    return [fname for fname in [os.path.abspath(os.path.join(directory, filename.name))
-                                for filename in os.scandir(directory) if filename.name.endswith(".conf")]]
+def get_config_files(directory: Path):
+    return [fname for fname in directory.iterdir() if fname.suffix == '.conf']
 
 
 def load_config_files(config_files):

--- a/src/retrace/plugins.py
+++ b/src/retrace/plugins.py
@@ -16,6 +16,8 @@
 import os
 import sys
 
+from pathlib import Path
+
 
 class Plugins(object):
     class __plugins:
@@ -23,24 +25,24 @@ class Plugins(object):
             self.plugins_read = False
             self.PLUGINS = []
 
-        def load(self, plugin_dir="/usr/share/retrace-server/plugins"):
+        def load(self, plugin_dir=Path("/usr/share/retrace-server/plugins")):
             self.PLUGINS = []
             self.plugins_read = True
             # if environment variable set, use rather that
             env_plugin_dir = os.environ.get('RETRACE_SERVER_PLUGIN_DIR')
             if env_plugin_dir:
-                plugin_dir = env_plugin_dir
-            sys.path.insert(0, plugin_dir)
+                plugin_dir = Path(env_plugin_dir)
+            sys.path.insert(0, str(plugin_dir))
 
             try:
-                files = os.listdir(plugin_dir)
+                files = list(plugin_dir.iterdir())
             except Exception as ex:
                 print("Unable to list directory '%s': %s" % (plugin_dir, ex))
                 raise ImportError(ex)
 
-            for filename in files:
-                if not filename.startswith("_") and filename.endswith(".py"):
-                    pluginname = filename.replace(".py", "")
+            for filepath in files:
+                if not filepath.name.startswith("_") and filepath.suffix == ".py":
+                    pluginname = filepath.stem
                     try:
                         this = __import__(pluginname)
                     except Exception:

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -7,6 +7,7 @@ import smtplib
 
 from dnf.subject import Subject
 from hawkey import FORM_NEVRA
+from pathlib import Path
 from subprocess import run, PIPE
 
 from .config import Config, DF_BIN, GZIP_BIN, TAR_BIN, XZ_BIN
@@ -56,7 +57,7 @@ HANDLE_ARCHIVE = {
 }
 
 
-def lock(lockfile):
+def lock(lockfile: Path):
     try:
         fd = os.open(lockfile, os.O_CREAT | os.O_EXCL, 0o600)
     except OSError as ex:
@@ -68,10 +69,10 @@ def lock(lockfile):
     return True
 
 
-def unlock(lockfile):
+def unlock(lockfile: Path):
     try:
-        if os.path.getsize(lockfile) == 0:
-            os.unlink(lockfile)
+        if lockfile.stat().st_size == 0:
+            lockfile.unlink()
     except OSError:
         return False
 


### PR DESCRIPTION
This PR replaces (mostly) the `path` functions from the `os` module with their equivalents from `pathlib` in a (rather feeble) attempt to make the code more readable, especially awkward constructs lilke 'os.path.join`.  
  
This is probably a lot less useful than I thought originally, so feel free to suggest complete rewrites or just dumping this completely. I figure it might potentially have some sort of an impact in the future if/when stricter type checking is introduced with the [typing module](https://docs.python.org/3/library/typing.html).   
  
Thorough testing is still needed.