### PR TITLE
Repair coredump2packages

### DIFF
--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -309,3 +309,9 @@ def main() -> None:
 
     for path, build_id in missing_buildid_list:
         print(f"{path} {build_id}")
+
+
+if __name__ == '__main__':
+    main()
+else:
+    raise NotImplementedError

--- a/src/coredump2packages
+++ b/src/coredump2packages
@@ -48,7 +48,9 @@ def binary_packages_from_debuginfo_package(debuginfo_package: Package, binobj_pa
             package_list.append(package)
     else:
         logger.info("   Dnf search for %s...", binobj_path)
-        binobj_package_list = dnfbase.sack.query().filter(file=binobj_path)
+        binobj_package_list = (dnfbase.sack.query()
+                               .filter(file=binobj_path,
+                                       arch=debuginfo_package.arch))
         for binobj_package in binobj_package_list:
             logger.info("    - %s", str(binobj_package))
             if binobj_package.evr_cmp(debuginfo_package) != 0:


### PR DESCRIPTION
* Call the `main()` function in `coredump2packages`. The refactor in 81e750f failed to ever call the function.
* Only look for binary packages with same architecture as debuginfo packages.

This should fix many of the recent retracing failures.