### PR TITLE
retrace: fix timeout exception error message in run_crash_cmdline

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1328,9 +1328,9 @@ class RetraceTask:
                      crash_cmdline.replace('\r', '; ').replace('\n', '; '))
             log_warn("  %s" % err)
         except TimeoutExpired:
-            raise Exception("WARNING: crash command: '%s' exceeded " + str(t) +
-                            " second timeout - damaged vmcore?" %
-                            crash_cmdline.replace('\r', '; ').replace('\n', '; '))
+            raise Exception("WARNING: crash command: '%s' exceeded %s "
+                            " second timeout - damaged vmcore?" % (
+                            crash_cmdline.replace('\r', '; ').replace('\n', '; '), t))
         except Exception as err:
             log_warn("crash command: '%s' triggered Unknown exception %s" %
                      (crash_cmdline.replace('\r', '; ').replace('\n', '; '), err))


### PR DESCRIPTION
Somewhere along the line the Exception string failed to format
properly and the following cryptic error message would be thrown
on a crash command that exceeded ProcessCommunicateTimeout:
  [E] not all arguments converted during string formatting

After this patch we get back the more informative message:
  [E] WARNING: crash command: 'log; quit; ' exceeded 60  second timeout - damaged vmcore?

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>