### PR TITLE
Clean up logic for mock and vmcores and add configurable debugger path option

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -133,8 +133,9 @@ UseFafPackages = 0
 # Spool directory for FAF packages
 FafLinkDir = /var/spool/faf
 
-# Run the retrace in a Mock chroot (default), or a Podman container
-# (mock|podman)
+# Run the retrace in a Mock chroot (default), a Podman container,
+# or on the native machine.
+# (mock|podman|native)
 RetraceEnvironment = mock
 
 # Whether to enable e-mail notifications

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -171,6 +171,9 @@ BugzillaRegExes = retrace-server-interact\\s+([0-9]{9}), /var/spool/retrace-serv
 # Timeout (in seconds) for communication with any process
 ProcessCommunicateTimeout = 3600
 
+# Path to the kernel (vmcore) debugger
+KernelDebuggerPath = /usr/bin/crash
+
 [archhosts]
 i386 =
 x86_64 =

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -149,12 +149,7 @@ if __name__ == "__main__":
                                     "Try restarting or resubmitting the task.\n" %
                                     task.get_taskid())
 
-            if not task.has_mock():
-                if task.has_crashrc():
-                    cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), str(vmcore_path), vmlinux]
-                else:
-                    cmdline = task.get_crash_cmd().split() + [str(vmcore_path), vmlinux]
-            else:
+            if task.has_mock():
                 cfgdir = Path(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())
                 if task.has_crashrc():
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
@@ -162,6 +157,11 @@ if __name__ == "__main__":
                 else:
                     cmdline = ["/usr/bin/mock", "--configdir", cfgdir,
                                "shell", "crash %s %s" % (str(vmcore_path), vmlinux)]
+            else:
+                if task.has_crashrc():
+                    cmdline = task.get_crash_cmd().split() + ["-i", task.get_crashrc_path(), str(vmcore_path), vmlinux]
+                else:
+                    cmdline = task.get_crash_cmd().split() + [str(vmcore_path), vmlinux]
 
             print_cmdline(cmdline)
             os.execvp(cmdline[0], cmdline)

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -81,6 +81,7 @@ class Config(object):
             "BugzillaTriggerWords": "",
             "BugzillaRegExes": "",
             "ProcessCommunicateTimeout": 3600,
+            "KernelDebuggerPath": "/usr/bin/crash",
         }
 
         def __getitem__(self, key):

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -80,7 +80,6 @@ class Config(object):
             "BugzillaComponent": "kernel",
             "BugzillaTriggerWords": "",
             "BugzillaRegExes": "",
-            "Crashi386": "",
             "ProcessCommunicateTimeout": 3600,
         }
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1314,7 +1314,10 @@ class RetraceTask:
                 for i in range(CONFIG["TaskPassLength"]):
                     pwdfile.write(generator.choice(TASKPASS_ALPHABET))
 
-            self.set_crash_cmd("crash")
+            cmd = "crash"
+            if CONFIG["KernelDebuggerPath"]:
+                cmd = CONFIG["KernelDebuggerPath"]
+            self.set_crash_cmd(cmd)
             (self._savedir / RetraceTask.RESULTS_DIR).mkdir(parents=True)
             os.umask(oldmask)
         else:
@@ -1602,7 +1605,6 @@ class RetraceTask:
     def set_kernelver(self, value):
         """Atomically writes given value into KERNELVER_FILE."""
         self.set_atomic(RetraceTask.KERNELVER_FILE, str(value))
-        self.set_crash_cmd("crash")
 
     def has_notes(self):
         return self.has(RetraceTask.NOTES_FILE)
@@ -2090,11 +2092,7 @@ class RetraceTask:
 
     def get_crash_cmd(self):
         """Gets the contents of CRASH_CMD_FILE"""
-        result = self.get(RetraceTask.CRASH_CMD_FILE, maxlen=1 << 22)
-        if result is None:
-            self.set_crash_cmd("crash")
-            return "crash"
-        return result
+        return self.get(RetraceTask.CRASH_CMD_FILE, maxlen=1 << 22)
 
     def set_crash_cmd(self, data: str):
         """Writes data to CRASH_CMD_FILE"""

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -884,7 +884,7 @@ class RetraceWorker():
                 raise Exception("Failing task due to crash exiting with non-zero status and "
                                 "small kernellog size = %d bytes" % len(kernellog))
             # If log is 1024 bytes or above, try 'crash --minimal'
-            task.set_crash_cmd("crash --minimal")
+            task.set_crash_cmd(task.get_crash_cmd() + " --minimal")
 
         crashrc_lines = []
 


### PR DESCRIPTION
These patches remove the old set_mock() / get_mock() logic that was used to allow 32-bit crash to run on a 64-bit machine.  This is not used anymore and was fairly ugly code.

In addition, this adds a "native" mode to "RetraceEnvironment" config variable which is the ability to run on the native machine, not in mock or podman.  This mode is used for interactive mode of retrace-server for vmcores, but is not used for userspace coredumps.

Finally, we add a "KernelDebuggerPath" config option.  This allows us to set the path to crash to be some non-system path which we can build and deploy to, and cleans up the hardcoded path.