### PR TITLE
retrace-server-reposync: Create cachedir as <RepoDir>/temp

### DIFF
--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -136,7 +136,7 @@ def process_unstrip_output(unstrip: str, dnfbase: dnf.Base) -> Tuple[PackageList
         try:
             # if FILE (parts[2]) is not present on local filesystem
             # eu-unstrip uses FILE as MODULENAME (parts[4])
-            if (binobj_path == '-' or binobj_path == '.') and parts[4] != '[exe]':
+            if (binobj_path in ('-', '.')) and parts[4] != '[exe]':
                 binobj_path = parts[4]
             if binobj_path[0] != '/' and parts[4] != '[exe]':
                 continue

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -17,7 +17,7 @@ PackageList = List[Package]
 
 
 def binary_packages_from_debuginfo_package(debuginfo_package: Package, binobj_path: str,
-        dnfbase: dnf.Base) -> PackageList:
+                                           dnfbase: dnf.Base) -> PackageList:
     """
     Returns a list of packages corresponding to the provided debuginfo
     package. One of the packages in the list contains the binary
@@ -78,8 +78,8 @@ def process_unstrip_entry(build_id: str, binobj_path: str, dnfbase: dnf.Base) ->
     coredump_base_package_list: List[str] = []
     # Ask for a known path from debuginfo package.
     debuginfo_paths = [
-            "/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2], build_id[2:]),
-            "/usr/lib/.build-id/{0}/{1}".format(build_id[:2], build_id[2:])
+        "/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2], build_id[2:]),
+        "/usr/lib/.build-id/{0}/{1}".format(build_id[:2], build_id[2:])
     ]
 
     logger.info("Dnf search for debuginfo packages for build-id %s:", build_id)
@@ -173,7 +173,7 @@ def find_duplicates(package_list: PackageList) -> Union[Tuple[None, None], Tuple
 
 
 def count_removals(package_list: PackageList, base_package_name: str, epoch: str,
-        ver: str, rel: str, arch: str) -> int:
+                   ver: str, rel: str, arch: str) -> int:
     count = 0
     for package in package_list:
         if package.name != base_package_name:

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -229,7 +229,7 @@ def main() -> None:
     # paths
     logger.info("Running eu-unstrip...")
     unstrip_args = ['eu-unstrip', f'--core={args.coredump}', '-n']
-    unstrip_proc = subprocess.run(unstrip_args, stdout=subprocess.PIPE, encoding='utf8')
+    unstrip_proc = subprocess.run(unstrip_args, stdout=subprocess.PIPE, check=False, encoding='utf8')
     unstrip = unstrip_proc.stdout
     logger.info("%s", unstrip)
     if not unstrip:

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -282,7 +282,7 @@ def main() -> None:
                         removal_candidate.release, removal_candidate.arch)
         # Remove the removal_candidate packages from the package list
         for package in package_list[:]:
-            if package.name == removal_candidate.name and 0 == package.evr_cmp(removal_candidate):
+            if package.name == removal_candidate.name and package.evr_cmp(removal_candidate) == 0:
                 package_list.remove(package)
 
     # Clean coredump_package_list:

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -2,6 +2,7 @@
 # Gets list of packages necessary for processing of a coredump.
 # Uses eu-unstrip and dnf.
 
+import sys
 import argparse
 import logging
 import subprocess
@@ -208,7 +209,7 @@ def main() -> None:
     else:
         dnfbase.conf.read()
     if not dnfbase.conf.cachedir:
-        exit(2)
+        sys.exit(2)
     dnfbase.read_all_repos()
     logger.info("Closing all enabled repositories...")
     for repo in dnfbase.repos.iter_enabled():
@@ -232,7 +233,7 @@ def main() -> None:
     unstrip = unstrip_proc.stdout
     logger.info("%s", unstrip)
     if not unstrip:
-        exit(1)
+        sys.exit(1)
 
     package_list, missing_buildid_list, coredump_package_list = process_unstrip_output(unstrip, dnfbase)
 

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -7,10 +7,11 @@ to a log and for tasks found in the comments set bugzillano field with bugzilla 
 import sys
 import re
 import time
-import bugzilla
-from typing import Dict, List, Set
 
+from typing import Dict, List, Set
 from pathlib import Path
+
+import bugzilla
 
 from retrace.retrace import BUGZILLA_STATUS, RetraceTask
 from retrace.config import Config

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -4,6 +4,7 @@ Refresh tasks that have bugzilla bugs in an open state to prevent them from gett
 retrace-server-cleanup tool.
 """
 
