### PR TITLE
Add '-y' to autogen.sh option to install dependencies without prompting

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -37,7 +37,7 @@ case "$1" in
 
             if [ "$2" == "--install" ]; then
                 set -x verbose
-                eval sudo dnf install --setopt=strict=0 $DEPS_LIST
+                eval sudo dnf install --setopt=strict=0 $DEPS_LIST -y
                 set +x verbose
             else
                 echo $DEPS_LIST


### PR DESCRIPTION
When a user passes 'sysdeps --install' to autogen.sh this will stop
with a prompt today and there's no way to run unattended.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>