### PR TITLE
Podman backend refactor and fixes

### DIFF
--- a/retrace-server.spec
+++ b/retrace-server.spec
@@ -73,8 +73,9 @@ Requires(post): /sbin/install-info
 %endif
 Requires(post): /usr/bin/crontab
 Requires(post): /usr/bin/systemctl
-Recommends: podman
+Recommends: httpd
 Recommends: logrotate
+Recommends: podman
 
 Obsoletes: abrt-retrace-server < 2.0.3
 Provides: abrt-retrace-server = 2.0.3

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     if CONFIG["UseFafPackages"]:
         log_info("Creating repository from faf database")
         releaseid = f"{distribution}-{version}-{arch}"
-        targetdir = CONFIG["RepoDir"] / releaseid
+        targetdir = Path(CONFIG["RepoDir"], releaseid)
 
         if not targetdir.is_dir():
             targetdir.mkdir(parents=True)

--- a/src/retrace-server-reposync
+++ b/src/retrace-server-reposync
@@ -2,9 +2,9 @@
 import argparse
 import contextlib
 import errno
-import os
-import logging
 import grp
+import logging
+import os
 import pwd
 import shutil
 import sys
@@ -12,7 +12,8 @@ import tempfile
 
 from functools import cmp_to_key
 from pathlib import Path
-from subprocess import run, DEVNULL, PIPE
+from subprocess import run, DEVNULL, STDOUT
+from typing import Iterator, TextIO
 
 import rpm
 import dnf
@@ -27,9 +28,6 @@ from retrace.config import Config
 from retrace.plugins import Plugins
 from retrace.util import lock, unlock, parse_rpm_name
 
-sys.path.insert(0, "/usr/share/retrace-server")
-
-
 CONFIG = Config()
 plugins = Plugins()
 
@@ -40,17 +38,19 @@ BUFSIZE = 1 << 22 # 4 MB
 
 
 @contextlib.contextmanager
-def redirect_stderr(path):
-    with Path(path).open(mode="a") as dnflog:
+def redirect_stderr(path: Path) -> Iterator[TextIO]:
+    with path.open(mode="a") as dnflog:
         _stderr = sys.stderr
         sys.stderr = dnflog
 
         try:
-            yield (_stderr, dnflog)
+            yield _stderr
         finally:
             sys.stderr = _stderr
 
-def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "", local_dnf_cfg: str = "") -> int:
+
+def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "",
+                   local_dnf_cfg: str = "") -> int:
     dnftmp = tempfile.NamedTemporaryFile(mode="w", delete=False,
                                          prefix="repo", suffix=".conf")
     dnftmp.write(global_dnf_cfg)
@@ -68,7 +68,7 @@ def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "", loca
 
     cachedir.mkdir(parents=True, exist_ok=True)
 
-    with redirect_stderr(Path(CONFIG["LogDir"], "reposync_dnf.log")) as (old_stderr, _):
+    with redirect_stderr(Path(CONFIG["LogDir"], "reposync_dnf.log")) as old_stderr:
         # BEGIN DNF
         dnfbase = dnf.Base()
         dnfbase.conf.read(filename=dnftmp.name)
@@ -90,7 +90,7 @@ def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "", loca
         for pkg in dnfbase.sack.query():
             rpmname = Path(pkg.location).name
             pkgpath = Path(pkg_dir) / rpmname
-            if not pkgpath.is_file() or pkgpath.stat().st_size() != pkg.size:
+            if not pkgpath.is_file() or pkgpath.stat().st_size != pkg.size:
                 log_info("%s will be downloaded" % rpmname)
                 download.append(pkg)
             else:
