### PR TITLE
retrace-server-task: Add options to restart command similar to create

### DIFF
--- a/man/retrace-server-task.txt
+++ b/man/retrace-server-task.txt
@@ -7,23 +7,25 @@ retrace-server-task - Create a task, get and set fields on an existing task
 
 SYNOPSIS
 --------
-'retrace-server-task' create [-h] [-u | -k] [-t | -m | -f] [-i] [-d]
-                             [-s SERVER] [-n] [-v] [--vmem VMEM] [-r KERNELVER]
+'retrace-server-task' create [-h] [-n] [-s SERVER] [-v]
+                             [-u | -k] [-t | -m | -f] [-i] [-d]
+                             [-bz BUGZILLANO] [-c CASENO] [-e EMAIL]
                              [-o OS_RELEASE] [-p PACKAGE] [-x EXECUTABLE]
-                             [-e EMAIL] [-c CASENO] [-bz BUGZILLANO]
+                             [-r KERNELVER]
+                             [--vmem VMEM]
                              COREFILE
 
-'retrace-server-task' restart [-h] [-s SERVER] [-n] [-v]
+'retrace-server-task' restart [-h] [-n] [-s SERVER] [-v]
+                              [-bz BUGZILLANO] [-c CASENO] [-e EMAIL]
                               [-r KERNELVER]
-                              [-e EMAIL] [-c CASENO] [-bz BUGZILLANO]
                               TASK_ID
 