+import sys
 import time
 
 from pathlib import Path
@@ -31,7 +32,7 @@ if __name__ == "__main__":
             bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
         except (bugzilla.BugzillaError, ValueError) as e:
             log.write("Exception: {0}".format(e))
-            exit(1)
+            sys.exit(1)
 
         if not bzapi.logged_in and bz_creds:
             bzapi.readconfig(bz_creds)

--- a/src/retrace-server-bugzilla-refresh
+++ b/src/retrace-server-bugzilla-refresh
@@ -5,9 +5,10 @@ retrace-server-cleanup tool.
 """
 
 import time
-import bugzilla
 
 from pathlib import Path
+
+import bugzilla
 
 from retrace.retrace import RetraceTask
 from retrace.config import Config

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -19,16 +19,16 @@ from retrace.config import Config, LSOF_BIN
 CONFIG = Config()
 
 
-def get_process_tree(pid: int, ps_output: List[str]) -> List[int]:
-    result = [pid]
+def get_process_tree(process_id: int, ps_output: List[str]) -> List[int]:
+    result = [process_id]
 
-    parser = re.compile(r"^([0-9]+)[ \t]+(%d).*$" % pid)
+    parser = re.compile(r"^([0-9]+)[ \t]+(%d).*$" % process_id)
 
     for line in ps_output:
         match = parser.match(line)
         if match:
-            pid = int(match.group(1))
-            result.extend(get_process_tree(pid, ps_output))
+            process_id = int(match.group(1))
+            result.extend(get_process_tree(process_id, ps_output))
 
     return result
 
@@ -39,23 +39,23 @@ def kill_process_and_childs(process_id: int, ps_output: Optional[List[str]] = No
     if ps_output is None:
         ps_output = run_ps()
 
-    for pid in get_process_tree(process_id, ps_output):
+    for proc_id in get_process_tree(process_id, ps_output):
         try:
-            os.kill(pid, 9)
+            os.kill(proc_id, 9)
         except OSError:
             result = False
 
     return result
 
 
-def check_open_crash_file(task: RetraceTask) -> bool:
+def check_open_crash_file(retrace_task: RetraceTask) -> bool:
     """
     Check if vmcore or coredump for given task is used by another process.
     """
-    if task.has_vmcore():
-        crash_path = task.get_vmcore_path()
-    elif task.has_coredump():
-        crash_path = task.get_crashdir() / task.COREDUMP_FILE
+    if retrace_task.has_vmcore():
+        crash_path = retrace_task.get_vmcore_path()
+    elif retrace_task.has_coredump():
+        crash_path = retrace_task.get_crashdir() / retrace_task.COREDUMP_FILE
     else:
         return False
 
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         log.write(time.strftime("[%Y-%m-%d %H:%M:%S] Running cleanup\n"))
 
         # kill tasks running > 1 hour
-        ps_output = run_ps()
-        running_tasks = get_running_tasks(ps_output)
+        ps_out = run_ps()
+        running_tasks = get_running_tasks(ps_out)
         for pid, taskid, runtime in running_tasks:
             # do not kill tasks started from task manager
             if CONFIG["AllowTaskManager"]:
@@ -116,7 +116,7 @@ if __name__ == "__main__":
             # ToDo: 5 = mm:ss, >5 = hh:mm:ss
             if len(runtime) > 5:
                 log.write("Killing task %d running for %s\n" % (taskid, runtime))
-                kill_process_and_childs(pid, ps_output)
+                kill_process_and_childs(pid, ps_out)
 
         # kill orphaned tasks
         running_tasks = get_running_tasks()

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -59,7 +59,7 @@ def check_open_crash_file(task: RetraceTask) -> bool:
     else:
         return False
 
-    lsof = run([LSOF_BIN, "+wt", crash_path], stdout=PIPE, encoding='utf-8')
+    lsof = run([LSOF_BIN, "+wt", crash_path], stdout=PIPE, check=False, encoding='utf-8')
     pids = lsof.stdout
 
     if pids:
@@ -174,7 +174,7 @@ if __name__ == "__main__":
                     targetfile = dropdir / ("%s-%s.tar.gz" % (filepath.name, time.strftime("%Y%m%d%H%M%S")))
 
                     child = run(["tar", "czf", str(targetfile), str(task.get_savedir())],
-                                stdout=PIPE, stderr=STDOUT)
+                                stdout=PIPE, stderr=STDOUT, check=False)
                     stdout = child.stdout
                     if child.returncode:
                         log.write("Error: tar exited with %d: %r\n" % (child.returncode, stdout))

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -23,9 +23,9 @@ CONFIG = Config()
 
 ACTIONS = ["shell", "gdb", "crash", "printdir", "delete", "set-success", "set-fail"]
 
-def print_cmdline(cmdline: List[str]):
+def print_cmdline(cmd_line: List[str]):
     sys.stderr.write("If you want to execute the command manually, you can run\n")
-    sys.stderr.write("$ %s\n\n" % list2cmdline(cmdline))
+    sys.stderr.write("$ %s\n\n" % list2cmdline(cmd_line))
 
 if __name__ == "__main__":
     groups = [grp.getgrgid(g).gr_name for g in os.getgroups()]

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                     raise Exception("Unable to determine crash command")
                 if task.has_crashrc():
                     cmdline = crash_cmd.split() + ["-i", str(task.get_crashrc_path()),
-                            str(vmcore_path), vmlinux]
+                                                   str(vmcore_path), vmlinux]
                 else:
                     cmdline = crash_cmd.split() + [str(vmcore_path), vmlinux]
 

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -13,13 +13,13 @@ def main() -> None:
     argparser.add_argument("VERSION", type=str, help="Release version")
     argparser.add_argument("ARCHITECTURE", type=str, help="CPU architecture")
     argparser.add_argument("--plugin-dir", default="/usr/share/retrace-server/plugins",
-                        help="Path to plugins.")
+                           help="Path to plugins.")
     argparser.add_argument("--only-valid", action='store_true',
-                        help="Print only valid mirrors")
+                           help="Print only valid mirrors")
     argparser.add_argument("--only-invalid", action='store_true',
-                        help="Print only invalid mirrors")
+                           help="Print only invalid mirrors")
     argparser.add_argument("--first-valid", action='store_true',
-                        help="Print first valid mirror per repository.")
+                           help="Print first valid mirror per repository.")
 
     args = argparser.parse_args()
 

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -47,7 +47,7 @@ def main() -> None:
                 try:
                     urllib.request.urlopen(mirror_path)
                     path_ok = True
-                except Exception as ex:
+                except Exception:
                     pass
             elif p.startswith("rsync:"):
                 rsync = run(['rsync', '--list-only', mirror_path], stdout=DEVNULL, stderr=DEVNULL, check=False)

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -50,7 +50,7 @@ def main() -> None:
                 except Exception as ex:
                     pass
             elif p.startswith("rsync:"):
-                rsync = run(['rsync', '--list-only', mirror_path], stdout=DEVNULL, stderr=DEVNULL)
+                rsync = run(['rsync', '--list-only', mirror_path], stdout=DEVNULL, stderr=DEVNULL, check=False)
                 path_ok = not rsync.returncode
             else:
                 path_ok = os.path.exists(mirror_path)

--- a/src/retrace-server-plugin-checker
+++ b/src/retrace-server-plugin-checker
@@ -62,7 +62,7 @@ def main() -> None:
                 if args.first_valid and path_ok:
                     print(mirror_path)
                     break
-                elif args.only_valid and path_ok:
+                if args.only_valid and path_ok:
                     print(mirror_path)
                 elif args.only_invalid and not path_ok:
                     print(mirror_path)

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -68,7 +68,7 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
 
     tmpdir.mkdir(parents=True, exist_ok=True)
 
-    with redirect_stderr(Path(CONFIG["LogDir"], "reposync_dnf.log")) as (old_stderr, new_stderr):
+    with redirect_stderr(Path(CONFIG["LogDir"], "reposync_dnf.log")) as (old_stderr, _):
         # BEGIN DNF
         dnfbase = dnf.Base()
         dnfbase.conf.read(filename=dnftmp.name)

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -50,18 +50,18 @@ def redirect_stderr(path):
         finally:
             sys.stderr = _stderr
 
-def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnfcfg: str = "") -> int:
+def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "", local_dnf_cfg: str = "") -> int:
     dnftmp = tempfile.NamedTemporaryFile(mode="w", delete=False,
                                          prefix="repo", suffix=".conf")
-    dnftmp.write(globaldnfcfg)
-    dnftmp.write(localdnfcfg)
+    dnftmp.write(global_dnf_cfg)
+    dnftmp.write(local_dnf_cfg)
     dnftmp.close()
 
     with Path(dnftmp.name).open("r") as f:
         log_debug("Using dnf config from %s\n%s" % (dnftmp.name, f.read()))
 
-    pkgdir = Path(CONFIG["RepoDir"], targetid, "Packages")
-    cachedir = Path(CONFIG["RepoDir"], "temp", targetid)
+    pkg_dir = Path(CONFIG["RepoDir"], target_id, "Packages")
+    cachedir = Path(CONFIG["RepoDir"], "temp", target_id)
 
     if cachedir.is_dir():
         shutil.rmtree(cachedir)
@@ -75,7 +75,7 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
 
         dnfbase.conf.cachedir = cachedir
 
-        dnfbase.repos.add_new_repo(targetid, dnfbase.conf, baseurl=[repourl])
+        dnfbase.repos.add_new_repo(target_id, dnfbase.conf, baseurl=[repo_url])
 
         try:
             # Fill the sack with repository packages
@@ -87,12 +87,12 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
 
         download = []
 
-        for package in dnfbase.sack.query():
-            rpmname = Path(package.location).name
-            pkgpath = Path(pkgdir) / rpmname
-            if not pkgpath.is_file() or pkgpath.stat().st_size() != package.size:
+        for pkg in dnfbase.sack.query():
+            rpmname = Path(pkg.location).name
+            pkgpath = Path(pkg_dir) / rpmname
+            if not pkgpath.is_file() or pkgpath.stat().st_size() != pkg.size:
                 log_info("%s will be downloaded" % rpmname)
-                download.append(package)
+                download.append(pkg)
             else:
                 log_debug("%s is already downloaded, skipping" % rpmname)
 
@@ -101,9 +101,9 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
         except dnf.exceptions.DownloadError as ex:
             print("Some errors occurred during download:\n%s" % ex, file=old_stderr)
 
-        for package in download:
-            downloadpath = Path(package.localPkg())
-            targetpath = pkgdir / downloadpath.name
+        for pkg in download:
+            downloadpath = Path(pkg.localPkg())
+            targetpath = pkg_dir / downloadpath.name
 
             if not downloadpath.is_file():
                 # error message should be listed in errors
@@ -133,17 +133,17 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
 
 def vercmp(ver1, ver2):
     # ToDo: Involve epoch?
-    version, release = ver1.split("-", 1)
-    first = (None, version, release)
-    version, release = ver2.split("-", 1)
-    second = (None, version, release)
+    ver, rel = ver1.split("-", 1)
+    first = (None, ver, rel)
+    ver, rel = ver2.split("-", 1)
+    second = (None, ver, rel)
 
     return rpm.labelCompare(first, second)
 
 def clean_rawhide_repo(release):
     packages = {}
-    pkgdir = Path(CONFIG["RepoDir"], release, "Packages")
-    for f in pkgdir.iterdir():
+    pkg_dir = Path(CONFIG["RepoDir"], release, "Packages")
+    for f in pkg_dir.iterdir():
         if f.suffix != ".rpm":
             continue
 
@@ -163,17 +163,15 @@ def clean_rawhide_repo(release):
 
         packages[pkgdata["name"]][ver] = [f.name]
 
-    for package in packages:
-        pkgcnt = len(packages[package])
+    for pkg in packages:
+        pkgcnt = len(packages[pkg])
         if pkgcnt > CONFIG["KeepRawhideLatest"]:
             vers = sorted(packages[package].keys(), key=cmp_to_key(vercmp))
-            i = 0
-            for ver in vers:
-                for filename in packages[package][ver]:
-                    if i < pkgcnt - CONFIG["KeepRawhideLatest"]:
+            for n, ver in enumerate(vers):
+                for filename in packages[pkg][ver]:
+                    if n < pkgcnt - CONFIG["KeepRawhideLatest"]:
                         log_info("Removing %s" % filename)
-                        (pkgdir / filename).unlink()
-                i += 1
+                        (pkg_dir / filename).unlink()
 
 if __name__ == "__main__":
     # parse arguments

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -66,7 +66,7 @@ def sync_using_dnf(targetid: str, repourl: str, globaldnfcfg: str = "", localdnf
     if cachedir.is_dir():
         shutil.rmtree(cachedir)
 
-    tmpdir.mkdir(parents=True, exist_ok=True)
+    cachedir.mkdir(parents=True, exist_ok=True)
 
     with redirect_stderr(Path(CONFIG["LogDir"], "reposync_dnf.log")) as (old_stderr, _):
         # BEGIN DNF

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -15,7 +15,6 @@ import rpm
 import dnf
 
 from functools import cmp_to_key
-from pathlib import Path
 from subprocess import run, DEVNULL, PIPE
 
 from retrace.retrace import (get_canon_arch,

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -204,7 +204,7 @@ if __name__ == "__main__":
 
         cmd_line = ["retrace-server-reposync-faf", distribution, version, arch,
                     "--outputdir", targetdir]
-        child = run(cmd_line, stdout=PIPE, stderr=PIPE, encoding="utf-8")
+        child = run(cmd_line, stdout=PIPE, stderr=PIPE, encoding="utf-8", check=False)
         if child.returncode:
             log_error("Could not create faf repo")
             log_debug(child.stdout)
@@ -300,7 +300,8 @@ if __name__ == "__main__":
                             log_info("Trying another mirror")
                             continue
 
-                    retcode = run(["rsync", "-t"] + files + [pkgdir], stdout=null, stderr=null).returncode
+                    retcode = run(["rsync", "-t"] + files + [pkgdir],
+                                  stdout=null, stderr=null, check=False).returncode
 
                 if retcode == 0:
                     log_info("Download succeeded")
@@ -323,7 +324,7 @@ if __name__ == "__main__":
         if CONFIG["UseCreaterepoUpdate"]:
             cmd.append("--update")
 
-        retcode = run(cmd, stdout=null, stderr=null).returncode
+        retcode = run(cmd, stdout=null, stderr=null, check=False).returncode
     finally:
         unlock(lockfile)
 

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -9,13 +9,13 @@ import pwd
 import shutil
 import sys
 import tempfile
+
+from functools import cmp_to_key
 from pathlib import Path
+from subprocess import run, DEVNULL, PIPE
 
 import rpm
 import dnf
-
-from functools import cmp_to_key
-from subprocess import run, DEVNULL, PIPE
 
 from retrace.retrace import (get_canon_arch,
                              log_debug,

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -76,6 +76,7 @@ def generate_repo(db: Database, outputdir: Path, opsys: str, release: str, arch:
     repomd = cr.Repomd()
 
     # Add records into the repomd.xml
+    #pylint: disable=bad-whitespace
     repomdrecords = (("primary",      pri_xml_path, pri_db),
                      ("filelists",    fil_xml_path, fil_db),
                      ("other",        oth_xml_path, oth_db),

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -94,7 +94,7 @@ def generate_repo(db: Database, outputdir: Path, opsys: str, release: str, arch:
         record = cr.RepomdRecord(name, str(path))
         record.fill(cr.SHA256)
         record.rename_file()
-        if (db_to_update):
+        if db_to_update:
             db_to_update.dbinfo_update(record.checksum)
             db_to_update.close()
         repomd.set_record(record)

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -233,7 +233,7 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
         print("Task password: {0}".format(task_password))
         return (task_id, task_password)
 
-    elif args['task_input'] == "manager":
+    if args['task_input'] == "manager":
         args['COREFILE'] = Path(args['COREFILE']).resolve().as_uri()
         if args['vmem']:
             args['vmem'] = Path(args['vmem']).resolve().as_uri()
@@ -435,9 +435,9 @@ def get_backtrace(args: Dict[str, Any]) -> bool:
         if res.text == "There is no backtrace for the specified task":
             print("No backtrace. Check status if task is running or failed.")
             return False
-        else:
-            print("Error: {0}".format(res.text))
-            sys.exit(1)
+
+        print("Error: {0}".format(res.text))
+        sys.exit(1)
 
     with open("backtrace", "w") as fld:
         fld.write(res.text)

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -730,4 +730,3 @@ if __name__ == "__main__":
 
     if ARGS['task_action'] == "restart":
         restart_existing_task(ARGS)
-

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -205,13 +205,13 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
                    'X-Task-Type': str(task_type),
                    'Connection': 'close'}
 
-        req = requests.Request('POST',
-                               args['server'] + "/create",
-                               headers=headers)
+        request = requests.Request('POST',
+                                   args['server'] + "/create",
+                                   headers=headers)
 
         LOGGER.info("Connecting to %s", args['server'] + "/create")
 
-        prepped = req.prepare()
+        prepped = request.prepare()
         with open(tar_name, 'rb') as fld:
             prepped.body = fld.read(tar_size)
 

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -12,9 +12,9 @@ import logging
 import argparse
 import tempfile
 from typing import Any, Dict, Optional, Tuple
+from pathlib import Path
 
 import requests
-from pathlib import Path
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 


### PR DESCRIPTION
The `tmpdir` variable was accidentally left unchanged in [b6400d45](https://github.com/abrt/retrace-server/commit/b6400d45d6b94445840f40cbf1ce0b00c2b1f398), resulting in an error when trying to create the `temp` directory under `RepoDir`.  
  
Also, resolve some pylint issues.