### PR TITLE
Rework manager page

### DIFF
--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -13,6 +13,23 @@ CONFIG = Config()
 MANAGER_URL_PARSER = re.compile(r"^(.*/manager)(/(([^/]+)(/(__custom__|start|backtrace|savenotes|"
                                 r"caseno|notify|delete(/(sure/?)?)?|results/([^/]+)/?)?)?)?)?$")
 tableheader = """
+<head>
+<style>
+table {
+  width: 100%;
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+table td {
+  border: 1px solid black;
+  padding: 2px 4px;
+}
+table th {
+  background-color: #ccc;
+}
+</style>
+</head>
+<body>
           <table>
             <tr>
               <th class="tablename">FTP files</th>
@@ -20,6 +37,7 @@ tableheader = """
 """
 tablefooter = """
           </table>
+</body>
 """
 
 def async_ftp_list_dir(filterexp):
@@ -50,6 +68,7 @@ def application(environ, start_response):
         filterexp = get["filterexp"][0]
 
     output = ""
+    output += "<h2><a href=\"manager\">%s</a></h2>" % "Back to task manager"
     output += tableheader
     output += async_ftp_list_dir(filterexp)
     output += tablefooter

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -929,25 +929,6 @@ def application(environ, start_response):
     if CONFIG["CalculateMd5"]:
         md5_enabled = 'checked="checked"'
 
-    if CONFIG["UseFTPTasks"]:
-        starturl = "ftp"
-        qs = {}
-        if filterexp:
-            qs["filterexp"] = filterexp
-
-        qs_text = urllib.parse.urlencode(qs)
-
-        if qs_text:
-            starturl = "\"%s?%s\"" % (starturl, qs_text)
-        else:
-            starturl = "\"" + starturl + "\""
-
-        ftpcallback = ftpcallback.replace("<URL>", "url: %s," %(starturl))
-        output = output.replace("{ftpscript}", ftpcallback)
-    else:
-        output = output.replace("{ftpscript}", "")
-        available_str = _("FTP files")
-
     custom_url = "%s/__custom__" % match.group(1)
 
     vmcore_form = ""

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -6,7 +6,7 @@ import time
 import urllib
 from webob import Request
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from retrace.retrace import (STATUS, STATUS_DOWNLOADING, STATUS_FAIL,
                              STATUS_SUCCESS, TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE,
@@ -118,6 +118,68 @@ def get_start_content_calc_md5() -> str:
         md5sum_enabled = "checked=\"checked\""
     return "      <input type=\"checkbox\" name=\"md5sum\" id=\"md5sum\" %s />" \
            "Calculate md5 checksum for all downloaded resources<br />" % md5sum_enabled
+
+def get_available_table(rows: List) -> str:
+    if len(rows) <= 0:
+        return ""
+    table_str = "<div id=\"available\"> " \
+                "  <table> " \
+                "    <tr> " \
+                "       <th colspan=\"1\" class=\"tablename\">Available tasks</th> " \
+                "    </tr>" \
+                "    <tr>"  \
+                "       <th class=\"taskid\">Task ID</th> " \
+                "    </tr> "
+    for r in rows:
+        table_str += r
+    table_str += "      </th> "\
+                 "    </tr> " \
+                 "  </table> " \
+                 "</div>"
+    return table_str
+
+def get_running_table(rows: List) -> str:
+    if len(rows) <= 0:
+        return ""
+    table_str = "<div id=\"running\"> " \
+                "   <table> " \
+                "       <tr>" \
+                "           <th colspan=\"6\" class=\"tablename\">Running tasks</th> " \
+                "       </tr>" \
+                "       <tr>"  \
+                "           <th class=\"taskid\">Task ID</th> " \
+                "           <th class=\"caseno\">Case no.</th>" \
+                "           <th class=\"bugzillano\">Bugzilla no.</th>" \
+                "           <th>File(s)</th> " \
+                "           <th class=\"timestamp\">Started</th>" \
+                "           <th class=\"status\">Status</th>" \
+                "       </tr> "
+    for r in rows:
+        table_str += r
+    table_str += "   </table>" \
+                 "</div>"
+    return table_str
+
+def get_finished_table(rows: List) -> str:
+    if len(rows) <= 0:
+        return ""
+    table_str = "<div id=\"finished\"> " \
+                "   <table> " \
+                "       <tr>" \
+                "           <th colspan=\"5\" class=\"tablename\">Finished tasks</th> " \
+                "       </tr>" \
+                "       <tr>"  \
+                "           <th class=\"taskid\">Task ID</th> " \
+                "           <th class=\"caseno\">Case no.</th>" \
+                "           <th class=\"bugzillano\">Bugzilla no.</th>" \
+                "           <th>File(s)</th> " \
+                "           <th class=\"timestamp\">Finished</th>" \
+                "       </tr> "
+    for r in rows:
+        table_str += r
+    table_str += "   </table>" \
+                 "</div>"
+    return table_str
 
 def application(environ, start_response):
     request = Request(environ)
@@ -855,9 +917,6 @@ def application(environ, start_response):
     finished = [f[1] for f in sorted(finished, key=lambda x: x[0], reverse=True)]
     running = [r[1] for r in sorted(running, key=lambda x: x[0], reverse=True)]
 
-    available_str = _("Available tasks")
-    running_str = _("Running tasks")
-    finished_str = _("Finished tasks")
     taskid_str = _("Task ID")
     caseno_str = _("Case no.")
     bugzillano_str = _("Bugzilla no.")
@@ -904,21 +963,10 @@ def application(environ, start_response):
     output = output.replace("{usrcore_task_form}", usrcore_form)
 
     output = output.replace("{title}", title)
-    output = output.replace("{available_str}", available_str)
-    output = output.replace("{running_str}", running_str)
-    output = output.replace("{finished_str}", finished_str)
-    output = output.replace("{taskid_str}", taskid_str)
-    output = output.replace("{caseno_str}", caseno_str)
-    output = output.replace("{bugzillano_str}", bugzillano_str)
-    output = output.replace("{files_str}", files_str)
-    output = output.replace("{starttime_str}", starttime_str)
-    output = output.replace("{finishtime_str}", finishtime_str)
-    output = output.replace("{status_str}", status_str)
+    output = output.replace("{available_table}", get_available_table(available))
+    output = output.replace("{running_table}", get_running_table(running))
+    output = output.replace("{finished_table}", get_finished_table(finished))
     output = output.replace("{create_custom_url}", custom_url)
-    # spaces to keep the XML nicely aligned
-    output = output.replace("{running}", "\n            ".join(running))
-    output = output.replace("{finished}", "\n            ".join(finished))
     output = output.replace("{md5_enabled}", md5_enabled)
-
 
     return response(start_response, "200 OK", output, [("Content-Type", "text/html")])

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -708,7 +708,6 @@ def application(environ, start_response):
         output = f.read(1 << 20) # 1MB
 
     title = _("Retrace Server Task Manager")
-    sitename = _("Retrace Server Task Manager")
 
     baseurl = request.path_url
     if not baseurl.endswith("/"):
@@ -905,7 +904,6 @@ def application(environ, start_response):
     output = output.replace("{usrcore_task_form}", usrcore_form)
 
     output = output.replace("{title}", title)
-    output = output.replace("{sitename}", sitename)
     output = output.replace("{available_str}", available_str)
     output = output.replace("{running_str}", running_str)
     output = output.replace("{finished_str}", finished_str)

--- a/src/manager.xhtml
+++ b/src/manager.xhtml
@@ -15,6 +15,11 @@
                 float: right;
             }
 
+            #task_tables {
+                width: 100%;
+                float: left;
+            }
+
             #available {
 
             }
@@ -203,47 +208,10 @@
         {vmcore_task_form}
         {usrcore_task_form}
         <div id="main">
-            <div id="right">
-                <div id="running">
-                    <table>
-                        <tr>
-                            <th colspan="6" class="tablename">{running_str}</th>
-                        </tr>
-                        <tr>
-                            <th class="taskid">{taskid_str}</th>
-                            <th class="caseno">{caseno_str}</th>
-                            <th class="bugzillano">{bugzillano_str}</th>
-                            <th>{files_str}</th>
-                            <th class="timestamp">{starttime_str}</th>
-                            <th class="status">{status_str}</th>
-                        </tr>
-                        {running}
-                    </table>
-                </div>
-                <div id="available">
-                    <table>
-                        <tr>
-                            <th class="tablename">{available_str}</th>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <div id="left">
-                <div id="finished">
-                    <table>
-                        <tr>
-                            <th colspan="5" class="tablename">{finished_str}</th>
-                        </tr>
-                        <tr>
-                            <th class="taskid">{taskid_str}</th>
-                            <th class="caseno">{caseno_str}</th>
-                            <th class="bugzillano">{bugzillano_str}</th>
-                            <th>{files_str}</th>
-                            <th class="timestamp">{finishtime_str}</th>
-                        </tr>
-                        {finished}
-                    </table>
-                </div>
+            <div id="task_tables">
+                {available_table}
+                {running_table}
+                {finished_table}
             </div>
         </div>
     </body>

--- a/src/manager.xhtml
+++ b/src/manager.xhtml
@@ -6,12 +6,12 @@
         <title>{title}</title>
         <style type="text/css">
             #left {
-                width: 36%;
+                width: 63%;
                 float: left;
             }
 
             #right {
-                width: 63%;
+                width: 36%;
                 float: right;
             }
 
@@ -27,15 +27,9 @@
                 margin-bottom: 20px;
             }
 
-            #filter {
-                width: 100%;
-                text-align: center;
-                margin-bottom: 30px;
-            }
-
             #custom {
                 width: 100%;
-                text-align: center;
+                text-align: left;
                 margin: 0 auto;
             }
 
@@ -60,11 +54,21 @@
             }
 
             #vmcore-wrapper {
-                margin-bottom: 30px;
+                width: 60%;
+                float: left;
+                text-align: left;
+                border: 1px solid black;
+                padding: 4px;
+                margin: 4px;
             }
 
             #usrcore-wrapper {
-                margin-bottom: 30px;
+                width: 60%;
+                float: left;
+                text-align: left;
+                border: 1px solid black;
+                padding: 4px;
+                margin: 4px;
             }
 
             #memory-box {
@@ -196,24 +200,9 @@
     </head>
     <body>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        {ftpscript}
-        <h1>{sitename}</h1>
-        <form method="get" id="filter">
-            <input type="text" name="filter" />
-            <input type="submit" value="Filter" class="submit" />
-        </form>
         {vmcore_task_form}
         {usrcore_task_form}
         <div id="main">
-            <div id="left">
-                <div id="available">
-                    <table>
-                        <tr>
-                            <th class="tablename">{available_str}</th>
-                        </tr>
-                    </table>
-                </div>
-            </div>
             <div id="right">
                 <div id="running">
                     <table>
@@ -231,6 +220,15 @@
                         {running}
                     </table>
                 </div>
+                <div id="available">
+                    <table>
+                        <tr>
+                            <th class="tablename">{available_str}</th>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <div id="left">
                 <div id="finished">
                     <table>
                         <tr>

--- a/src/manager.xhtml
+++ b/src/manager.xhtml
@@ -58,6 +58,15 @@
                 margin-left: 0;
             }
 
+            #ftp-wrapper {
+                width: 60%;
+                float: left;
+                text-align: left;
+                border: 1px solid black;
+                padding: 4px;
+                margin: 4px;
+            }
+
             #vmcore-wrapper {
                 width: 60%;
                 float: left;
@@ -205,6 +214,9 @@
     </head>
     <body>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <div id="ftp-wrapper">
+            <h2><a href="ftp">List FTP files (create vmcore task from FTP)</a></h2>
+        </div>
         {vmcore_task_form}
         {usrcore_task_form}
         <div id="main">

--- a/src/manager_usrcore_task_form.xhtml
+++ b/src/manager_usrcore_task_form.xhtml
@@ -1,7 +1,6 @@
 <div id="usrcore-wrapper">
-    <h2>userspace core</h2>
+    <h2>Create coredump task (userspace memory dump)</h2>
     <form method="post" action="{create_custom_url}" id="custom">
-        <div id="middle">
             <div>
                 <span class="formsubhead">Package:</span>
                 <input type="text" name="package" />
@@ -22,19 +21,19 @@
 
             <p id="custom">All of these three fields override contents of package, executable and os_release files contained in the coredump archive.<br />
             If you're uploading you have just the bare (compressed) coredump, you must specify these.</p>
-        </div>
-        <div id="middle">
-            <input type="checkbox" checked="checked" name="debug" class="checkbox" /><span class="formsubhead"> Be more verbose in case of error</span><br/>
-            <input type="checkbox" {md5_enabled} name="md5sum" class="checkbox" /><span class="formsubhead"> Calculate md5 checksum for all downloaded resources</span>
-        </div>
-        <div id="middle">
-            <span class="formhead">Custom core location:</span>
-            <input type="text" name="custom_url" class="url" />
-            <input type="hidden" name="task_type" value="coredump">
-
-            <div class="center">Any URL that wget can download or a local path (file:///foo/bar or just /foo/bar)</div>
+            <div>
+                <input type="checkbox" checked="checked" name="debug" class="checkbox" /><span class="formsubhead"> Be more verbose in case of error</span><br/>
+            </div>
+            <div>
+                <input type="checkbox" {md5_enabled} name="md5sum" class="checkbox" /><span class="formsubhead"> Calculate md5 checksum for all downloaded resources</span>
+            </div>
+            <div>
+                <span class="formhead">Custom core location:</span>
+                <span>(Any URL that wget can download or a local path, e.g. file:///foo/bar or just /foo/bar)</span>
+                <input type="text" name="custom_url" class="url" />
+                <input type="hidden" name="task_type" value="coredump">
+            </div>
 
             <input type="submit" value="Create coredump task" class="submit" />
-        </div>
     </form>
 </div>

--- a/src/manager_vmcore_task_form.xhtml
+++ b/src/manager_vmcore_task_form.xhtml
@@ -1,13 +1,10 @@
 <div id="vmcore-wrapper">
-    <h2>vmcore</h2>
+    <h2>Create vmcore task (kernel memory dump)</h2>
     <form method="post" action="{create_custom_url}" id="custom">
-        <div id="middle">
             <span class="formsubhead">Kernel version:</span>
             <input type="text" name="kernelver" />
             <span>(e.g. 2.6.32-287.el6.x86_64, empty to autodetect)</span>
-        </div>
 
-        <div id="middle">
             <div>
                 <input type="checkbox" id="memory-check" name="vmem-check" class="checkbox" />
                 <span class="formsubhead"> Include memory file for vmcore snapshot</span>
@@ -22,26 +19,20 @@
                 <input type="checkbox" {md5_enabled} name="md5sum" class="checkbox" />
                 <span class="formsubhead"> Calculate md5 checksum for all downloaded resources</span>
             </div>
-        </div>
 
-        <div id="middle">
             <div>
                 <span class="formhead">Custom core location:</span>
+                <span>(Any URL that wget can download or a local path, e.g. file:///foo/bar or just /foo/bar)</span>
                 <input type="text" name="custom_url" class="url" />
                 <input type="hidden" name="task_type" value="vmcore">
             </div>
 
             <div id="memory-box">
                 <span class="formhead">Custom memory location:</span>
+                <span>(Any URL that wget can download or a local path, e.g. file:///foo/bar or just /foo/bar)</span>
                 <input type="text" name="custom_vmem_url" class="url" />
             </div>
-
-            <div class="center">
-                Any URL that wget can download or a local path (file:///foo/bar or just /foo/bar)
-            </div>
-
             <input type="submit" value="Create vmcore task" class="submit" />
-        </div>
     </form>
 
     <script type="text/javascript">

--- a/src/managertask.xhtml
+++ b/src/managertask.xhtml
@@ -75,7 +75,7 @@
             }
 
             textarea.backtrace {
-                width: 90%;
+                width: 100%;
                 height: 400px;
                 padding: 6px;
             }
@@ -88,7 +88,6 @@
             form.notes {
                 float: right;
                 width: 610px;
-                margin-right: 100px;
             }
         </style>
     </head>


### PR DESCRIPTION
These changes rework the manager page to be a bit cleaner.  I though of going further with these, such as adding a small navigation bar on the left side of the page, but I think this is enough for now.

Short list of changes:
1. "FTP files" list removed from the first page, added link at the top
* FTP based vmcore file tasks are very low utilization now
* It takes time to load the page and probably does not make sense to have this on the front page
* This was always somewhat of a hack - if you reload the page you'll see a "Available tasks" table header pop up briefly before "FTP files"

2. Add border around the "Create vmcore task" area

3. Make "Finished Tasks" take up the full page.
* Previously the page was split, and a lot of space was wasted
* Now "Running Tasks" and "Available Tasks" only show up above "Finished tasks" if any exist.

4. On the per task manager page, remove about 1" of whitespace from right side of page