-'retrace-server-task' get [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
-                          [-t | -b | -m | -e | -c | -bz]
+'retrace-server-task' get [-h] [-n] [-p PASSWORD] [-s SERVER] [-v]
+                          [-b | -bz | -c | -e | -m | -t]
                           TASK_ID
 
-'retrace-server-task' set [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
-                          [-c CASENO] [-e EMAIL] [-bz BUGZILLANO]
+'retrace-server-task' set [-h] [-n] [-p PASSWORD] [-s SERVER] [-v]
+                          [-bz BUGZILLANO] [-c CASENO] [-e EMAIL]
                           TASK_ID
 
 DESCRIPTION
@@ -69,22 +71,38 @@ COMMON OPTIONS
 -h, --help::
    Display help and exit.
 
+-n, --no-verify::
+   Do not verify certificate. (off by default)
+
+-p, --password PASSWORD::
+   Password of the task (only for http tasks)
+
 -s, --server SERVER::
    URL for Retrace server. If not specified local server is tried and if not
    available https://retrace.fedoraproject.org/ is used.
-
--n, --no-verify::
-   Do not verify certificate. (off by default)
 
 -v, --verbose::
    Be verbose.  Note this also turns on debug logging for create, batch or
    restart operations.
 
--p, --password PASSWORD::
-   Password of the task (only for http tasks)
-
 CREATE OR BATCH OPTIONS
 -----------------------
+
+-bz BUGZILLANO, --bugzillano BUGZILLANO::
+   Write the bugzillano field in the task to BUGZILLANO.
+   Available only for manager and ftp task.
+
+-c CASENO, --caseno CASENO::
+   Write the caseno field in the task to CASENO.
+   Available only for manager and ftp task.
+
+-e EMAIL, --email EMAIL::
+   Write the email field in the task to EMAIL.
+   Available only for manager and ftp task.
+
+-d, --no-md5::
+   Do not calculate md5sum on the task.
+   Available only for manager and ftp task.
 
 -u, --userspace_core::
    The COREFILE specified is userspace core.
@@ -111,7 +129,7 @@ CREATE OR BATCH OPTIONS
    Virtual memory file VMEM needed for retracing kernel vmcore snapshots.
    Only valid for kernel cores.
 
--k KERNELVER, --kernelver KERNELVER::
+-r KERNELVER, --kernelver KERNELVER::
    Force the kernel version in the COREFILE to KERNELVER.
    Only valid for kernel cores.
 
@@ -167,6 +185,10 @@ GET OPTIONS
 -m, --md5sum::
    Return the md5sum field in the task to the terminal.
    Available only for manager and ftp task.
+
+-t, --status::
+   Return the status field in the task to the terminal.
+   If no option is given, this field is selected as default.
 
 SET OPTIONS
 -----------

--- a/man/retrace-server-task.txt
+++ b/man/retrace-server-task.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 
 'retrace-server-task' restart [-h] [-s SERVER] [-n] [-v]
                               [-r KERNELVER]
+                              [-e EMAIL] [-c CASENO] [-bz BUGZILLANO]
                               TASK_ID
 
 'retrace-server-task' get [-h] [-p PASSWORD] [-s SERVER] [-n] [-v]
@@ -128,8 +129,20 @@ CREATE OR BATCH OPTIONS
 RESTART OPTIONS
 ---------------
 
--k KERNELVER, --kernelver KERNELVER::
-   Force the kernel version in the COREFILE to KERNELVER.
+-bz BUGZILLANO, --bugzillano BUGZILLANO::
+   Write the bugzillano field in the task to BUGZILLANO.
+   Available only for manager and ftp task.
+
+-c CASENO, --caseno CASENO::
+   Write the caseno field in the task to CASENO.
+   Available only for manager and ftp task.
+
+-e EMAIL, --email EMAIL::
+   Write the email field in the task to EMAIL.
+   Available only for manager and ftp task.
+
+-r KERNELVER, --kernelver KERNELVER::
+   Force the kernel version in the task to KERNELVER.
    Only valid for kernel cores.
 
 GET OPTIONS

--- a/man/retrace-server-task.txt
+++ b/man/retrace-server-task.txt
@@ -77,7 +77,8 @@ COMMON OPTIONS
    Do not verify certificate. (off by default)
 
 -v, --verbose::
-   Be verbose
+   Be verbose.  Note this also turns on debug logging for create, batch or
+   restart operations.
 
 -p, --password PASSWORD::
    Password of the task (only for http tasks)

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -248,7 +248,7 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
             payload.update({"custom_vmem_url": args['vmem']})
 
         payload['md5sum'] = 'off' if args['no_md5'] else 'on'
-        for itm in ["vra", "task_type", "os_release", "package", "executable"]:
+        for itm in ["debug", "vra", "task_type", "os_release", "package", "executable"]:
             if itm in args.keys():
                 payload[itm] = args[itm]
 
@@ -263,7 +263,7 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
         LOGGER.info("Starting new ftp task")
         server = args['server'] + "/manager/"
         payload = {'md5sum': 'off' if args['no_md5'] else 'on'}
-        for itm in ["vra", "task_type", "os_release", "package", "executable"]:
+        for itm in ["debug", "vra", "task_type", "os_release", "package", "executable"]:
             if itm in args.keys():
                 payload[itm] = args[itm]
 
@@ -656,6 +656,10 @@ if __name__ == "__main__":
     # create logger
     logging.basicConfig(level=ARGS['verbose'])
     LOGGER = logging.getLogger()
+
+    # If verbose was given, turn on debug for task commands
+    if ARGS['verbose'] != logging.WARNING:
+        ARGS['debug'] = "on"
 
     # check kerberos
     if ticket_check():

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -162,9 +162,11 @@ def restart_existing_task(args: Dict[str, Any]) -> None:
                 args['server'] + "/manager/" + args['TASK_ID'])
     server = args['server'] + "/manager/" + args['TASK_ID'] + "/restart"
     payload = {}
-    for itm in ["vra", "debug"]:
+    for itm in ["vra", "debug", "caseno", "bugzillano"]:
         if itm in args.keys():
             payload[itm] = args[itm]
+    if args['email']:
+        payload['notify'] = args['email']
     res = requests.post(server,
                         data=payload,
                         verify=(not args['no_verify']),
@@ -630,12 +632,18 @@ if __name__ == "__main__":
     TMP = TASK_PARSER.add_parser('restart')
     TMP.add_argument("TASK_ID",
                      help="ID of existing task")
-    TMP.add_argument("-s", "--server",
-                     help="URL for retrace-server")
     TMP.add_argument("-n", "--no-verify", action="store_true",
                      help="Do not verify certificate")
+    TMP.add_argument("-s", "--server",
+                     help="URL for retrace-server")
     TMP.add_argument("-v", "--verbose", action="store_const",
                      default=logging.WARNING, const=logging.DEBUG)
+    TMP.add_argument("-bz", "--bugzillano",
+                     help="Set bugzilla number of the task.")
+    TMP.add_argument("-c", "--caseno",
+                     help="Set case number of the task.")
+    TMP.add_argument("-e", "--email",
+                     help="Set email to the task.")
     TMP.add_argument("-r", "--kernelver",
                      help="Version of kernel in vmcore")
 

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -667,7 +667,11 @@ class RetraceWorker:
 
         task = self.task
         crashdir = task.get_crashdir()
+        task.find_vmcore_file()
+        if not task.get_vmcore_path().is_file():
+            raise Exception("Vmcore file not found at %s" % task.get_vmcore_path())
         vmcore_path = task.get_vmcore_path()
+        log_debug("Task vmcore path: %s" % task.get_vmcore_path())
 
         try:
             self.stats["coresize"] = vmcore_path.stat().st_size


### PR DESCRIPTION
Commit 6bf02a8 implemented a 'restart' option on the retrace-server-task
command, but did not implement all options which would be appropriate
for restart.  Add options options email, caseno, bugzillano, and md5sum.

Since these options are the same as when we 'start' a new task, refactor
the manager code on the backend to avoid parsing duplication.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>