### PR TITLE
retrace: Fix "file not found" when the archive contains directories

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1514,7 +1514,7 @@ class RetraceTask:
             vmcore_path = self.get_vmcore_path()
             for file_path in crashdir.iterdir():
                 if file_path.is_dir():
-                    move_dir_contents(fullpath, crashdir)
+                    move_dir_contents(file_path, crashdir)
 
             files = list(crashdir.iterdir())
             if not files:


### PR DESCRIPTION
When iterating over some directories found in the crashdir,
retrace was trying to move the "fullpath" (i.e. the original
file) instead of "file_path" (the directory), and the task
would fail with the following message:

[2021-02-04 10:52:48] [E] Task failed: [Errno 2] No such file or
directory: '/cores/retrace/tasks/231067672/crash/testfile-vmcore'

Signed-off-by: Pierguido Lambri <plambri@redhat.com>
Reviewed-by: Dave Wysochanski <dwysocha@redhat.com>