### PR TITLE
Fix group and other permissions on dmesg file

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -934,6 +934,9 @@ class KernelVMcore:
             result = int(match.group(1))
             break
 
+        if os.path.isfile(dmesg_path):
+            os.chmod(dmesg_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+
         self._dump_level = result
         return result
 


### PR DESCRIPTION
The files inside the 'results' directory should be readable by
all users in AuthGroup.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>
Reported-by: Bud Brown <bubrown@redhat.com>