### PR TITLE
Add debuginfod support to retrace-server

### DIFF
--- a/doc/retrace-server.texi
+++ b/doc/retrace-server.texi
@@ -427,6 +427,15 @@ The files containing the debugging symbols for the binary and libraries
 (build-ids are used to find the pairs) need to be available to GDB.
 @end itemize
 
+Alternatively if GDB is built with @command{debuginfod} support and
+the @var{DebuginfodEnable} option is enabled in the Retrace Server's
+configuration, then GDB will query the @command{debuginfod} servers
+listed in @var{DebuginfodURLs} in the configuration file for all
+of the debugging resources needed to generate the backtrace. The
+task also needs to be created with the @var{X-Debuginfod} header.
+For more information regarding @command{debuginfod} see
+@uref{https://sourceware.org/elfutils/Debuginfod.html}.
+
 The chroot environments are created and managed by @command{mock}, and
 they reside in @file{/var/lib/mock/@var{taskid}}. The retrace worker
 generates a mock configuration file and then invokes @command{mock} to
@@ -1046,6 +1055,10 @@ Default 0,
 @var{UseFafPackages} boolean; experimental; whether to use FAF's
 package database for getting debuginfos. @xref{FAF integration}.
 Default 0.
+@var{DebuginfodEnable} boolean; whether to use debuginfod to aquire
+debugging resources for corefile.
+@var{DebuginfodURLs} string; space-separated URLs of debuginfod servers.
+Default @url{debuginfod.fedoraproject.org}.
 
 @end itemize
 

--- a/man/retrace-server-interact.txt
+++ b/man/retrace-server-interact.txt
@@ -60,6 +60,9 @@ OPTIONS
 --priv::
    Use the chroot as privileged user.
 
+--debuginfod::
+   Use debuginfod to aquire debugging resources needed for corefile
+
 AUTHORS
 -------
 * Michal Toman <_mtoman@redhat.com_>

--- a/man/retrace-server-task.txt
+++ b/man/retrace-server-task.txt
@@ -100,6 +100,9 @@ CREATE OR BATCH OPTIONS
    Write the email field in the task to EMAIL.
    Available only for manager and ftp task.
 
+-D, --debuginfod::
+   Use debuginfod to aquire debugging resources needed for corefile.
+
 -d, --no-md5::
    Do not calculate md5sum on the task.
    Available only for manager and ftp task.

--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -120,6 +120,12 @@ FTPBufferSize = 16
 # Whether to use wget as a fallback to finding kernel debuginfos
 WgetKernelDebuginfos = 0
 
+# Whether to use debuginfod to aquire debugging resources for corefile
+DebuginfodEnable = 0
+
+# Space-separated URLs of debuginfod servers
+DebuginfodURLs = debuginfod.fedoraproject.org
+
 # Where to download kernel debuginfos from
 # $VERSION $RELEASE and $ARCH are replaced by the appropriate value
 # kernel-debuginfo-VRA.rpm is appended to the end

--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -82,6 +82,12 @@ def application(environ, start_response):
                         _("X-CoreFileDirectory header has been disabled "
                           "by server administrator"))
 
+    if (not CONFIG["DebuginfodEnable"] and
+            "X-Debuginfod" in request.headers):
+        return response(start_response, "403 Forbidden",
+                        _("X-Debuginfod header has been disabled "
+                          "by server administrator"))
+
     workdir = Path(CONFIG["SaveDir"])
 
     if not workdir.is_dir():
@@ -224,6 +230,9 @@ def application(environ, start_response):
         task.set_type(tasktype)
     else:
         task.set_type(TASK_RETRACE)
+
+    if "X-Debuginfod" in request.headers:
+        task.set_debuginfod_enabled(True)
 
     present_files = [f.name for f in files]
     for required_file in REQUIRED_FILES[task.get_type()]:

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -39,6 +39,8 @@ if __name__ == "__main__":
     parser.add_argument("action", help="Desired action (%s)" % "|".join(ACTIONS))
     parser.add_argument("-f", "--force", action="store_true", default=False,
                         help="Run `set-success` or `set-fail` action even if the task is still running")
+    parser.add_argument("-D", "--debuginfod", action="store_true", default=False,
+                        help="Use debuginfod to aquire debugging resources needed for corefile")
     args = parser.parse_args()
 
     if args.action not in ACTIONS:
@@ -54,6 +56,9 @@ if __name__ == "__main__":
 
     # touch the task directory
     task.reset_age()
