### PR TITLE
hooks: Change path to python interpreter from /bin to /usr/bin

### DIFF
--- a/src/backtrace.wsgi
+++ b/src/backtrace.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import RetraceTask

--- a/src/checkpackage.wsgi
+++ b/src/checkpackage.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import is_package_known

--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 import os
 import sys
 from typing import List

--- a/src/delete.wsgi
+++ b/src/delete.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import RetraceTask

--- a/src/exploitable.wsgi
+++ b/src/exploitable.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import RetraceTask

--- a/src/ftp.wsgi
+++ b/src/ftp.wsgi
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import fnmatch
 import re
 import urllib

--- a/src/index.wsgi
+++ b/src/index.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import (get_active_tasks,

--- a/src/log.wsgi
+++ b/src/log.wsgi
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from webob import Request
 from retrace.retrace import RetraceTask
 from retrace.config import Config

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 import datetime
 import fnmatch
 import re

--- a/src/retrace/argparser.py
+++ b/src/retrace/argparser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # Copyright (C) 2012 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -1,4 +1,3 @@
-#!/bin/python3
 import configparser
 from pathlib import Path
 from typing import Dict, List

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import itertools
 import multiprocessing as mp
 import os

--- a/src/settings.wsgi
+++ b/src/settings.wsgi
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from retrace.retrace import get_active_tasks, get_supported_releases
 from retrace.config import Config
 from retrace.stats import save_crashstats_reportfull

--- a/src/start.wsgi
+++ b/src/start.wsgi
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import urllib
 from webob import Request
 

--- a/src/stats.wsgi
+++ b/src/stats.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 import sys
 import time
 

--- a/src/status.wsgi
+++ b/src/status.wsgi
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 from webob import Request
 
 from retrace.retrace import STATUS, RetraceTask


### PR DESCRIPTION
Install was giving this error which indicated /bin/python3 was
not provided:
Error:
 Problem: conflicting requests
  - nothing provides /bin/python3 needed by retrace-server-1.21.0-1.git.1011.3e498e3.el8.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>