### PR TITLE
retrace and r-s-cleanup improvements

### DIFF
--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -3,10 +3,10 @@ import os
 import sys
 import re
 import time
-from typing import Dict, List, Optional
-
-from subprocess import run, PIPE, STDOUT
+from datetime import timedelta
 from pathlib import Path
+from subprocess import run, PIPE, STDOUT
+from typing import Dict, List, Optional
 
 from retrace.retrace import (STATUS_FAIL,
                              get_active_tasks,
@@ -114,7 +114,8 @@ if __name__ == "__main__":
                     log.write("RetraceTask with taskid %d does not exist\n" % taskid)
 
             if runtime > 60 * 60:  # 1 hour
-                log.write("Killing task %d running for %ss\n" % (taskid, runtime))
+                elapsed = timedelta(seconds=runtime)
+                log.write("Killing task %d running for %s\n" % (taskid, elapsed))
                 kill_process_and_childs(pid, ps_out)
 
         # kill orphaned tasks

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -23,7 +23,7 @@ CONFIG = Config()
 def get_process_tree(process_id: int, ps_output: List[str]) -> List[int]:
     result = [process_id]
 
-    parser = re.compile(r"^([0-9]+)[ \t]+(%d).*$" % process_id)
+    parser = re.compile(r"^\s*(\d+)\s+%d\s" % process_id, re.ASCII)
 
     for line in ps_output:
         match = parser.match(line)

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -5,6 +5,7 @@ import re
 import time
 from datetime import timedelta
 from pathlib import Path
+from signal import SIGKILL
 from subprocess import run, PIPE, STDOUT
 from typing import Dict, List, Optional
 
@@ -41,7 +42,7 @@ def kill_process_and_childs(process_id: int, ps_output: Optional[List[str]] = No
 
     for proc_id in get_process_tree(process_id, ps_output):
         try:
-            os.kill(proc_id, 9)
+            os.kill(proc_id, SIGKILL)
         except OSError:
             result = False
 

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -119,10 +119,7 @@ if __name__ == "__main__":
                 kill_process_and_childs(pid, ps_out)
 
         # kill orphaned tasks
-        running_tasks = get_running_tasks()
-        running_ids = []
-        for _, taskid, _ in running_tasks:
-            running_ids.append(taskid)
+        running_ids = [taskid for _, taskid, _ in get_running_tasks()]
 
         for taskid in get_active_tasks():
             if taskid not in running_ids:

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -113,15 +113,14 @@ if __name__ == "__main__":
                 except Exception:
                     log.write("RetraceTask with taskid %d does not exist\n" % taskid)
 
-            # ToDo: 5 = mm:ss, >5 = hh:mm:ss
-            if len(runtime) > 5:
-                log.write("Killing task %d running for %s\n" % (taskid, runtime))
+            if runtime > 60 * 60:  # 1 hour
+                log.write("Killing task %d running for %ss\n" % (taskid, runtime))
                 kill_process_and_childs(pid, ps_out)
 
         # kill orphaned tasks
         running_tasks = get_running_tasks()
         running_ids = []
-        for pid, taskid, runtime in running_tasks:
+        for _, taskid, _ in running_tasks:
             running_ids.append(taskid)
 
         for taskid in get_active_tasks():

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -82,7 +82,7 @@ REPODIR_NAME_PARSER = re.compile(r"^[^\-]+\-[^\-]+\-[^\-]+$")
 
 KO_DEBUG_PARSER = re.compile(r"^.*/([a-zA-Z0-9_\-]+)\.ko\.debug$")
 
-WORKER_RUNNING_PARSER = re.compile(r"^\s*(\d+)\s+\d+\s+(\S+)\s+"
+WORKER_RUNNING_PARSER = re.compile(r"^\s*(\d+)\s+\d+\s+(\d+)\s+"
                                    r".*retrace-server-worker (\d+)( .*)?$",
                                    re.ASCII)
 
@@ -592,13 +592,13 @@ def unpack_coredump(path: Path) -> None:
 
 
 def run_ps() -> List[str]:
-    lines = run(["ps", "-eo", "pid,ppid,etime,cmd"],
-                stdout=PIPE, encoding='utf-8', check=False).stdout.splitlines()
+    lines = run(["ps", "-eo", "pid,ppid,etimes,cmd"],
+                stdout=PIPE, encoding="utf-8", check=False).stdout.splitlines()
 
     return lines
 
 
-def get_running_tasks(ps_output: Optional[List[str]] = None) -> List[Tuple[int, int, str]]:
+def get_running_tasks(ps_output: Optional[List[str]] = None) -> List[Tuple[int, int, int]]:
     if ps_output is None:
         ps_output = run_ps()
 
@@ -607,7 +607,10 @@ def get_running_tasks(ps_output: Optional[List[str]] = None) -> List[Tuple[int, 
     for line in ps_output:
         match = WORKER_RUNNING_PARSER.match(line)
         if match:
-            result.append((int(match.group(1)), int(match.group(3)), match.group(2)))
+            pid = int(match.group(1))
+            elapsed = int(match.group(2))
+            taskid = int(match.group(3))
+            result.append((pid, taskid, elapsed))
 
     return result
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1106,11 +1106,9 @@ class RetraceTask:
         """Returns whether the task is running. Reads /proc if readproc=True
         otherwise just reads the STATUS_FILE."""
         if readproc:
-            for _, taskid, _ in get_running_tasks():
-                if taskid == self._taskid:
-                    return True
+            return any(taskid == self._taskid
+                       for _, taskid, _ in get_running_tasks())
 
-            return False
         return self.has_status() and self.get_status() not in [STATUS_SUCCESS, STATUS_FAIL]
 
     def get_age(self) -> int:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -82,8 +82,9 @@ REPODIR_NAME_PARSER = re.compile(r"^[^\-]+\-[^\-]+\-[^\-]+$")
 
 KO_DEBUG_PARSER = re.compile(r"^.*/([a-zA-Z0-9_\-]+)\.ko\.debug$")
 
-WORKER_RUNNING_PARSER = re.compile(r"^[ \t]*([0-9]+)[ \t]+[0-9]+[ \t]+([^ ^\t]+)[ \t]"
-                                   r"+.*retrace-server-worker ([0-9]+)( .*)?$")
+WORKER_RUNNING_PARSER = re.compile(r"^\s*(\d+)\s+\d+\s+(\S+)\s+"
+                                   r".*retrace-server-worker (\d+)( .*)?$",
+                                   re.ASCII)
 
 MD5_PARSER = re.compile(r"[a-fA-F0-9]{32}")
 

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1838,7 +1838,11 @@ class RetraceTask:
             if child.returncode:
                 log_warn("Podman image %s not removed" % image_tag)
 
-        for f in Path(self._savedir).iterdir():
+        savedir = Path(self._savedir)
+        if not savedir.is_dir():
+            return
+
+        for f in savedir.iterdir():
             if f.name not in [RetraceTask.REMOTE_FILE, RetraceTask.CASENO_FILE,
                               RetraceTask.BACKTRACE_FILE, RetraceTask.DOWNLOADED_FILE,
                               RetraceTask.FINISHED_FILE, RetraceTask.LOG_FILE,

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -203,7 +203,7 @@ def splitFilename(filename: str) -> Union[Tuple[None, None, None, None, None], T
         foo-1.0-1.i386.rpm returns foo, 1.0, 1, i386
     """
 
-    if filename[-4:] == '.rpm':
+    if filename.endswith('.rpm'):
         filename = filename[:-4]
 
     subject = Subject(filename)


### PR DESCRIPTION
* Time out and abort if Podman takes too long.
* Express elapsed process time in seconds.
* Check if crash directory exists before cleaning it up.
* Improve some regular expressions.
* Various minor Pythonic style improvements.

Resolves #394