+
+    if args.debuginfod:
+        task.set_debuginfod_enabled(True)
 
     if args.action == "printdir":
         sys.stdout.write("%s\n" % task.get_savedir())
@@ -106,8 +111,12 @@ if __name__ == "__main__":
                 sys.stderr.write("executable contains forbidden characters.\n")
                 sys.exit(1)
 
-            cmdline = ["/usr/bin/mock", "--configdir", str(task.get_savedir()), "shell",
-                       "gdb '%s' /var/spool/abrt/crash/coredump" % executable]
+            if task.get_debuginfod_enabled():
+                cmdline = ["/usr/bin/mock", "--configdir", str(task.get_savedir()), "shell",
+                           "gdb -c /var/spool/abrt/crash/coredump"]
+            else:
+                cmdline = ["/usr/bin/mock", "--configdir", str(task.get_savedir()), "shell",
+                           "gdb '%s' /var/spool/abrt/crash/coredump" % executable]
 
             print_cmdline(cmdline)
             os.execvp(cmdline[0], cmdline)

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -207,6 +207,9 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
                    'X-Task-Type': str(task_type),
                    'Connection': 'close'}
 
+        if args['debuginfod']:
+            headers['X-Debuginfod'] = "1"
+
         request = requests.Request('POST',
                                    args['server'] + "/create",
                                    headers=headers)
@@ -533,6 +536,9 @@ if __name__ == "__main__":
                                 help="Retrace kernel vmcore")
         tmp.add_argument("COREFILE",
                          help="File to be retraced")
+        tmp.add_argument("-D", "--debuginfod", action="store_true",
+                         help=("Use debuginfod in order to aquire server-side "
+                               "debugging resources."))
 
         input_group = tmp.add_mutually_exclusive_group()
         input_group.add_argument("-t", "--http", action="store_const",

--- a/src/retrace-server-worker
+++ b/src/retrace-server-worker
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     cmdline_parser.add_argument("--kernelver", default=None,
                                 help="Kernel version (e.g. 2.6.32-287.el6), also needs --arch")
     cmdline_parser.add_argument("--arch", help="Architecture")
+    cmdline_parser.add_argument("--debuginfod", action="store_true", default=False,
+                                help="Use debuginfod to aquire debugging resources needed for corefile")
     cmdline = cmdline_parser.parse_args()
 
     log = cmdline._log
@@ -43,6 +45,9 @@ if __name__ == "__main__":
     except Exception:
         sys.stderr.write("Task '%d' does not exist\n" % cmdline.task_id)
         sys.exit(1)
+
+    if cmdline.debuginfod:
+        task.set_debuginfod_enabled(True)
 
     if task.has_status():
         if not cmdline.restart:

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -67,6 +67,8 @@ class Config:
             "FTPPass": "",
             "FTPDir": "/",
             "FTPBufferSize": 16,
+            "DebuginfodEnable": 0,
+            "DebuginfodURLs": "debuginfod.fedoraproject.org",
             "WgetKernelDebuginfos": False,
             "KernelDebuginfoURL": "http://kojipkgs.fedoraproject.org/packages/kernel/$VERSION/$RELEASE/$ARCH/",
             "VmcoreDumpLevel": 0,


### PR DESCRIPTION
Debuginfod is an HTTP server for distributing ELF, DWARF and source
code.

This patch allows retrace-server to skip aquiring packages needed to
generate a backtrace from a corefile. Instead, when configured to do so,
GDB's built-in debuginfod client will automatically query debuginfod
servers in order to aquire the necessary debugging resources during
backtrace generation.

Two new options are added to retrace-server.conf: 'DebuginfodEnable'
determines whether the server will permit debuginfod functionality and
'DebuginfodURLs' is a list of servers to be queried by the GDB
debuginfod client.

'--debuginfod' options are also added to retrace-server-{interact, task,
worker}.

Documentation is updated to mention debuginfod.

For more information regarding debuginfod, see
https://sourceware.org/elfutils/Debuginfod.html

Note that upstream improvements to GDB's debuginfod corefile support
are currently in the works. Until these improvements are available
in the Fedora builds of GDB available from DNF, it is recommended
that retrace-server uses the following GDB rpms for the best
debuginfod performance when testing or experimenting with this PR:
https://copr.fedorainfracloud.org/coprs/amerey/gdb-debuginfod-core/  