### PR TITLE
Replace TASK_RETRACE with TASK_COREDUMP for consistency

### DIFF
--- a/doc/retrace-server.texi
+++ b/doc/retrace-server.texi
@@ -201,10 +201,10 @@ Large} HTTP error code. The limit can be checked by calling
 @indicateurl{https://server/settings}. The limit is changeable
 from the server configuration file. Client is allowed to specify
 an optional @var{X-Task-Type} header, identifying the task type.
-At the moment @code{TASK_RETRACE (0)}, @code{TASK_DEBUG (1)} and
-@code{TASK_RETRACE_INTERACTIVE (3)} can be used for binary crashes
+At the moment @code{TASK_COREDUMP (0)}, @code{TASK_DEBUG (1)} and
+@code{TASK_COREDUMP_INTERACTIVE (3)} can be used for binary crashes
 and @code{TASK_VMCORE (2)} and @code{TASK_VMCORE_INTERACTIVE (4)} for
-kernel crashes. If no @var{X-Task-Type} is specified, @code{TASK_RETRACE}
+kernel crashes. If no @var{X-Task-Type} is specified, @code{TASK_COREDUMP}
 is used.
 
 If unpacking the archive would result in having the free disk space
@@ -780,7 +780,7 @@ safely use it, as the data will also be signed.
 @section Overview
 
 When the task type specified by @var{X-Task-Type} header is either
-@code{TASK_RETRACE_INTERACTIVE} or @code{TASK_VMCORE_INTERACTIVE},
+@code{TASK_COREDUMP_INTERACTIVE} or @code{TASK_VMCORE_INTERACTIVE},
 the standard process is executed, but the chroot is not cleaned up.
 It can be later accessed by the @file{retrace-server-interact} tool,
 which is basically a wrapper over @file{mock}, @file{gdb}
@@ -922,8 +922,8 @@ Now FAF's package database is used for the following:
 @item @command{is_package_known} function to find out whether a
 package is supported for retracing.
 @item @command{find_kernel_debuginfo} function to get debuginfos for
-@code{TASK_VMCORE} and @code{TAS_VMCORE_INTERACTIVE} tasks.
-@item @code{TASK_RETRACE} and @code{TASK_RETRACE_INTERACTIVE} tasks.
+@code{TASK_VMCORE} and @code{TASK_VMCORE_INTERACTIVE} tasks.
+@item @code{TASK_COREDUMP} and @code{TASK_COREDUMP_INTERACTIVE} tasks.
 Every time a retracing environment is being created, the coredump is
 passed to FAF's @code{c2p} action (instead of Retrace Server's
 @code{coredump2packages} tool), which copies or links debuginfos to a

