### PR TITLE
Update Packit config

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -9,11 +9,11 @@ jobs:
 - job: propose_downstream
   trigger: release
   metadata:
-    dist_git_branch: fedora-all
+    dist_git_branches: fedora-all
 - job: propose_downstream
   trigger: release
   metadata:
-    dist_git_branch: epel8
+    dist_git_branches: epel8
 - job: copr_build
   trigger: pull_request
   metadata:


### PR DESCRIPTION
The `dist_git_branch` key has been renamed to `dist_git_branches` (plural) in Packit [0.10.1](https://github.com/packit/packit/blob/master/CHANGELOG.md#0101). Update our config accordingly.