### PR TITLE
retrace-server-task: Fix Traceback with no arguments

### DIFF
--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -649,6 +649,10 @@ if __name__ == "__main__":
 
     ARGS = vars(PARSER.parse_args())
 
+    if len(ARGS) == 1:
+        PARSER.print_help(sys.stderr)
+        sys.exit(1)
+
     # if not verifying certificates, suppress warning
     if ARGS['no_verify']:
         requests.packages.urllib3.disable_warnings(InsecureRequestWarning)


### PR DESCRIPTION
Fix the following Traceback by checking for no arguments and
defaulting to help text.

Before this patch:
$ retrace-server-task
Traceback (most recent call last):
  File "/usr/bin/retrace-server-task", line 653, in <module>
    if ARGS['no_verify']:
KeyError: 'no_verify'

After this patch:
$ retrace-server-task
usage: retrace-server-task [-h] {create,batch,get,set,restart} ...

Create, watch and settasks through commandline

positional arguments:
  {create,batch,get,set,restart}

optional arguments:
  -h, --help            show this help message and exit

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>