@@ -131,7 +131,8 @@ def sync_using_dnf(target_id: str, repo_url: str, global_dnf_cfg: str = "", loca
 
     return 0
 
-def vercmp(ver1, ver2):
+
+def vercmp(ver1: str, ver2: str) -> int:
     # ToDo: Involve epoch?
     ver, rel = ver1.split("-", 1)
     first = (None, ver, rel)
@@ -140,7 +141,8 @@ def vercmp(ver1, ver2):
 
     return rpm.labelCompare(first, second)
 
-def clean_rawhide_repo(release):
+
+def clean_rawhide_repo(release: str) -> None:
     packages = {}
     pkg_dir = Path(CONFIG["RepoDir"], release, "Packages")
     for f in pkg_dir.iterdir():
@@ -173,6 +175,7 @@ def clean_rawhide_repo(release):
                         log_info("Removing %s" % filename)
                         (pkg_dir / filename).unlink()
 
+
 if __name__ == "__main__":
     # parse arguments
     argparser = argparse.ArgumentParser(description="Retrace Server repository downloader")
@@ -191,23 +194,25 @@ if __name__ == "__main__":
     version = args.version
     arch = get_canon_arch(args.architecture)
 
-
     if CONFIG["UseFafPackages"]:
-        log_info("Creating repo from faf")
-        targetid = Path("%s-%s-%s" % (distribution, version, arch))
-        targetdir = CONFIG["RepoDir"] / targetid
+        log_info("Creating repository from faf database")
+        releaseid = f"{distribution}-{version}-{arch}"
+        targetdir = CONFIG["RepoDir"] / releaseid
 
         if not targetdir.is_dir():
             targetdir.mkdir(parents=True)
 
         cmd_line = ["retrace-server-reposync-faf", distribution, version, arch,
                     "--outputdir", targetdir]
-        child = run(cmd_line, stdout=PIPE, stderr=PIPE, encoding="utf-8", check=False)
+        child = run(cmd_line, stdout=sys.stderr, stderr=STDOUT, encoding="utf-8",
+                    check=False)
+
         if child.returncode:
-            log_error("Could not create faf repo")
+            log_error("Could not create repository")
             log_debug(child.stdout)
             log_debug(child.stderr)
             sys.exit(child.returncode)
+
         sys.exit(0)
 
     # drop privilegies if possible
@@ -233,11 +238,11 @@ if __name__ == "__main__":
         log_error("Unknown distribution: '%s'" % distribution)
         sys.exit(1)
 
-    targetid = "%s-%s-%s" % (distribution, version, arch)
-    lockfile = Path("/tmp/retrace-reposync-lock-%s" % targetid)
+    releaseid = f"{distribution}-{version}-{arch}"
+    lockfile = Path(f"/tmp/retrace-reposync-lock-{releaseid}")
 
     if lockfile.is_file():
-        log_error("Another process with repository download is running")
+        log_error(f"Repository for {releaseid} is already being created by a different process")
         sys.exit(2)
 
     # set lock
@@ -250,7 +255,7 @@ if __name__ == "__main__":
         null = DEVNULL
 
     try:
-        targetdir = Path(CONFIG["RepoDir"], targetid)
+        targetdir = Path(CONFIG["RepoDir"], releaseid)
         pkgdir = targetdir / "Packages"
 
         if not pkgdir.is_dir():
@@ -272,7 +277,10 @@ if __name__ == "__main__":
             localdnfcfg = ""
             if isinstance(repo, tuple):
                 repo, localdnfcfg = repo
-                localdnfcfg = localdnfcfg.replace("$ARCH", arch).replace("$VER", version)
+                localdnfcfg = (
+                    localdnfcfg.replace("$ARCH", arch)
+                               .replace("$VER", version)
+                )
 
             for mirror in repo:
                 repourl = mirror.replace("$ARCH", arch).replace("$VER", version)
@@ -283,7 +291,7 @@ if __name__ == "__main__":
                 if repourl.startswith("http://") or \
                    repourl.startswith("https://") or \
                    repourl.startswith("ftp://"):
-                    retcode = sync_using_dnf(targetid, repourl, globaldnfcfg, localdnfcfg)
+                    retcode = sync_using_dnf(releaseid, repourl, globaldnfcfg, localdnfcfg)
                 else:
                     if repourl.startswith("rsync://"):
                         files = [repourl]
@@ -312,7 +320,7 @@ if __name__ == "__main__":
 
         if version.lower() == "rawhide":
             log_info("Cleaning rawhide repo...")
-            clean_rawhide_repo(targetid)
+            clean_rawhide_repo(releaseid)
 
         # run createrepo
         log_info("Running createrepo on '%s'..." % targetdir)

--- a/src/retrace-server-reposync-faf
+++ b/src/retrace-server-reposync-faf
@@ -1,27 +1,34 @@
 #!/usr/bin/python3
 
 from argparse import ArgumentParser
+import logging
 import os
 from os.path import abspath, join, relpath
 import shutil
+import sys
 from typing import Generator
 
 import createrepo_c as cr
 from pyfaf.queries import get_packages_by_osrelease
 from pyfaf.storage import Database, getDatabase
 
-faf_names = {'rhel': "Red Hat Enterprise Linux",
-             'fedora': 'Fedora',
-             'centos': 'CentOS'}
+faf_names = {"rhel": "Red Hat Enterprise Linux",
+             "fedora": "Fedora",
+             "centos": "CentOS"}
+
+logging.basicConfig(format="[%(asctime)s] %(levelname)s: %(message)s",
+                    datefmt="%F %T", level=logging.INFO)
+logger = logging.getLogger("r-s-reposync-faf")
 
 
-def get_pkglist(db: Database, opsys: str, release: str, arch: str) -> Generator[str, None, None]:
+def get_pkglist(db: Database, opsys: str, release: str, arch: str) -> \
+        Generator[str, None, None]:
     if opsys in faf_names.keys():
         opsys = faf_names[opsys]
-    q = get_packages_by_osrelease(db, opsys, release, arch)
-    for pkg in q:
+
+    for pkg in get_packages_by_osrelease(db, opsys, release, arch):
         if pkg.has_lob("package"):
-            print("Adding package: %s-%s-%s" % (pkg.name, pkg.build.version, pkg.build.release))
+            logger.info("Adding package: %s", pkg.nevra())
             yield abspath(pkg.get_lob_path("package"))
 
 
@@ -78,45 +85,63 @@ def generate_repo(db: Database, outputdir: str, opsys: str, release: str,
 
     # Add records into the repomd.xml
     #pylint: disable=bad-whitespace
-    repomdrecords = (("primary",      pri_xml_path, pri_db),
-                     ("filelists",    fil_xml_path, fil_db),
-                     ("other",        oth_xml_path, oth_db),
-                     ("primary_db",   pri_db_path,  None),
-                     ("filelists_db", fil_db_path,  None),
-                     ("other_db",     oth_db_path,  None))
+    repomd_records = (("primary",      pri_xml_path, pri_db),
+                      ("filelists",    fil_xml_path, fil_db),
+                      ("other",        oth_xml_path, oth_db),
+                      ("primary_db",   pri_db_path,  None),
+                      ("filelists_db", fil_db_path,  None),
+                      ("other_db",     oth_db_path,  None))
 
-    for name, path, db_to_update in repomdrecords:
+    for name, path, db_to_update in repomd_records:
+        logger.info("Postprocessing database ‘%s’", name)
+
         # Compress sqlite files with bzip2
         if path.endswith('.sqlite'):
             new_path = '%s.bz2' % path
+            logger.info("Compressing %s...", path)
             cr.compress_file(path, new_path, cr.BZ2)
             os.remove(path)
             path = new_path
+            logger.info("Done")
 
         record = cr.RepomdRecord(name, path)
         record.fill(cr.SHA256)
         record.rename_file()
         if db_to_update:
+            logger.info("Updating related database")
             db_to_update.dbinfo_update(record.checksum)
             db_to_update.close()
         repomd.set_record(record)
+
+        logger.info("Postprocessing ‘%s’ finished", name)
 
     # Write repomd.xml
     with open(repomd_path, "w") as repomd_file:
         repomd_file.write(repomd.xml_dump())
 
+    logger.info("Repository metadata written to %s", repomd_path)
+
 
 def main() -> None:
-    parser = ArgumentParser(description="Generates dnf repo from FAF databse")
+    parser = ArgumentParser(description="Generate a DNF repository from FAF package "
+                                        "database")
     parser.add_argument("OPSYS")
     parser.add_argument("RELEASE")
     parser.add_argument("ARCHITECTURE")
     parser.add_argument("--outputdir", default=os.getcwd())
     args = parser.parse_args()
 
-    print("Creating repo in '%s'" % (args.outputdir))
+    logger.info("Creating DNF repository in ‘%s’", args.outputdir)
 
-    generate_repo(getDatabase(), args.outputdir, args.OPSYS, args.RELEASE, args.ARCHITECTURE)
+    try:
+        generate_repo(getDatabase(), args.outputdir, args.OPSYS, args.RELEASE,
+                      args.ARCHITECTURE)
+    except Exception as ex:
+        logger.error("Could not create repository: %s", ex)
+        sys.exit(1)
+
+    logger.info("Repository created successfully")
+
 
 if __name__ == "__main__":
     main()

--- a/src/retrace/backends/meson.build
+++ b/src/retrace/backends/meson.build
@@ -1,0 +1,17 @@
+sources = [
+  '__init__.py',
+  'podman.py',
+]
+
+foreach file: sources
+  configure_file(
+    copy: true,
+    input: file,
+    output: file,
+  )
+endforeach
+
+python_installation.install_sources(sources,
+  subdir: join_paths('retrace', 'backends'),
+  pure: true,
+)

--- a/src/retrace/backends/podman.py
+++ b/src/retrace/backends/podman.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from subprocess import CompletedProcess, DEVNULL, PIPE, run, STDOUT
+from typing import List, Optional, Union
+
+from retrace.retrace import (log_debug,
+                             log_info,
+                             RETRACE_GPG_KEYS,
+                             RetraceError)
+from retrace.config import Config, PODMAN_BIN
+
+class PodmanContainer:
+    def __init__(self, container_id: str) -> None:
+        self.id = container_id
+
+    def copy_to(self, src: Union[str, Path], dst: Union[str, Path]) -> None:
+        proc = run([PODMAN_BIN, "cp", str(src), f"{self.id}:{dst}"],
+                   stdout=DEVNULL, stderr=PIPE, encoding="utf-8")
+
+        if proc.returncode:
+            raise RetraceError(
+                f"Could not copy file ‘{src}’ to container: {proc.stderr}")
+
+    def exec(self, cmd: List[str], user: Optional[str] = None) \
+            -> CompletedProcess:
+        args = [PODMAN_BIN, "exec"]
+
+        if user is not None:
+            args.append(f"--user={user}")
+
+        args.append(self.id)
+        args.extend(cmd)
+
+        return run(args, stderr=STDOUT, stdout=PIPE, encoding="utf-8")
+
+    @property
+    def short_id(self) -> str:
+        return self.id[1:7]
+
+    def stop_and_remove(self) -> None:
+        proc = run([PODMAN_BIN, "rm", "--force", self.id],
+                   stderr=PIPE, stdout=DEVNULL, encoding="utf-8")
+
+        if proc.returncode:
+            raise RetraceError(f"Could not stop container {self.short_id}: {proc.stderr}")
+
+        log_info(f"Container {self.short_id} stopped and removed")
+
+    def __enter__(self) -> 'PodmanContainer':
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        self.stop_and_remove()
+
+class LocalPodmanBackend:
+    def __init__(self, retrace_config: Config):
+        self.config = retrace_config
+
+    def start_container(self, image_tag: str, taskid: int, repopath: str) \
+            -> PodmanContainer:
+        run_call = [PODMAN_BIN, "run",
+                    "--quiet",
+                    "--detach",
+                    "--interactive",
+                    "--tty",
+                    "--sdnotify=ignore",
+                    f"--name=retrace-{taskid}",
+                    f"--volume={repopath}:{repopath}:ro"]
+
+        if self.config["RequireGPGCheck"]:
+            run_call.append("--volume={0}:{0}:ro".format(RETRACE_GPG_KEYS))
+
+        if self.config["UseFafPackages"]:
+            log_debug("Using FAF repository")
+            run_call.append("--volume={0}:{0}:ro".format(self.config["FafLinkDir"]))
+
+        run_call.append(image_tag)
+
+        child = run(run_call, stderr=PIPE, stdout=PIPE, encoding="utf-8",
+                    check=False)
+
+        if child.returncode:
+            raise RetraceError(f"Could not start container: {child.stderr}")
+
+        container_id = child.stdout.strip()
+        container = PodmanContainer(container_id)
+        log_info(f"Container {container.short_id} started")
+
+        return container

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -9,6 +9,7 @@
 #    before first reading from GLOBAL with default path.
 # Note:all modules share one instance, therefore only one load is needed.
 import os
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import configparser
 
@@ -19,15 +20,20 @@ PODMAN_BIN = "@PODMAN_BIN@"
 TAR_BIN = "@TAR_BIN@"
 XZ_BIN = "@XZ_BIN@"
 
+Getter = Union[Callable[[str, str], int],
+               Callable[[str, str], bool],
+               Callable[[str, str], float],
+               Callable[[str, str], List[str]],
+               Callable[[str, str], str]]
 
-class Config(object):
+
+class Config:
     class __config:
-        def __init__(self):
-            self.conf_file_read = False
+        _conf_file_read = False
 
-        ARCH_HOSTS = {}
+        ARCH_HOSTS: Dict[str, str] = {}
 
-        GLOBAL = {
+        GLOBAL: Dict[str, Any] = {
             "TaskIdLength": 9,
             "TaskPassLength": 32,
             "MaxParallelTasks": 10,
@@ -85,21 +91,28 @@ class Config(object):
             "KernelDebuggerPath": "/usr/bin/crash",
         }
 
-        def __getitem__(self, key):
-            if not self.conf_file_read:
+        def __getitem__(self, key: str) -> Any:
+            if not self._conf_file_read:
                 self.load()
+
             return self.GLOBAL[key]
 
-        def load(self, filepath="/etc/retrace-server/retrace-server.conf"):
-            self.conf_file_read = True
-            # if environment variable set, use rather that
-            env_config_path = os.environ.get('RETRACE_SERVER_CONFIG_PATH')
+        def load(self, filepath: str = "/etc/retrace-server/retrace-server.conf") \
+                -> None:
+            self._conf_file_read = True
+
+            # Prefer environment variable over argument if set.
+            env_config_path = os.environ.get("RETRACE_SERVER_CONFIG_PATH")
             if env_config_path:
                 filepath = env_config_path
+
             parser = configparser.ConfigParser()
             parser.read(filepath)
+
             for key in self.GLOBAL.keys():
                 vartype = type(self.GLOBAL[key])
+                get: Optional[Getter] = None
+
                 if vartype is int:
                     get = parser.getint
                 elif vartype is bool:
@@ -107,9 +120,12 @@ class Config(object):
                 elif vartype is float:
                     get = parser.getfloat
                 elif vartype is list:
-                    get = lambda sect, key: parser.get(sect, key).split()
+                    def get(section, key):
+                        return parser.get(section, key).split()
                 else:
                     get = parser.get
+
+                assert get is not None
 
                 try:
                     self.GLOBAL[key] = get("retrace", key)
@@ -122,21 +138,23 @@ class Config(object):
                     if host:
                         self.ARCH_HOSTS[arch] = host
 
-        def get_arch_hosts(self):
+        def get_arch_hosts(self) -> Dict[str, str]:
             return self.ARCH_HOSTS
 
-        def get_list(self, key, sep=","):
-            return [val.strip() for val in self.GLOBAL[key].split(sep) if val.strip()]
+        def get_list(self, key: str, sep: str = ",") -> List[str]:
+            values = self.GLOBAL.get(key, "").split(sep)
+            return [val.strip() for val in values if val.strip()]
 
-    instance = None
+    _instance: Optional[__config] = None
 
     def __new__(cls):
-        if not Config.instance:
-            Config.instance = Config.__config()
-        return Config.instance
+        if Config._instance is None:
+            Config._instance = Config.__config()
 
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
+        return Config._instance
 
-    def __setattr__(self, name, value):
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._instance, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
         pass

--- a/src/retrace/meson.build
+++ b/src/retrace/meson.build
@@ -1,3 +1,4 @@
+subdir('backends')
 subdir('hooks')
 
 configuration = configuration_data()

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -887,7 +887,7 @@ class RetraceTask:
     MOCK_DEFAULT_CFG = "default.cfg"
     MOCK_SITE_DEFAULTS_CFG = "site-defaults.cfg"
     MOCK_LOGGING_INI = "logging.ini"
-    DOCKERFILE = "Dockerfile"
+    CONTAINERFILE = "Containerfile"
 
     def __init__(self, taskid: Optional[Union[int, str]] = None):
         """Creates a new task if taskid is None,
@@ -1879,7 +1879,7 @@ class RetraceTask:
                           RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
                           RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
                           RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE,
-                          RetraceTask.DOCKERFILE, RetraceTask.C2P_LOG_FILE]:
+                          RetraceTask.CONTAINERFILE, RetraceTask.C2P_LOG_FILE]:
                 continue
 
             try:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -13,7 +13,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 from signal import getsignal, signal, SIG_DFL, SIGPIPE
-from subprocess import PIPE, STDOUT, DEVNULL, TimeoutExpired, run
+from subprocess import DEVNULL, PIPE, STDOUT, TimeoutExpired, run
 from typing import Dict, List, Optional, Set, Tuple, Union
 import magic
 
@@ -306,7 +306,7 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
         podman_build_call = [PODMAN_BIN, "build",
                              "--quiet",
                              "--force-rm",
-                             "--file", savedir / RetraceTask.DOCKERFILE,
+                             "--file", str(savedir / RetraceTask.DOCKERFILE),
                              "--volume=%s:%s:ro" % (repopath, repopath)]
 
         if CONFIG["RequireGPGCheck"]:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1878,8 +1878,7 @@ class RetraceTask:
                           RetraceTask.TYPE_FILE, RetraceTask.RESULTS_DIR,
                           RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
                           RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
-                          RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE,
-                          RetraceTask.CONTAINERFILE, RetraceTask.C2P_LOG_FILE]:
+                          RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE]:
                 continue
 
             try:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -364,7 +364,7 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
     if not backtrace:
         raise Exception("An unusable backtrace has been generated")
 
-    python_labels = PYTHON_LABEL_START+'\n'+PYTHON_LABEL_END+'\n'
+    python_labels = "{}\n{}\n".format(PYTHON_LABEL_START, PYTHON_LABEL_END)
     if python_labels in backtrace:
         backtrace = backtrace.replace(python_labels, "")
 
@@ -867,6 +867,7 @@ class RetraceTask:
 
     BACKTRACE_FILE = "retrace_backtrace"
     CASENO_FILE = "caseno"
+    C2P_LOG_FILE = "c2p"
     BUGZILLANO_FILE = "bugzillano"
     CRASHRC_FILE = "crashrc"
     CRASH_CMD_FILE = "crash_cmd"
@@ -1081,7 +1082,8 @@ class RetraceTask:
             self.chgrp(key)
             self.chmod(key)
 
-    def set_atomic(self, key: Union[str, Path], value: Union[str, bytes], mode: str = "w") -> None:
+    def set_atomic(self, key: Union[str, Path], value: Union[str, bytes],
+                   mode: str = "w") -> None:
         if mode not in ["w", "a", "wb"]:
             raise ValueError("mode must be 'w', 'a', or 'wb'")
 
@@ -1867,31 +1869,31 @@ class RetraceTask:
             run([PODMAN_BIN, "rmi", image_tag],
                 stderr=DEVNULL, stdout=DEVNULL, check=False, timeout=60)
 
-        savedir = Path(self._savedir)
-        if not savedir.is_dir():
+        if not self._savedir.is_dir():
             return
 
-        for f in savedir.iterdir():
-            if f.name not in [RetraceTask.REMOTE_FILE, RetraceTask.CASENO_FILE,
-                              RetraceTask.BACKTRACE_FILE, RetraceTask.DOWNLOADED_FILE,
-                              RetraceTask.FINISHED_FILE, RetraceTask.LOG_FILE,
-                              RetraceTask.MANAGED_FILE, RetraceTask.NOTES_FILE,
-                              RetraceTask.NOTIFY_FILE, RetraceTask.PASSWORD_FILE,
-                              RetraceTask.STARTED_FILE, RetraceTask.STATUS_FILE,
-                              RetraceTask.TYPE_FILE, RetraceTask.RESULTS_DIR,
-                              RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
-                              RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
-                              RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE]:
+        for f in self._savedir.iterdir():
+            if f.name in [RetraceTask.REMOTE_FILE, RetraceTask.CASENO_FILE,
+                          RetraceTask.BACKTRACE_FILE, RetraceTask.DOWNLOADED_FILE,
+                          RetraceTask.FINISHED_FILE, RetraceTask.LOG_FILE,
+                          RetraceTask.MANAGED_FILE, RetraceTask.NOTES_FILE,
+                          RetraceTask.NOTIFY_FILE, RetraceTask.PASSWORD_FILE,
+                          RetraceTask.STARTED_FILE, RetraceTask.STATUS_FILE,
+                          RetraceTask.TYPE_FILE, RetraceTask.RESULTS_DIR,
+                          RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
+                          RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
+                          RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE]:
+                continue
 
-                try:
-                    if f.is_dir():
-                        shutil.rmtree(f)
-                    else:
-                        f.unlink()
-                except OSError:
-                    # clean as much as possible
-                    # ToDo advanced handling
-                    pass
+            try:
+                if f.is_dir():
+                    shutil.rmtree(f)
+                else:
+                    f.unlink()
+            except OSError:
+                # clean as much as possible
+                # ToDo advanced handling
+                pass
 
     def reset(self):
         """Remove all generated files and only keep the raw crash data"""

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -1882,7 +1882,8 @@ class RetraceTask:
                           RetraceTask.TYPE_FILE, RetraceTask.RESULTS_DIR,
                           RetraceTask.CRASHRC_FILE, RetraceTask.CRASH_CMD_FILE,
                           RetraceTask.URL_FILE, RetraceTask.MOCK_LOG_DIR,
-                          RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE]:
+                          RetraceTask.VMLINUX_FILE, RetraceTask.BUGZILLANO_FILE,
+                          RetraceTask.DOCKERFILE, RetraceTask.C2P_LOG_FILE]:
                 continue
 
             try:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -14,7 +14,7 @@ import urllib.request
 from pathlib import Path
 from signal import getsignal, signal, SIG_DFL, SIGPIPE
 from subprocess import DEVNULL, PIPE, STDOUT, TimeoutExpired, run
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 import magic
 
 from .config import Config, PODMAN_BIN
@@ -140,17 +140,6 @@ PYTHON_LABEL_END = "----------PYTHON--END---------"
 
 RETRACE_GPG_KEYS = "/usr/share/distribution-gpg-keys/"
 
-
-class RetraceError(Exception):
-    pass
-
-
-class RetraceWorkerError(RetraceError):
-    def __init__(self, message: str = None, errorcode: int = 1):
-        super(RetraceWorkerError, self).__init__(message)
-        self.errorcode = errorcode
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -169,8 +158,126 @@ def log_warn(msg: str):
 def log_error(msg: str):
     logger.error(msg)
 
+
 def log_exception(msg: str):
     logger.debug(msg, exc_info=True)
+
+
+class KernelVer:
+    FLAVOUR = ["debug", "highbank", "hugemem",
+               "kirkwood", "largesmp", "PAE", "omap",
+               "smp", "tegra", "xen", "xenU"]
+
+    ARCH = ARCHITECTURES
+
+    _arch: Optional[str]
+
+    @property
+    def arch(self) -> Optional[str]:
+        if self._arch is None:
+            return None
+        return get_canon_arch(self._arch)
+
+    @arch.setter
+    def arch(self, value: str) -> None:
+        self._arch = value
+
+    def __init__(self, kernelver_str: str) -> None:
+        log_debug("Parsing kernel version '%s'" % kernelver_str)
+        self.kernelver_str = kernelver_str
+        self.flavour = None
+        for kf in KernelVer.FLAVOUR:
+            if kernelver_str.endswith(".%s" % kf):
+                self.flavour = kf
+                kernelver_str = kernelver_str[:-len(kf) - 1]
+                break
+
+        self._arch = None
+        for ka in KernelVer.ARCH:
+            if kernelver_str.endswith(".%s" % ka):
+                self._arch = ka
+                kernelver_str = kernelver_str[:-len(ka) - 1]
+                break
+
+        self.version, self.release = kernelver_str.split("-", 1)
+
+        if self.flavour is None:
+            for kf in KernelVer.FLAVOUR:
+                if self.release.endswith(kf):
+                    self.flavour = kf
+                    self.release = self.release[:-len(kf)]
+                    break
+
+        self.rt = "rt" in self.release
+
+        log_debug("Version: '%s'; Release: '%s'; Arch: '%s'; Flavour: '%s'; Realtime: %s"
+                  % (self.version, self.release, self._arch, self.flavour, self.rt))
+
+    def __str__(self) -> str:
+        result = "%s-%s" % (self.version, self.release)
+
+        if self._arch:
+            result = "%s.%s" % (result, self._arch)
+
+        if self.flavour:
+            result = "%s.%s" % (result, self.flavour)
+
+        return result
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def package_name_base(self, debug: bool = False) -> str:
+        base = "kernel"
+        if self.rt:
+            base = "%s-rt" % base
+
+        if self.flavour and not (debug and ".EL" in self.release):
+            base = "%s-%s" % (base, self.flavour)
+
+        if debug:
+            base = "%s-debuginfo" % base
+
+        return base
+
+    def package_name(self, debug: bool = False) -> str:
+        if self._arch is None:
+            raise Exception("Architecture is required for building package name")
+
+        base = self.package_name_base(debug)
+
+        return "%s-%s-%s.%s.rpm" % (base, self.version, self.release, self._arch)
+
+    def needs_arch(self) -> bool:
+        return self._arch is None
+
+
+class Release:
+    is_rawhide = False
+
+    def __init__(self, distribution: str, version: str, arch: Optional[str] = None,
+                 name: Optional[str] = None) -> None:
+        self.distribution = distribution
+        self.version = version
+        self.arch = arch
+        self.name = name
+
+    def __str__(self) -> str:
+        if self.arch is None:
+            return f"{self.distribution}-{self.version}"
+
+        return f"{self.distribution}-{self.version}-{self.arch}"
+
+
+class RetraceError(Exception):
+    pass
+
+
+class RetraceWorkerError(RetraceError):
+    def __init__(self, message: str = None, errorcode: int = 1):
+        super().__init__(message)
+        self.errorcode = errorcode
+
 
 def get_canon_arch(arch: str) -> str:
     for canon_arch, derived_archs in ARCH_MAP.items():
@@ -181,7 +288,8 @@ def get_canon_arch(arch: str) -> str:
 
 
 def guess_arch(coredump_path: Path) -> Optional[str]:
-    output = run(["file", str(coredump_path)], stdout=PIPE, encoding='utf-8', check=False).stdout
+    output = run(["file", str(coredump_path)], stdout=PIPE, encoding='utf-8',
+                 check=False).stdout
     match = CORE_ARCH_PARSER.search(output)
     if match:
         if match.group(1) == "80386":
@@ -205,7 +313,8 @@ def guess_arch(coredump_path: Path) -> Optional[str]:
 
     result = None
     lines = run(["strings", str(coredump_path)],
-                stdout=PIPE, stderr=STDOUT, encoding='utf-8', check=False).stdout.splitlines()
+                stdout=PIPE, stderr=STDOUT, encoding='utf-8',
+                check=False).stdout.splitlines()
     for line in lines:
         for canon_arch, derived_archs in ARCH_MAP.items():
             if any(arch in line for arch in derived_archs):
@@ -235,12 +344,11 @@ def get_supported_releases() -> List[str]:
     return result
 
 
-def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
-    # exception is caught on the higher level
-    savedir = Path(savedir)
-    exec_file = open(savedir / "crash" / "executable", "r")
-    executable = exec_file.read(ALLOWED_FILES["executable"])
-    exec_file.close()
+def run_gdb(savedir: Path, repopath: str, taskid: int, image_tag: str,
+            packages: Iterable[str], corepath: Path, release: Release) \
+        -> Tuple[str, str]:
+    with (savedir / "crash" / "executable").open("r") as exec_file:
+        executable = exec_file.read(ALLOWED_FILES["executable"])
 
     if '"' in executable or "'" in executable:
         raise Exception("Executable contains forbidden characters")
@@ -248,38 +356,20 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
     if CONFIG["RetraceEnvironment"] == "mock":
         output = run(["/usr/bin/mock", "chroot", "--configdir", savedir,
                       "--", "ls '%s'" % executable],
-                     stdout=PIPE, stderr=DEVNULL, encoding='utf-8', check=False).stdout
+                     stdout=PIPE, stderr=DEVNULL, encoding='utf-8',
+                     check=False).stdout
         if output.strip() != executable:
             raise Exception("The appropriate package set could not be installed")
 
         child = run(["/usr/bin/mock", "chroot", "--configdir", savedir,
-                     "--", "/bin/chmod a+r '%s'" % executable], stdout=DEVNULL, check=False)
+                     "--", "/bin/chmod a+r '%s'" % executable],
+                    stdout=DEVNULL, check=False)
         if child.returncode:
             raise Exception("Unable to chmod the executable")
 
-    batfile = savedir / "gdb.sh"
-    with batfile.open(mode="w") as gdbfile:
-        gdbfile.write("#!/usr/bin/sh\n\n%s -batch "
-                      "-ex 'python exec(open(\"/usr/libexec/abrt-gdb-exploitable\").read())' \\\n"
-                      "                    -ex 'file %s' \\\n"
-                      "                    -ex 'core-file /var/spool/abrt/crash/coredump' \\\n"
-                      "                    -ex 'echo %s\\n' \\\n"
-                      "                    -ex 'py-bt' \\\n"
-                      "                    -ex 'py-list' \\\n"
-                      "                    -ex 'py-locals' \\\n"
-                      "                    -ex 'echo %s\\n' \\\n"
-                      "                    -ex 'thread apply all -ascending backtrace full 2048' \\\n"
-                      "                    -ex 'info sharedlib' \\\n"
-                      "                    -ex 'print (char*)__abort_msg' \\\n"
-                      "                    -ex 'print (char*)__glib_assert_msg' \\\n"
-                      "                    -ex 'info registers' \\\n"
-                      "                    -ex 'disassemble' \\\n"
-                      "                    -ex 'echo %s\\n' \\\n"
-                      "                    -ex 'abrt-exploitable'"
-                      % (plugin.gdb_executable, executable, PYTHON_LABEL_START,
-                         PYTHON_LABEL_END, EXPLOITABLE_SEPARATOR))
-
     if CONFIG["RetraceEnvironment"] == "mock":
+        batfile = savedir / "gdb.sh"
+
         child = run(["/usr/bin/mock", "--configdir", savedir, "--copyin",
                      batfile, "/var/spool/abrt/gdb.sh"],
                     stdout=DEVNULL, stderr=DEVNULL, check=False)
@@ -295,7 +385,7 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
         child = run(["/usr/bin/mock", "chroot", "--configdir", savedir,
                      "--", "su mockbuild -c '/bin/sh /var/spool/abrt/gdb.sh' 2>&1"],
                     # redirect GDB's stderr, ignore mock's stderr
-                    stdout=PIPE, stderr=DEVNULL, encoding='utf-8', check=False)
+                    stdout=PIPE, stderr=DEVNULL, encoding="utf-8", check=False)
 
         if child.returncode:
             raise Exception("Running GDB failed")
@@ -303,55 +393,46 @@ def run_gdb(savedir: Union[str, Path], plugin, repopath: str, taskid: int):
         backtrace = child.stdout.strip()
 
     elif CONFIG["RetraceEnvironment"] == "podman":
-        podman_build_call = [PODMAN_BIN, "build",
-                             "--quiet",
-                             "--force-rm",
-                             "--file", str(savedir / RetraceTask.DOCKERFILE),
-                             "--volume=%s:%s:ro" % (repopath, repopath)]
+        from .backends.podman import LocalPodmanBackend
 
-        if CONFIG["RequireGPGCheck"]:
-            podman_build_call.append("--volume=%s:%s:ro" % (RETRACE_GPG_KEYS, RETRACE_GPG_KEYS))
+        backend = LocalPodmanBackend(retrace_config=CONFIG)
 
-        if CONFIG["UseFafPackages"]:
-            faf_link_dir = CONFIG["FafLinkDir"]
-            log_debug("Using FAF repository")
-            podman_build_call.append("--volume=%s:%s" % (faf_link_dir, faf_link_dir))
+        # Start container from prepared release-specific image.
+        with backend.start_container(image_tag, taskid, repopath) as container:
+            # Copy coredump from crash directory to container.
+            container.copy_to(corepath, "/var/spool/abrt/crash/")
 
-        image_tag = "retrace-image:%d" % taskid
-        podman_build_call.extend(["--tag", image_tag])
+            # Make retrace user the owner of the coredump.
+            container.exec(["chown", "retrace:",
+                            f"/var/spool/abrt/crash/{corepath.name}"])
 
-        try:
-            child = run(podman_build_call, stdout=DEVNULL, stderr=DEVNULL, check=False,
-                        timeout=15 * 60)
-        except TimeoutExpired:
-            raise Exception("Unable to build Podman container (timeout)")
+            # Install packages required for retracing the coredump.
+            dnf_call = ["dnf", "install",
+                        "--assumeyes",
+                        "--skip-broken",
+                        "--allowerasing",
+                        "--setopt=tsflags=nodocs",
+                        f"--releasever={release.version}",
+                        f"--repo=retrace-{release.distribution}"]
+            dnf_call.extend(packages)
 
-        if child.returncode:
-            raise Exception("Unable to build Podman container")
+            child = container.exec(dnf_call)
 
-        try:
-            child = run([PODMAN_BIN, "run",
-                         "--interactive",
-                         "--rm",
-                         "--name=%d" % taskid,
-                         image_tag],
-                        stderr=DEVNULL, stdout=PIPE, encoding="utf-8", check=False,
-                        timeout=5 * 60)
-        except TimeoutExpired as ex:
-            if ex.stdout:
-                # GDB timed out but it generated some output. Let's assume
-                # it was the backtrace and see what happens.
-                log_warn("GDB timed out but generated some output")
-                backtrace = ex.stdout.strip()
-            else:
-                raise Exception("GDB timed out with no output")
-        else:
             if child.returncode:
-                # GDB finished in time but with a failure code.
-                raise Exception("Running GDB failed")
+                raise RetraceError("Could not install required packages inside "
+                                   f"container: {child.stderr}")
+
+            log_info("Required packages installed")
+
+            # Run GDB inside container and collect output.
+            child = container.exec(["/var/spool/abrt/gdb.sh", executable],
+                                   user="retrace")
+
+            if child.returncode:
+                raise RetraceError(f"GDB failed inside container: {child.stdout}")
 
             backtrace = child.stdout.strip()
-
+            log_info("Backtrace generated")
     elif CONFIG["RetraceEnvironment"] == "native":
         raise Exception("RetraceEnvironment == native not implemented for gdb")
     else:
@@ -687,95 +768,6 @@ def move_dir_contents(source: Union[str, Path], dest: Union[str, Path]) -> None:
 # except?
 
     shutil.rmtree(source)
-
-
-class KernelVer:
-    FLAVOUR = ["debug", "highbank", "hugemem",
-               "kirkwood", "largesmp", "PAE", "omap",
-               "smp", "tegra", "xen", "xenU"]
-
-    ARCH = ARCHITECTURES
-
-    _arch: Optional[str]
-
-    @property
-    def arch(self) -> Optional[str]:
-        if self._arch is None:
-            return None
-        return get_canon_arch(self._arch)
-
-    @arch.setter
-    def arch(self, value: str) -> None:
-        self._arch = value
-
-    def __init__(self, kernelver_str: str) -> None:
-        log_debug("Parsing kernel version '%s'" % kernelver_str)
-        self.kernelver_str = kernelver_str
-        self.flavour = None
-        for kf in KernelVer.FLAVOUR:
-            if kernelver_str.endswith(".%s" % kf):
-                self.flavour = kf
-                kernelver_str = kernelver_str[:-len(kf) - 1]
-                break
-
-        self._arch = None
-        for ka in KernelVer.ARCH:
-            if kernelver_str.endswith(".%s" % ka):
-                self._arch = ka
-                kernelver_str = kernelver_str[:-len(ka) - 1]
-                break
-
-        self.version, self.release = kernelver_str.split("-", 1)
-
-        if self.flavour is None:
-            for kf in KernelVer.FLAVOUR:
-                if self.release.endswith(kf):
-                    self.flavour = kf
-                    self.release = self.release[:-len(kf)]
-                    break
-
-        self.rt = "rt" in self.release
-
-        log_debug("Version: '%s'; Release: '%s'; Arch: '%s'; Flavour: '%s'; Realtime: %s"
-                  % (self.version, self.release, self._arch, self.flavour, self.rt))
-
-    def __str__(self) -> str:
-        result = "%s-%s" % (self.version, self.release)
-
-        if self._arch:
-            result = "%s.%s" % (result, self._arch)
-
-        if self.flavour:
-            result = "%s.%s" % (result, self.flavour)
-
-        return result
-
-    def __repr__(self) -> str:
-        return self.__str__()
-
-    def package_name_base(self, debug: bool = False) -> str:
-        base = "kernel"
-        if self.rt:
-            base = "%s-rt" % base
-
-        if self.flavour and not (debug and ".EL" in self.release):
-            base = "%s-%s" % (base, self.flavour)
-
-        if debug:
-            base = "%s-debuginfo" % base
-
-        return base
-
-    def package_name(self, debug: bool = False) -> str:
-        if self._arch is None:
-            raise Exception("Architecture is required for building package name")
-
-        base = self.package_name_base(debug)
-
-        return "%s-%s-%s.%s.rpm" % (base, self.version, self.release, self._arch)
-
-    def needs_arch(self) -> bool:
-        return self._arch is None
 
 
 def find_kernel_debuginfo(kernelver: KernelVer) -> Optional[Path]:
@@ -1594,8 +1586,12 @@ class RetraceTask:
                         if file_path == coredumps[0] and coredumps[0].name != self.COREDUMP_FILE:
                             file_path.rename(coredump)
 
+            required_files = REQUIRED_FILES[self.get_type()]
+            required_files.append("release")
+            required_files.append("os_release")
+
             for file_path in crashdir.iterdir():
-                if file_path.name in REQUIRED_FILES[self.get_type()]+["release", "os_release"]:
+                if file_path.name in required_files:
                     continue
 
                 file_path.unlink()

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -344,9 +344,11 @@ class RetraceWorker:
                     dnfcfg.write("baseurl=file://%s/%s/\n" % (CONFIG["RepoDir"], releaseid))
                     dnfcfg.write("failovermethod=priority\n")
 
-                child = run(["coredump2packages", str(crashdir / "coredump"),
-                             "--repos=%s" % repoid, "--config=%s" % dnfcfgpath,
-                             "--log=%s" % Path(self.task.get_savedir(), "c2p_log")],
+                child = run(["coredump2packages",
+                             str(crashdir / "coredump"),
+                             "--repos=%s" % repoid,
+                             "--config=%s" % dnfcfgpath,
+                             "--log=%s" % (self.task.get_savedir() / "c2p_log")],
                             stdout=PIPE, stderr=PIPE, encoding='utf-8', check=False)
                 section = 0
                 lines = child.stdout.split("\n")

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -73,7 +73,6 @@ class RetraceWorker:
         if self.logging_handler is not None:
             logger.removeHandler(self.logging_handler)
 
-
     def notify_email(self) -> None:
         task = self.task
         if not CONFIG["EmailNotify"] or not task.has_notify():
@@ -542,7 +541,7 @@ class RetraceWorker:
         if release.is_rawhide:
             # some packages might not be signed by rawhide key yet
             # but with a key of previous release
-            pre_rawhide_version = int(version) - 1
+            pre_rawhide_version = int(release.version) - 1
             release.version = "rawhide"
 
         releaseid = str(release)

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -930,14 +930,20 @@ class RetraceWorker:
                          "build",
                          "--file={}".format(savedir / RetraceTask.DOCKERFILE),
                          f"--tag=retrace-image:{img_cont_id}"],
-                        stdout=PIPE, stderr=STDOUT, check=False)
+                        stdout=PIPE, stderr=STDOUT, encoding="utf-8", check=False)
             if child.returncode:
                 raise Exception(f"Unable to build podman container: {child.stdout}")
 
             vmlinux = vmcore.prepare_debuginfo(task, kernelver=kernelver)
-            child = run([PODMAN_BIN, "run", "--detach", "-it", "--rm",
-                         "retrace-image:%s" % img_cont_id],
-                        stdout=PIPE, stderr=PIPE, encoding='utf-8', check=False)
+            child = run([PODMAN_BIN, "run",
+                         "--quiet",
+                         "--detach",
+                         "--interactive",
+                         "--tty",
+                         "--sdnotify=ignore",
+                         "--rm",
+                         f"retrace-image:{img_cont_id}"],
+                        stdout=PIPE, stderr=PIPE, encoding="utf-8", check=False)
             if child.stderr:
                 log_error(child.stderr)
                 raise Exception("Unable to run podman container")


### PR DESCRIPTION
These changes entail a complete refactoring of the Podman-based retracing backend. The biggest change is that only one container image is now built for each release (e.g. Fedora 32, Fedora 33, etc.) with basic tools preinstalled (abrt-addon-ccpp and GDB) and new containers are run from this base image on demand.

Some more changes are made for improving readability and maintainability.

See commits for details.

This code is currently deployed and ready for experimenting at <https://retrace-stg.aws.fedoraproject.org/> (only Fedora 33 supported).

Should fix at least [rhbz#1922471](https://bugzilla.redhat.com/show_bug.cgi?id=1922471) and [rhbz#1932768](https://bugzilla.redhat.com/show_bug.cgi?id=1932768).