### PR TITLE
retrace_worker: fix worker.dedup_vmcore due to missing Path.link_to

### DIFF
--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -619,7 +619,7 @@ class RetraceWorker():
 
         v2_link = Path(str(v2) + "-link")
         try:
-            v2_link.link_to(v1)
+            os.link(str(v1), str(v2_link))
         except OSError:
             log_warn("Failed to dedup %s and %s - failed to create hard link from %s to %s" % (v1, v2, v2_link, v1))
             return 0


### PR DESCRIPTION
Commit 8d0469b converted some strings to Path and path methods and
used 'link_to' which is a method added only in Python 3.8.  As a
result, retrace-server-cleanup would backtrace with the following
==> /var/log/retrace-server/cleanup_error.log-20200805 <==
    total_savings += worker.dedup_vmcore(md5_tasks[md5])
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 627, in dedup_vmcore
    v2_link.link_to(v1)
AttributeError: 'PosixPath' object has no attribute 'link_to'
Traceback (most recent call last):
  File "/usr/bin/retrace-server-cleanup", line 145, in <module>
    total_savings += worker.dedup_vmcore(md5_tasks[md5])
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 627, in dedup_vmcore
    v2_link.link_to(v1)
AttributeError: 'PosixPath' object has no attribute 'link_to'

Revert the use of 'Path.link_to()' to the previous 'os.link()',
which is more backward compatible with earlier Python versions such
as 3.6.x

Fixes https://github.com/abrt/retrace-server/issues/357

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>