--- a/src/create.wsgi
+++ b/src/create.wsgi
@@ -9,8 +9,8 @@ from tempfile import NamedTemporaryFile
 from retrace.retrace import (ALLOWED_FILES,
                              REQUIRED_FILES,
                              SNAPSHOT_SUFFIXES,
-                             TASK_RETRACE,
-                             TASK_RETRACE_INTERACTIVE,
+                             TASK_COREDUMP,
+                             TASK_COREDUMP_INTERACTIVE,
                              TASK_TYPES,
                              TASK_VMCORE,
                              TASK_VMCORE_INTERACTIVE,
@@ -211,19 +211,19 @@ def application(environ, start_response):
         try:
             tasktype = int(request.headers["X-Task-Type"])
         except TypeError:
-            tasktype = TASK_RETRACE
+            tasktype = TASK_COREDUMP
 
         if tasktype not in TASK_TYPES:
-            tasktype = TASK_RETRACE
+            tasktype = TASK_COREDUMP
 
-        if tasktype in [TASK_RETRACE_INTERACTIVE, TASK_VMCORE_INTERACTIVE] \
+        if tasktype in [TASK_COREDUMP_INTERACTIVE, TASK_VMCORE_INTERACTIVE] \
            and not CONFIG["AllowInteractive"]:
             task.remove()
             return response(start_response, "409 Conflict",
                             _("Interactive tasks were disabled by server administrator"))
         task.set_type(tasktype)
     else:
-        task.set_type(TASK_RETRACE)
+        task.set_type(TASK_COREDUMP)
 
     present_files = [f.name for f in files]
     for required_file in REQUIRED_FILES[task.get_type()]:

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, List
 
 from retrace.retrace import (STATUS, STATUS_DOWNLOADING, STATUS_FAIL,
-                             STATUS_SUCCESS, TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE,
+                             STATUS_SUCCESS, TASK_DEBUG, TASK_COREDUMP, TASK_COREDUMP_INTERACTIVE,
                              TASK_VMCORE, TASK_VMCORE_INTERACTIVE,
                              KernelVer,
                              RetraceTask)
@@ -30,10 +30,10 @@ FTP_SUPPORTED_EXTENSIONS = [".tar.gz", ".tgz", ".tarz", ".tar.bz2", ".tar.xz",
 MANAGER_URL_PARSER = re.compile(r"^(.*/manager)(/(([^/]+)(/(__custom__|start|restart|restart_confirm|backtrace|savenotes|caseno|"
                                 r"bugzillano|notify|delete(/(sure/?)?)?|results/([^/]+)/?)?)?)?)?$")
 
-LONG_TYPES = {TASK_RETRACE: "Coredump retrace",
+LONG_TYPES = {TASK_COREDUMP: "Coredump retrace",
               TASK_DEBUG: "Coredump retrace - debug",
               TASK_VMCORE: "VMcore retrace",
-              TASK_RETRACE_INTERACTIVE: "Coredump retrace - interactive",
+              TASK_COREDUMP_INTERACTIVE: "Coredump retrace - interactive",
               TASK_VMCORE_INTERACTIVE: "VMcore retrace - interactive"}
 
 
@@ -515,7 +515,7 @@ def application(environ, start_response):
             return response(start_response, "500 Internal Server Error", _("Unable to create a new task"))
 
         if "task_type" in POST and POST["task_type"] == "coredump":
-            task.set_type(TASK_RETRACE_INTERACTIVE)
+            task.set_type(TASK_COREDUMP_INTERACTIVE)
             if "package" in POST and POST["package"]:
                 task.set("custom_package", POST["package"])
             if "executable" in POST and POST["executable"]:
@@ -598,7 +598,7 @@ def application(environ, start_response):
                 backtrace = "<tr><td colspan=\"2\"><a href=\"%s/backtrace\">%s</a></td></tr>" \
                             % (request.path_url.rstrip("/"), _("Show raw backtrace"))
                 backtracewindow = "<h2>Backtrace</h2><textarea class=\"backtrace\">%s</textarea>" % task.get_backtrace()
-                if task.get_type() in [TASK_RETRACE_INTERACTIVE, TASK_VMCORE_INTERACTIVE]:
+                if task.get_type() in [TASK_COREDUMP_INTERACTIVE, TASK_VMCORE_INTERACTIVE]:
                     if task.get_type() == TASK_VMCORE_INTERACTIVE:
                         debugger = "crash"
                     else:

--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -12,7 +12,7 @@ from subprocess import list2cmdline
 from retrace.retrace import (ALLOWED_FILES,
                              STATUS_FAIL,
                              STATUS_SUCCESS,
-                             TASK_RETRACE_INTERACTIVE,
+                             TASK_COREDUMP_INTERACTIVE,
                              TASK_VMCORE_INTERACTIVE,
                              KernelVMcore,
                              KernelVer,
@@ -94,7 +94,7 @@ if __name__ == "__main__":
             task.set_finished_time(int(time.time()))
         sys.exit(0)
 
-    if task.get_type() == TASK_RETRACE_INTERACTIVE:
+    if task.get_type() == TASK_COREDUMP_INTERACTIVE:
         if args.action == "shell":
             cmdline = ["/usr/bin/mock", "--configdir", str(task.get_savedir()), "shell"]
             print_cmdline(cmdline)

--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -22,7 +22,7 @@ from retrace.retrace import add_snapshot_suffix
 
 
 FALLBACK_SERVER = 'https://retrace.fedoraproject.org'
-TASK_RETRACE, TASK_DEBUG, TASK_VMCORE, TASK_RETRACE_INTERACTIVE, \
+TASK_COREDUMP, TASK_DEBUG, TASK_VMCORE, TASK_COREDUMP_INTERACTIVE, \
     TASK_VMCORE_INTERACTIVE = range(5)
 
 
@@ -183,9 +183,9 @@ def create_new_task(args: Dict[str, Any]) -> Tuple[int, Optional[str]]:
         LOGGER.info("Starting new http task")
         if args['task_type'] == 'coredump':
             if args['interactive']:
-                task_type = TASK_RETRACE_INTERACTIVE
+                task_type = TASK_COREDUMP_INTERACTIVE
             else:
-                task_type = TASK_RETRACE
+                task_type = TASK_COREDUMP
         elif args['interactive']:
             task_type = TASK_VMCORE_INTERACTIVE
         else:

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -45,17 +45,17 @@ ALLOWED_FILES = {
     "vmcore.vmem": 0,
 }
 
-TASK_RETRACE, TASK_DEBUG, TASK_VMCORE, TASK_RETRACE_INTERACTIVE, \
+TASK_COREDUMP, TASK_DEBUG, TASK_VMCORE, TASK_COREDUMP_INTERACTIVE, \
   TASK_VMCORE_INTERACTIVE = range(5)
 
-TASK_TYPES = [TASK_RETRACE, TASK_DEBUG, TASK_VMCORE,
-              TASK_RETRACE_INTERACTIVE, TASK_VMCORE_INTERACTIVE]
+TASK_TYPES = [TASK_COREDUMP, TASK_DEBUG, TASK_VMCORE,
+              TASK_COREDUMP_INTERACTIVE, TASK_VMCORE_INTERACTIVE]
 
 REQUIRED_FILES = {
-    TASK_RETRACE:             ["coredump", "executable", "package"],
+    TASK_COREDUMP:             ["coredump", "executable", "package"],
     TASK_DEBUG:               ["coredump", "executable", "package"],
     TASK_VMCORE:              ["vmcore"],
-    TASK_RETRACE_INTERACTIVE: ["coredump", "executable", "package"],
+    TASK_COREDUMP_INTERACTIVE: ["coredump", "executable", "package"],
     TASK_VMCORE_INTERACTIVE:  ["vmcore"],
 }
 
@@ -1154,17 +1154,17 @@ class RetraceTask:
 
     def get_type(self) -> int:
         """Returns task type. If TYPE_FILE is missing,
-        task is considered standard TASK_RETRACE."""
+        task is considered standard TASK_COREDUMP."""
         result = self.get(RetraceTask.TYPE_FILE, maxlen=8)
         if result is None:
-            return TASK_RETRACE
+            return TASK_COREDUMP
 
         return int(result)
 
     def set_type(self, newtype: int) -> None:
         """Atomically writes given type into TYPE_FILE."""
         if newtype not in TASK_TYPES:
-            newtype = TASK_RETRACE
+            newtype = TASK_COREDUMP
 
         self.set_atomic(RetraceTask.TYPE_FILE, str(newtype))
 
@@ -1495,7 +1495,7 @@ class RetraceTask:
                         unpack_vmcore(fullpath)
                     except Exception as ex:
                         errors.append((str(fullpath), str(ex)))
-                if self.get_type() in [TASK_RETRACE, TASK_RETRACE_INTERACTIVE]:
+                if self.get_type() in [TASK_COREDUMP, TASK_COREDUMP_INTERACTIVE]:
                     try:
                         unpack_coredump(fullpath)
                     except Exception as ex:
@@ -1554,7 +1554,7 @@ class RetraceTask:
 
                 file_path.unlink()
 
-        if self.get_type() in [TASK_RETRACE, TASK_RETRACE_INTERACTIVE]:
+        if self.get_type() in [TASK_COREDUMP, TASK_COREDUMP_INTERACTIVE]:
             coredump = crashdir / self.COREDUMP_FILE
             for file_path in crashdir.iterdir():
                 if file_path.is_dir():

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -18,7 +18,7 @@ from .retrace import (ALLOWED_FILES, EXPLOITABLE_SEPARATOR, PYTHON_LABEL_END,
                       PYTHON_LABEL_START, REPO_PREFIX, REQUIRED_FILES,
                       STATUS, STATUS_ANALYZE, STATUS_BACKTRACE, STATUS_CLEANUP,
                       STATUS_FAIL, STATUS_INIT, STATUS_STATS, STATUS_SUCCESS,
-                      TASK_DEBUG, TASK_RETRACE, TASK_RETRACE_INTERACTIVE, TASK_VMCORE,
+                      TASK_DEBUG, TASK_COREDUMP, TASK_COREDUMP_INTERACTIVE, TASK_VMCORE,
                       TASK_VMCORE_INTERACTIVE, RETRACE_GPG_KEYS, SNAPSHOT_SUFFIXES,
                       get_active_tasks,
                       get_supported_releases,
@@ -179,7 +179,7 @@ class RetraceWorker:
         except Exception as ex:
             log_warn("Failed to save crash statistics: %s" % str(ex))
 
-        if not task.get_type() in [TASK_DEBUG, TASK_RETRACE_INTERACTIVE, TASK_VMCORE_INTERACTIVE]:
+        if not task.get_type() in [TASK_DEBUG, TASK_COREDUMP_INTERACTIVE, TASK_VMCORE_INTERACTIVE]:
             self.clean_task()
 
         self.hook.run("fail")
@@ -516,7 +516,7 @@ class RetraceWorker:
 
         return image_tag
 
-    def start_retrace(self, custom_arch: Optional[str] = None) -> bool:
+    def start_coredump(self, custom_arch: Optional[str] = None) -> bool:
         self.hook.run("start")
 
         task = self.task
@@ -664,7 +664,7 @@ class RetraceWorker:
         # does not work at the moment
         rootsize = 0
 
-        if not task.get_type() in [TASK_DEBUG, TASK_RETRACE_INTERACTIVE]:
+        if not task.get_type() in [TASK_DEBUG, TASK_COREDUMP_INTERACTIVE]:
             # clean up temporary data
             task.set_status(STATUS_CLEANUP)
             log_info(STATUS[STATUS_CLEANUP])
@@ -1122,8 +1122,8 @@ class RetraceWorker:
                 if not self._check_required_file(required_file, crashdir):
                     raise Exception("Crash directory does not contain required file '%s'" % required_file)
 
-            if tasktype in [TASK_RETRACE, TASK_DEBUG, TASK_RETRACE_INTERACTIVE]:
-                self.start_retrace(custom_arch=arch)
+            if tasktype in [TASK_COREDUMP, TASK_DEBUG, TASK_COREDUMP_INTERACTIVE]:
+                self.start_coredump(custom_arch=arch)
             elif tasktype in [TASK_VMCORE, TASK_VMCORE_INTERACTIVE]:
                 self.start_vmcore(custom_kernelver=kernelver)
             else:


### PR DESCRIPTION
In retrace-server there are userspace coredumps and kernel vmcores.
The kernel vmcores have tasks identified by TASK_VMCORE and
TASK_VMCORE_INTERACTIVE.  However, userspace coredumps are
identified with TASK_RETRACE and TASK_RETRACE_INTERACTIVE,
which is inconsistent and ambigous.  Thus, rename TASK_RETRACE
and TASK_RETRACE_INTERACTIVE to TASK_COREDUMP and
TASK_COREDUMP_INTERACTIVE.  In addition, correct one typo
in doc/retrace-server.texi.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>