### PR TITLE
NEEDINFO: spec: Set ownership and permission for logotate.d

### DIFF
--- a/retrace-server.spec
+++ b/retrace-server.spec
@@ -171,7 +171,7 @@ exit 0
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/start.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/success.conf
 %config(noreplace) %{_sysconfdir}/%{name}/hooks/task.conf
-%config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+%config(noreplace) %attr(0644, retrace, retrace) %{_sysconfdir}/logrotate.d/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/kernel
 %dir %attr(0755,retrace,retrace) %{_localstatedir}/cache/%{name}/download


### PR DESCRIPTION
According to a comment in:
https://github.com/abrt/retrace-server/issues/403

We should change the ownsership to our logrotate config file.

This change will result in both retrace and root (instead of just root) to be able to modify the config file.

I am not sure why retrace user needs to be able to do this. Usually configuration is only modofied by a user with root priviledges. Can someone clarify?