### PR TITLE
retrace_worker: Add backtrace to log when a task fails with error

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -169,6 +169,8 @@ def log_warn(msg: str):
 def log_error(msg: str):
     logger.error(msg)
 
+def log_exception(msg: str):
+    logger.debug(msg, exc_info=True)
 
 def get_canon_arch(arch: str) -> str:
     for canon_arch, derived_archs in ARCH_MAP.items():

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -23,6 +23,7 @@ from .retrace import (ALLOWED_FILES, REPO_PREFIX, REQUIRED_FILES,
                       is_package_known,
                       KernelVer,
                       KernelVMcore,
+                      log_exception,
                       log_debug,
                       log_error,
                       log_info,
@@ -1016,6 +1017,7 @@ class RetraceWorker:
                 raise Exception("Unsupported task type '%s'" % tasktype)
         except Exception as ex:
             log_error("Task failed: %s" % ex)
+            log_exception("Backtrace: %s" % ex)
             self._fail()
 
     def clean_task(self) -> None:


### PR DESCRIPTION
With this we log the exception backtrace in addition to the normal
error message when debug is enabled. This may be helpful when troubleshooting
some issues where it's not clear where the error comes from.

For example, before applying this patch we would get this error:

[2021-02-04 10:52:48] [E] Task failed: [Errno 2] No such file or
directory: '/cores/retrace/tasks/231067672/crash/testfile-vmcore'

Now we get this error plus backtrace:

[2021-02-05 07:00:42] [E] Task failed: [Errno 2] No such file or directory: '/cores/retrace/tasks/889893066/crash/testfile-vmcore'
[2021-02-05 07:00:42] [D] Backtrace: [Errno 2] No such file or directory: '/cores/retrace/tasks/889893066/crash/testfile-vmcore'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 986, in start
    errors = task.download_remote()
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 1498, in download_remote
    move_dir_contents(fullpath, crashdir)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 648, in move_dir_contents
    for filename in Path(source).iterdir():
  File "/usr/lib64/python3.6/pathlib.py", line 1081, in iterdir
    for name in self._accessor.listdir(self):
  File "/usr/lib64/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: '/cores/retrace/tasks/889893066/crash/testfile-vmcore'

Signed-off-by: Pierguido Lambri <plambri@redhat.com>
Reviewed-by: Dave Wysochanski <dwysocha@redhat.com>