### PR TITLE
retrace: Add restart to retrace-server-task to restart an existing task

### DIFF
--- a/man/retrace-server-task.txt
+++ b/man/retrace-server-task.txt
@@ -13,6 +13,10 @@ SYNOPSIS
                              [-e EMAIL] [-c CASENO] [-bz BUGZILLANO]
                              COREFILE
 
+'retrace-server-task' restart [-h] [-s SERVER] [-n] [-v]
+                              [-r KERNELVER]
+                              TASK_ID
+
 'retrace-server-task' get [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
                           [-t | -b | -m | -e | -c | -bz]
                           TASK_ID
@@ -24,8 +28,9 @@ SYNOPSIS
 DESCRIPTION
 -----------
 This tool is able to communicate with Retrace server: create a new task,
-get and set values of an existing task. If kerberos ticket is available, all
-communication uses it. To stop using the ticket you must destroy it (kdestroy).
+restart an existing task, get and set values of an existing task. If kerberos
+ticket is available, all communication uses it. To stop using the ticket you
+must destroy it (kdestroy).
 
 OPERATIONS
 ----------
@@ -36,6 +41,10 @@ create::
    If none of the options "-t", "-m", or "-f" are given, the following logic
    is tried. If COREFILE is a local file, then the "-m" option is used,
    otherwise the "-f" option is used.
+
+restart::
+   Restart an existing task. Note that restarting an existing task removes
+   all files inside the 'results' directory.
 
 set::
     Write (set) information on an existing task. Available only for manager
@@ -116,6 +125,13 @@ CREATE OR BATCH OPTIONS
    Force the COREDUMP executable to EXECUTABLE.
    Only valid for userspace cores.
 
+RESTART OPTIONS
+---------------
+
+-k KERNELVER, --kernelver KERNELVER::
+   Force the kernel version in the COREFILE to KERNELVER.
+   Only valid for kernel cores.
+
 GET OPTIONS
 -----------
 
@@ -183,6 +199,14 @@ Write the caseno field for task 925483242 to 01234567
 Write the bugzillano field for task 31415926 to 53589793, 23846264
 
    retrace-server-task set --bugzillano 53589793,23846264 31415926
+
+Restart task 790216008
+
+   retrace-server-task restart 790216008
+
+Restart task 164167944 forcing kernel version to 4.18.0-80.el8.x86_64
+
+   retrace-server-task restart 790216008 --kernelver 4.18.0-80.el8.x86_64
 
 AUTHORS
 -------

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -293,6 +293,9 @@ def application(environ, start_response):
             task = RetraceTask(filename)
         except:
             return response(start_response, "404 Not Found", _("There is no such task"))
+        if not task.has_finished_time() or (task.get_status() != STATUS_SUCCESS and task.get_status() != STATUS_FAIL):
+            return response(start_response, "403 Forbidden",
+                                _("Task is still running, cannot restart"))
 
         debug = "debug" in POST
         kernelver = None

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -150,6 +150,24 @@ def parse_bugzillano(response):
                 return "Bugzilla number is not set."
             return candidate
 
+def restart_existing_task(args):
+    """Restart exiting task."""
+    LOGGER.info("Restarting task from server %s",
+                args['server'] + "/manager/" + args['TASK_ID'])
+    server = args['server'] + "/manager/" + args['TASK_ID'] + "/restart"
+    payload = {}
+    for itm in ["vra", "debug"]:
+        if itm in args.keys():
+            payload[itm] = args[itm]
+    res = requests.post(server,
+                        data=payload,
+                        verify=(not args['no_verify']),
+                        auth=args['kerberos'])
+
+    check_response(res)
+
+    print("Restarted task '{0}'"
+          .format(args['TASK_ID']))
 
 def create_new_task(args):
     """Start new task."""
@@ -602,6 +620,18 @@ if __name__ == "__main__":
     TMP.add_argument("-bz", "--bugzillano",
                      help="Set bugzilla number of the task.")
 
+    TMP = TASK_PARSER.add_parser('restart')
+    TMP.add_argument("TASK_ID",
+                     help="ID of existing task")
+    TMP.add_argument("-s", "--server",
+                     help="URL for retrace-server")
+    TMP.add_argument("-n", "--no-verify", action="store_true",
+                     help="Do not verify certificate")
+    TMP.add_argument("-v", "--verbose", action="store_const",
+                     default=logging.WARNING, const=logging.DEBUG)
+    TMP.add_argument("-r", "--kernelver",
+                     help="Version of kernel in vmcore")
+
     ARGS = vars(PARSER.parse_args())
 
     # if not verifying certificates, suppress warning
@@ -681,3 +711,7 @@ if __name__ == "__main__":
             update_caseno(ARGS)
         if ARGS['bugzillano']:
             update_bugzillano(ARGS)
+
+    if ARGS['task_action'] == "restart":
+        restart_existing_task(ARGS)
+

--- a/src/retrace-server-task.txt
+++ b/src/retrace-server-task.txt
@@ -1,1 +1,0 @@
-../man/retrace-server-task.txt

--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import sys
 import os
+import pwd
 from retrace.argparser import ArgumentParser
 from retrace.retrace import (log_debug,
                              log_error,
@@ -24,6 +25,10 @@ if __name__ == "__main__":
     cmdline = cmdline_parser.parse_args()
 
     log = cmdline._log
+
+    if pwd.getpwnam('retrace').pw_uid != os.getuid():
+        sys.stderr.write("Please use 'retrace-server-task' to restart or create a new task\n")
+        sys.exit(1)
 
     # do not use logging yet - we need the task
     if cmdline.kernelver and not cmdline.arch:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1437,6 +1437,23 @@ class RetraceTask:
 
         return self._start_local(debug=debug, kernelver=kernelver, arch=arch)
 
+    def restart(self, debug=False, kernelver=None, arch=None):
+        cmdline = ["/usr/bin/retrace-server-worker", "%d" % self._taskid]
+        cmdline.append("--restart")
+        if debug:
+            cmdline.append("-v")
+
+        if kernelver is not None:
+            cmdline.append("--kernelver")
+            cmdline.append(kernelver)
+
+        if arch is not None:
+            cmdline.append("--arch")
+            cmdline.append(arch)
+
+        child = run(cmdline)
+        return child.returncode
+
     def chgrp(self, key: Union[str, Path]) -> None:
         gr = grp.getgrnam(CONFIG["AuthGroup"])
         try:

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -114,14 +114,14 @@ class RetraceWorker():
             if task.get_type() in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE] and task.get_status() == STATUS_FAIL:
                 message += "\nIf kernel version detection failed (the log shows 'Unable to determine kernel " \
                            "version'), and you know the kernel version, you may try re-starting the task " \
-                           "with the 'retrace-server-worker --restart' command.  Please check the log below " \
+                           "with the 'retrace-server-task restart' command.  Please check the log below " \
                            "for more information on why the task failed.  The following example assumes " \
                            "the vmcore's kernel version is 2.6.32-358.el6 on x86_64 arch: \n" \
-                           "$ retrace-server-worker --restart --kernelver 2.6.32-358.el6.x86_64 --arch x86_64 %d\n" \
+                           "$ retrace-server-task restart --kernelver 2.6.32-358.el6.x86_64 %d\n" \
                            % task.get_taskid()
                 message += "\nIf this is a test kernel with a non-errata kernel version, or for some reason " \
                            "the kernel-debuginfo repository is unavailable, you can place the kernel-debuginfo RPM " \
-                           "at %s/download/ and restart the task with: \n$ retrace-server-worker --restart %d\n" \
+                           "at %s/download/ and restart the task with: \n$ retrace-server-task restart %d\n" \
                            % (CONFIG["RepoDir"], task.get_taskid())
                 message += "\nIf the retrace-log contains a message similar to 'Failing task due to crash " \
                            "exiting with non-zero status and small kernellog size' then the vmcore may be " \


### PR DESCRIPTION
It makes more sense to use retrace-server-task to restart a task the
same way we create a task.  In this way, we avoid numerous problems
with user credentials such as storing task files with user ownership
as well as issues with extracting kernel-debuginfos.

Fixes https://github.com/abrt/retrace-server/issues/346

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>