### PR TITLE
Fix vmware snapshots

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -452,13 +452,13 @@ def get_archive_type(path: Union[str, Path]) -> int:
     log_debug("unknown file type, unpacking finished")
     return ARCHIVE_UNKNOWN
 
-def add_snapshot_suffix(filename: str, snapshot: Path) -> str:
+def add_snapshot_suffix(filename: Path, snapshot: Path) -> str:
     """
     Adds a snapshot suffix to the filename.
     """
     suffix = snapshot.suffix
     if suffix in SNAPSHOT_SUFFIXES:
-        return filename + suffix
+        return filename.with_suffix(suffix)
 
     return filename
 
@@ -468,7 +468,7 @@ def rename_with_suffix(frompath: Path, topath: Path) -> Path:
     # check if the file has a snapshot suffix
     # if it does, keep the suffix
     if not suffix:
-        suffix = add_snapshot_suffix(suffix, frompath)
+        suffix = add_snapshot_suffix(Path(suffix), frompath)
 
     if not topath.suffix == suffix:
         topath = topath.with_suffix(suffix)

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1491,7 +1491,7 @@ class RetraceTask:
                 vmcores = []
                 for filename in files:
                     fname, fext = filename.parent / filename.stem, filename.suffix
-                    if self.VMCORE_FILE in fname and fext != ".vmem":
+                    if str(self.VMCORE_FILE) in filename.stem and filename.suffix != ".vmem":
                         vmcores.append(filename)
 
                 # pick the largest file


### PR DESCRIPTION
This fixes the first two problems with vmware snapshots recently introduced.  The next problem has something to do with one of the two files being renamed / removed and results in the following error:
[2020-07-25 22:37:01] [E] [Errno 2] No such file or directory: '/cores/retrace/tasks/651051598/crash/vmware.vmss' -> '/cores/retrace/tasks/651051598/crash/vmcore/.vmss'