### PR TITLE
Remove mentions of unsupported autogen option from documentation

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -10,9 +10,9 @@
 
         $ ./autogen.sh sysdeps
 
-    or installed by (two versions based on your package manager):
+    or installed by:
 
-        $ ./autogen.sh sysdeps --install-dnf
+        $ ./autogen.sh sysdeps --install
 
     The dependency installer gets the data from [the rpm spec file](retrace-server.spec.in)
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,7 +11,7 @@ Usage:
 Options:
 
   sysdeps              prints out all dependencies
-    --install-dnf      install all dependencies ('sudo dnf install \$DEPS')
+    --install          install all dependencies ('sudo dnf install \$DEPS')
 
 EOH
 }


### PR DESCRIPTION
`autogen.sh` does not support the `--install-dnf` option, don't mention it in the documentation.