### PR TITLE
Add back symlink to retrace-server-task.txt

### DIFF
--- a/src/retrace-server-task.txt
+++ b/src/retrace-server-task.txt
@@ -1,0 +1,1 @@
+../man/retrace-server-task.txt


### PR DESCRIPTION
3f46464be80fecfb2c1cda262f2fdd3ad23f3ac2 removed the symlink to
man/retrace-server-task.txt, which was added to retain compatibility for
Autotools builds.