### PR TITLE
retrace-server-task: Improve verbose error message when 'create' fails

### DIFF
--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -708,8 +708,10 @@ if __name__ == "__main__":
             sys.exit(1)
         if req.status_code != 200:
             raise requests.exceptions.ConnectionError
-    except requests.exceptions.RequestException:
-        LOGGER.info("Could not connect to server ‘%s’. Falling back to ‘%s’",
+    except requests.exceptions.RequestException as ex:
+        if 'debug' in ARGS:
+            LOGGER.error("Requests generic exception: '%s'", str(ex))
+        LOGGER.error("Could not connect to server ‘%s’. Falling back to ‘%s’",
                     ARGS['server'], FALLBACK_SERVER)
         ARGS['server'] = FALLBACK_SERVER
 


### PR DESCRIPTION
When the 'create' command fails due to some error on the server such as a
certificate problem, today we don't print any more information but just
print "Could not connect to server".  Improve debugging when connections
fail by printing the string value of the requests exception.

Before this patch:
$ retrace-server-task create -v ./vmcore
INFO:root:Defaulting to manager task
INFO:root:Trying to connect to ‘https://retrace.example.com’...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): retrace.example.com:443
INFO:root:Could not connect to server ‘https://retrace.example.com’. Falling back to ‘https://retrace.fedoraproject.org’

After this patch:
$ ./retrace-server-task create -v ./vmcore
INFO:root:Defaulting to manager task
INFO:root:Trying to connect to ‘https://retrace.example.com’...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): retrace.example.com:443
ERROR:root:Requests generic exception: 'HTTPSConnectionPool(host='retrace.example.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)'),))'
ERROR:root:Could not connect to server ‘https://retrace.example.com’. Falling back to ‘https://retrace.fedoraproject.org’

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>