### PR TITLE
util: Print 1024 bytes as 1.00 kB

### DIFF
--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -130,10 +130,9 @@ def ftp_list_dir(ftpdir: str = "/", ftp: Optional[ftplib.FTP] = None) -> List[st
 def human_readable_size(bytesize: SupportsFloat) -> str:
     size = float(bytesize)
     unit = 0
-    while size > 1024.0 and unit < len(UNITS) - 1:
+    while size >= 1024.0 and unit < len(UNITS) - 1:
         unit += 1
         size /= 1024.0
-
     return "%.2f %s" % (size, UNITS[unit])
 
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,6 +24,7 @@ test_env.set('RETRACE_SERVER_TESTING', '1')
 
 test_files = [
   'test_backends.py',
+  'test_util.py',
 ]
 
 foreach file: test_files

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from retrace.util import human_readable_size
+
+
+class TestHumanReadableSize(TestCase):
+    CONTAINER_ID = "cefe728950018e14f00cc874d45259742e2925c6ab40e0044a4aedaf1514b660"
+
+    def test_zero_bytes(self):
+        self.assertEqual(human_readable_size(0), '0.00 B')
+
+    def test_one_byte(self):
+        self.assertEqual(human_readable_size(1), '1.00 B')
+
+    def test_one_kilobyte(self):
+        self.assertEqual(human_readable_size(1000), '1000.00 B')
+
+    def test_one_kibibyte(self):
+        self.assertEqual(human_readable_size(1024), '1.00 kB')
+
+    def test_1025_bytes(self):
+        self.assertEqual(human_readable_size(1025), '1.00 kB')
+
+    def test_one_mebibyte(self):
+        self.assertEqual(human_readable_size(1024 * 1024), '1.00 MB')
+
+    def test_five_mebibytes(self):
+        self.assertEqual(human_readable_size(5 * 1024 * 1024), '5.00 MB')
+
+    def test_one_pebibyte(self):
+        self.assertEqual(human_readable_size(1024 ** 5), '1.00 PB')


### PR DESCRIPTION
Adjust the `human_readable_size` function to print 1024 bytes as 1.00 kB intead of 1024.00 B.

Also testing the code coverage reporting setup.