### PR TITLE
reposync: Stop accessing cachedir attribute of Repo objects

### DIFF
--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -8,6 +8,8 @@ import pwd
 import shutil
 import sys
 import tempfile
+from pathlib import Path
+
 import rpm
 import dnf
 
@@ -131,7 +133,9 @@ def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
         sys.stderr = old_stderr
         try:
             os.unlink(dnftmp.name)
-            shutil.rmtree(dnfbase.repos[targetid].cachedir)
+            repo = dnfbase.repos[targetid]
+            cachedir = Path(repo.basecachedir) / targetid
+            shutil.rmtree(cachedir)
         except Exception as ex:
             log_error("Unable to clean up: %s." % ex)
             return -1


### PR DESCRIPTION
The cachedir property of Repo in DNF was made “private” in
62fcedbf32b9f0419dc4fcb9620860d51f4ffb29, largely due to $REASONS.
Following some more development since then, there is simply no way to
access the cache directory for individual repositories anymore (we
actually have correct code already, but this particular bit was missed).
The solution is to grab the base for cache and concatenate it with the
ID of the repository.