### PR TITLE
Fix crash if Kerberos authentication fails

### DIFF
--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -180,8 +180,10 @@ if __name__ == "__main__":
 
         if args.action == "shell":
             if task.has_mock():
-                cmdline = ["/usr/bin/mock", "--configdir",
-                           str(Path(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid())), "shell"]
+                cmdline = ["/usr/bin/mock",
+                           "--configdir",
+                           os.path.join(CONFIG["SaveDir"], "%d-kernel" % task.get_taskid()),
+                           "shell"]
 
                 print_cmdline(cmdline)
                 os.execvp(cmdline[0], cmdline)

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -51,7 +51,7 @@ def redirect_stderr(path):
         finally:
             sys.stderr = _stderr
 
-def sync_using_dnf(targetid, repourl, globaldnfcfg="", localdnfcfg=""):
+def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnfcfg: str = "") -> int:
     dnftmp = tempfile.NamedTemporaryFile(mode="w", delete=False,
                                          prefix="repo", suffix=".conf")
     dnftmp.write(globaldnfcfg)
@@ -236,7 +236,7 @@ if __name__ == "__main__":
         log_error("Unknown distribution: '%s'" % distribution)
         sys.exit(1)
 
-    targetid = Path("%s-%s-%s" % (distribution, version, arch))
+    targetid = "%s-%s-%s" % (distribution, version, arch)
     lockfile = Path("/tmp/retrace-reposync-lock-%s" % targetid)
 
     if lockfile.is_file():

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -21,6 +21,7 @@ from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 from retrace.retrace import add_snapshot_suffix
 
 
+FALLBACK_SERVER = 'https://retrace.fedoraproject.org'
 TASK_RETRACE, TASK_DEBUG, TASK_VMCORE, TASK_RETRACE_INTERACTIVE, \
     TASK_VMCORE_INTERACTIVE = range(5)
 
@@ -674,18 +675,27 @@ if __name__ == "__main__":
                 LOGGER.info("Defaulting to http task")
                 ARGS['task_input'] = 'http'
 
-    # default to local server if no assigned
+    # Default to localhost if no server was specified.
     if not ARGS['server']:
         ARGS['server'] = "https://" + socket.gethostname()
-        try:
-            if requests.get(ARGS['server'],
-                            verify=(not ARGS['no_verify']),
-                            auth=ARGS['kerberos']).status_code != 200:
-                raise requests.exceptions.ConnectionError
-        except requests.exceptions.RequestException:
-            LOGGER.info("Local server '%s' is not available", ARGS['server'])
-            ARGS['server'] = 'https://retrace.fedoraproject.org'
-        LOGGER.info("Trying server '%s'", ARGS['server'])
+
+    # Check that we are able to connect to the server.
+    LOGGER.info("Trying to connect to ‘%s’...", ARGS['server'])
+    try:
+        req = requests.get(ARGS['server'],
+                           verify=(not ARGS['no_verify']),
+                           auth=ARGS['kerberos'])
+        if req.status_code == 401:
+            print("Authentication failed for ‘{}’".format(ARGS['server']))
+            print("If the server requires Kerberos authentication, please use"
+                  " the ‘kinit’ command to obtain a valid ticket first.")
+            sys.exit(1)
+        if req.status_code != 200:
+            raise requests.exceptions.ConnectionError
+    except requests.exceptions.RequestException:
+        LOGGER.info("Could not connect to server ‘%s’. Falling back to ‘%s’",
+                    ARGS['server'], FALLBACK_SERVER)
+        ARGS['server'] = FALLBACK_SERVER
 
     # HACK - kernelver is better to use than vra
     ARGS['vra'] = ARGS.get('kernelver')

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -22,7 +22,7 @@ from retrace.retrace import add_snapshot_suffix
 
 
 TASK_RETRACE, TASK_DEBUG, TASK_VMCORE, TASK_RETRACE_INTERACTIVE, \
-        TASK_VMCORE_INTERACTIVE = range(5)
+    TASK_VMCORE_INTERACTIVE = range(5)
 
 
 def ticket_check() -> bool:
@@ -99,7 +99,7 @@ def parse_status(response) -> str:
     lines = response.text.split("\n")
     for i, line in enumerate(lines):
         if "<th>Status:</th>" in line:
-            return lines[i+1].strip()[4:-5]
+            return lines[i + 1].strip()[4:-5]
     return "unknown"
 
 
@@ -108,7 +108,7 @@ def parse_md5sum(response) -> str:
     lines = response.text.split("\n")
     for line in lines:
         if "<th>Md5sum:</th>" in line:
-            return line[line.find("<td>")+4:]
+            return line[line.find("<td>") + 4:]
     return "Md5sum not calculated. Not yet downloaded or md5sum not requested."
 
 
@@ -118,7 +118,7 @@ def parse_email(response) -> Optional[str]:
     lines = response.text.split("\n")
     for line in lines:
         if key_string in line:
-            first = line.find("value=")+7
+            first = line.find("value=") + 7
             last = line.find('"', first)
             candidate = line[first:last]
             if candidate == key_string:
@@ -133,7 +133,7 @@ def parse_caseno(response) -> Optional[str]:
     lines = response.text.split("\n")
     for line in lines:
         if key_string in line:
-            first = line.find("value=")+7
+            first = line.find("value=") + 7
             last = line.find('"', first)
             candidate = line[first:last]
             if candidate == key_string:
@@ -147,7 +147,7 @@ def parse_bugzillano(response) -> Optional[str]:
     lines = response.text.split("\n")
     for line in lines:
         if key_string in line:
-            first = line.find("value=")+7
+            first = line.find("value=") + 7
             last = line.find('"', first)
             candidate = line[first:last]
             if candidate == key_string:
@@ -189,7 +189,8 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
             task_type = TASK_VMCORE
 
         if args['vmem'] and task_type not in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE]:
-            LOGGER.warning("Ignoring: %s, option is only viable with vmcores.", args['vmem'])
+            LOGGER.warning("Ignoring: %s, option is only viable with vmcores.",
+                           args['vmem'])
             args['vmem'] = None
 
         LOGGER.info("Task_type: %s", task_type)
@@ -204,10 +205,10 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
                    'Connection': 'close'}
 
         req = requests.Request('POST',
-                               args['server']+"/create",
+                               args['server'] + "/create",
                                headers=headers)
 
-        LOGGER.info("Connecting to %s", args['server']+"/create")
+        LOGGER.info("Connecting to %s", args['server'] + "/create")
 
         prepped = req.prepare()
         with open(tar_name, 'rb') as fld:


### PR DESCRIPTION
If `retracer-server-task` cannot connect to the (default) `localhost` server, it falls back to retrace.fedoraproject.org, but does not check if it's able to connect there.

The problem is that it falls back to retrace.fp.org if the connection fails for any reason. Specifically, it falls back even if authentication fails on localhost.

Moreover, if retrace.fp.org is inacessible as well, we get an exception later down the road when trying to send an HTTP request.

In this change, we check if the server responded HTTP 401 Unauthorized, which should be the case if a valaid Kerberos ticket was expected by the server but not sent by the client.

Plus fix some code style issues reported by Pylint.
