### PR TITLE
Regex repairs and epoch stripping fix

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -349,10 +349,7 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
 
 
 def remove_epoch(nvr: str) -> str:
-    pos = nvr.find(":")
-    if pos > 0:
-        return nvr[pos + 1:]
-    return nvr
+    return re.sub("[1-9][0-9]*:", "", nvr)
 
 
 def is_package_known(package_nvr: str, arch: str, releaseid: Optional[str] = None):

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -19,15 +19,15 @@ GETTEXT_DOMAIN = "retrace-server"
 DF_OUTPUT_PARSER = re.compile(r"^([^ ^\t]*)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+)[ \t]+([0-9]+%)[ \t]+(.*)$")
 
 # architecture (i386, x86_64, armv7hl, mips4kec)
-INPUT_ARCH_PARSER = re.compile(r"^[\w\d_]+$")
+INPUT_ARCH_PARSER = re.compile(r"^\w+$", re.ASCII)
 # characters, numbers, dash (utf-8, iso-8859-2 etc.)
-INPUT_CHARSET_PARSER = re.compile(r"^([\w\d-]+)(,.*)?$")
+INPUT_CHARSET_PARSER = re.compile(r"^([a-zA-Z0-9-]+)(,.*)?$")
 # en_GB, sk-SK, cs, fr etc.
 INPUT_LANG_PARSER = re.compile(r"^([a-z]{2}([_\-][A-Z]{2})?)(,.*)?$")
 # characters allowed by Fedora Naming Guidelines
-INPUT_PACKAGE_PARSER = re.compile(r"^[\w\d_.+-]+([1-9][0-9]*:)?[\w\d.+~-]+$")
+INPUT_PACKAGE_PARSER = re.compile(r"^[\w.+-]+([1-9][0-9]*:)?[a-zA-Z0-9.+~-]+$", re.ASCII)
 # name-version-arch (fedora-16-x86_64, rhel-6.2-i386, opensuse-12.1-x86_64)
-INPUT_RELEASEID_PARSER = re.compile(r"^[\w\d]+-[\w\d.]+-[\w\d_]+$")
+INPUT_RELEASEID_PARSER = re.compile(r"^[a-zA-Z0-9]+-[a-zA-Z0-9.]+-\w+$", re.ASCII)
 
 UNITS = ["B", "kB", "MB", "GB", "TB", "PB", "EB"]
 URL_PARSER = re.compile(r"^/([0-9]+)/?")


### PR DESCRIPTION
* The changes in 84d67af made the regexes accept more inputs as valid than originally intended due to the use of `\w`, `\d`, etc. This commit changes the regexes to be equivalent to the previous state.
* Repair how epoch number is stripped from package designation in NEVR(A) form.
* Minor code style fixes.

Follow-up to #409