### PR TITLE
dockerfile: Fix build stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,12 @@
 FROM fedora:32
 USER root
-RUN dnf --assumeyes install git-core make tito
-COPY . /src
-WORKDIR /src
-RUN \
-    dnf --assumeyes builddep --spec retrace-server.spec && \
+RUN dnf --assumeyes install git-core make tito && \
+    git clone --quiet https://github.com/abrt/retrace-server.git /src && \
+    dnf --assumeyes builddep --spec /src/retrace-server.spec && \
     useradd --no-create-home builder && \
-    chown --recursive --quiet builder. .
+    chown --recursive --quiet builder:builder /src
 USER builder
+WORKDIR /src
 RUN tito build --output=rpm --rpm --test
 
 FROM fedora:32 as build


### PR DESCRIPTION
With `COPY . /src` in the `Dockerfile` it assumed that `origin`
was pointing to `https://github.com/abrt/retrace-server.git`.

If that wasn't true (like in my case, `origin=git@github.com:abrt/retrace-server.git`)
tito build didn't have permissions (ssh key) to check the remote repo
and failed with Tag does not exist in remote git repo.