### PR TITLE
Fix manager page ftp submission due to missing check for values

### DIFF
--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -141,14 +141,14 @@ def application(environ, start_response):
             if "vmem-check" in GET:
                 task.add_remote("FTP %s" % GET["custom_vmem_url"])
 
-            if "caseno" in GET:
+            if "caseno" in GET and GET["caseno"]:
                 try:
                     task.set_caseno(int(GET["caseno"]))
                 except:
                     # caseno is invalid number - do nothing, it can be set later
                     pass
 
-            if "bugzillano" in GET:
+            if "bugzillano" in GET and GET["bugzillano"]:
                 try:
                     bugzillano = list(filter(int, set(n.strip() for n in GET["bugzillano"].
                                                       replace(";", ",").split(","))))
@@ -163,7 +163,7 @@ def application(environ, start_response):
         debug = "debug" in GET
         kernelver = None
         arch = None
-        if "kernelver" in GET:
+        if "kernelver" in GET and GET["kernelver"]:
             try:
                 kernelver = KernelVer(GET["kernelver"])
                 if kernelver.arch is None:
@@ -175,7 +175,7 @@ def application(environ, start_response):
             arch = kernelver.arch
             kernelver = str(kernelver)
 
-        if "notify" in GET:
+        if "notify" in GET and GET["notify"]:
             task.set_notify([email for email in set(n.strip() for n in GET["notify"].
                                                     replace(";", ",").split(",")) if email])
 


### PR DESCRIPTION
Commit 53fd9b5 reworked the parsing of manager page and missed
a subtle change for null values.  By default the 'start' method
passes some of the parameters such as 'kernelver' with null values:
start?kernelver=&caseno=&bugzillano=&notify=&debug=on&md5sum=on

This results in the following error message if 'kernelver' is not
filled in:
Please use VRA format for kernel version (e.g. 2.6.32-287.el6.x86_64)

Fix this by checking for null values in kernelver, caseno, and
notify.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>