### PR TITLE
Fix typos

### DIFF
--- a/doc/retrace-server.texi
+++ b/doc/retrace-server.texi
@@ -56,7 +56,7 @@ Analyzing a program crash from a coredump is a difficult task. The GNU
 Debugger (GDB), that is commonly used to analyze coredumps on free
 operating systems, expects that the system analyzing the coredump is
 identical to the system where the program crashed. Software updates
-often break this assumption even on the system where the crash occured,
+often break this assumption even on the system where the crash occurred,
 making the coredump analyzable only with significant
 effort. Furthermore, older versions of software packages are often
 removed from software repositories, including the packages with

--- a/src/delete.wsgi
+++ b/src/delete.wsgi
@@ -40,7 +40,7 @@ def application(environ, start_response):
         task.remove()
     except Exception:
         return response(start_response, "500 Internal Server Error",
-                        _("An error occured while deleting task data"))
+                        _("An error occurred while deleting task data"))
 
     return response(start_response, "200 OK",
                     _("All task data were deleted successfully"))

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -994,7 +994,7 @@ class RetraceTask:
         status = url.getcode()
         url.close()
 
-        # 1/0 just to be consitent with call() in _start_local
+        # 1/0 just to be consistent with call() in _start_local
         if status != 201:
             return 1
 
@@ -1701,7 +1701,7 @@ class RetraceTask:
             self.delete(RetraceTask.MANAGED_FILE)
 
     def has_downloaded(self) -> bool:
-        """Verifies whether DOWNLOAD_FILE exists"""
+        """Verifies whether DOWNLOADED_FILE exists"""
         return self.has(RetraceTask.DOWNLOADED_FILE)
 
     def get_downloaded(self) -> Optional[str]:

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -193,7 +193,7 @@ class RetraceWorker:
             output = child.stdout
         except Exception as ex:
             child = None
-            log_error("An unhandled exception occured: %s" % ex)
+            log_error("An unhandled exception occurred: %s" % ex)
 
         if not child or child.returncode != 0:
             exit_code = str(child.returncode) if child else 'unknown'
@@ -1029,7 +1029,7 @@ class RetraceWorker:
         if ret == 0 and crash_sys:
             task.add_results("sys", crash_sys)
         else:
-            # FIXME: Probably a better hueristic can be done here
+            # FIXME: Probably a better heuristic can be done here
             if len(kernellog) < 1024:
                 # If log < 1024 bytes, probably it is not useful so fail task
                 raise Exception("Failing task due to crash exiting with non-zero status and "


### PR DESCRIPTION
Just some stuff I noticed when checking pull/447 - an identifier in a docstring for consistency and a few typos.