### PR TITLE
retrace: Open log files with utf-8 encoding

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1078,7 +1078,7 @@ class RetraceTask:
             return None
 
         filename = self._get_file_path(key)
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding='utf-8', errors='replace') as f:
             result = f.read(maxlen)
 
         return result


### PR DESCRIPTION
We do not specify encoding when reading the log file. This causes
https://github.com/abrt/retrace-server/issues/364

I wonder if we should use utf-8 hardcoded or first try the environment settings and fall back to utf-8 if it does not work.

What do you guys think?