### PR TITLE
bugzilla-query: Use 'limit' option and search only recently modified …

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -170,6 +170,11 @@ BugzillaComponent = kernel
 BugzillaTriggerWords = retrace-server-interact, retrace/tasks
 # Regular expressions used to get task numbers from the text of bugzilla bugs
 BugzillaRegExes = retrace-server-interact\\s+([0-9]{9}), /var/spool/retrace-server/([0-9]{9})/crash/vmcore
+# Used to limit the bugzilla query to bugs changed to a number of hours ago
+# Should be set to a number of hours that is greater than or equal to
+# the frequency of the cronjob that runs retrace-server-bugzilla-query.
+# Default: 168 hours (7 days)
+BugzillaQueryLastChangeDelta = 168
 
 # Timeout (in seconds) for communication with any process
 ProcessCommunicateTimeout = 3600

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 """
-Query bugzilla for component bugs and search through comments for trigger words. Output results
-to a log and for tasks found in the comments set bugzillano field with bugzilla ids.
+Query bugzilla for component bugs and search through comments for
+trigger words.  Output results to a log and for tasks found in the
+comments set bugzillano field with bugzilla ids.
 """
 
 import sys
@@ -32,7 +33,8 @@ if __name__ == "__main__":
         bz_creds = CONFIG["BugzillaCredentials"]
 
         try:
-            bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None, tokenfile=None)
+            bzapi = bugzilla.Bugzilla(url=bz_url, cookiefile=None,
+                                      tokenfile=None)
         except (bugzilla.BugzillaError, ValueError) as e:
             log.write("Exception: {0}".format(e))
             sys.exit(1)
@@ -81,7 +83,7 @@ if __name__ == "__main__":
                 found_ids: Set[str] = set()
                 for comment in bug.comments:
                     for i, trigger_word in enumerate(trigger_words):
-                        # Only if trigger word is in comment do we use slower regex
+                        # Use slower regex only if trigger word is in comment
                         if trigger_word in comment["text"]:
                             m = re.findall(regexes[i], comment["text"])
                             found_ids.update(m)
@@ -105,10 +107,13 @@ if __name__ == "__main__":
 
             existing_tasks.append(taskdir.name)
 
-        log.write("------------Existing tasks with found bugzillas-----------\n")
+        log.write("------------"
+                  "Existing tasks with found bugzillas"
+                  "------------\n")
         for taskid in found_tasks:
             if taskid in existing_tasks:
-                log.write("Task {0} has following bugzilla(s): {1}.\n".format(taskid, ", ".join(found_tasks[taskid])))
+                log.write("Task {0} has following bugzilla(s): {1}."
+                          "\n".format(taskid, ", ".join(found_tasks[taskid])))
                 try:
                     task = RetraceTask(taskid)
                 except Exception:
@@ -118,18 +123,25 @@ if __name__ == "__main__":
                     current = task.get_bugzillano()
                     assert isinstance(current, list)
                     found = found_tasks[taskid]
-                    # only set bugzillano if some found bugzillas aren't in current bugzillano list
+                    # Only set bugzillano if some aren't in current list
                     if not set(found).issubset(current):
                         task.set_bugzillano(current + found)
                 else:
                     task.set_bugzillano(found_tasks[taskid])
 
-        log.write("\n\n------------Found tasks in bugzillas that do not exist on local system-----------\n")
+        log.write("\n\n"
+                  "------------"
+                  "Found tasks in bugzillas that do not exist on local system"
+                  "------------\n")
         for taskid in found_tasks:
             if taskid not in existing_tasks:
                 log.write("Unknown task {0} has following bugzilla(s): {1}.\n"
                           .format(taskid, ", ".join(found_tasks[taskid])))
 
-        log.write("\n\n------------Existing tasks that no bugzilla was found for-----------\n")
-        no_bz_tasks = [taskid for taskid in existing_tasks if taskid not in found_tasks.keys()]
+        log.write("\n\n"
+                  "------------"
+                  "Existing tasks that no bugzilla was found "
+                  "------------\n")
+        no_bz_tasks = [taskid for taskid in existing_tasks
+                       if taskid not in found_tasks.keys()]
         log.write("{0}\n\n".format(", ".join(no_bz_tasks)))

--- a/src/retrace-server-bugzilla-query
+++ b/src/retrace-server-bugzilla-query
@@ -7,6 +7,7 @@ to a log and for tasks found in the comments set bugzillano field with bugzilla 
 import sys
 import re
 import time
+from datetime import datetime, timedelta
 
 from typing import Dict, List, Set
 from pathlib import Path
@@ -17,6 +18,7 @@ from retrace.retrace import BUGZILLA_STATUS, RetraceTask
 from retrace.config import Config
 
 CONFIG = Config()
+BUGZILLA_QUERY_LIMIT = 500
 
 if __name__ == "__main__":
 
@@ -47,37 +49,39 @@ if __name__ == "__main__":
         else:
             log.write("Not logged in. Continue as anonymous user.\n")
 
+        found_tasks: Dict[str, List[str]] = {}
         product_list = CONFIG.get_list("BugzillaProduct")
         component_list = CONFIG.get_list("BugzillaComponent")
-
-        query = bzapi.build_query(
-            product=product_list,
-            component=component_list,
-            include_fields=["id"])
-
-        # I don't want to run regex on each and every comment, at first try fast check
-        # if trigger word is in comment and if is, then use slower regex
+        config_status = CONFIG.get_list("BugzillaStatus")
         trigger_words = CONFIG.get_list("BugzillaTriggerWords")
         regexes = CONFIG.get_list("BugzillaRegExes")
+        delta = CONFIG["BugzillaQueryLastChangeDelta"]
 
-        config_status = CONFIG.get_list("BugzillaStatus")
+        query = bzapi.build_query(product=product_list,
+                                  component=component_list,
+                                  include_fields=["id", "comments"])
         query["status"] = list(set(BUGZILLA_STATUS).difference(config_status))
+        query["last_change_time"] = datetime.today() - timedelta(hours = delta)
+        bugzilla_offset = 0
+        bugzilla_bug_count = 0
+        while True:
+            bugzilla_offset += bugzilla_bug_count
+            query["offset"] = bugzilla_offset
+            query["limit"] = BUGZILLA_QUERY_LIMIT
+            bugs = bzapi.query(query)
 
-        found_tasks: Dict[str, List[str]] = {}
+            bugzilla_bug_count = len(bugs)
+            log.write("Query returned {0} bugs at offset {1}"
+                      "\n".format(bugzilla_bug_count, bugzilla_offset))
+            # Query until we get no bugs back, which indicates the end
+            if bugzilla_bug_count == 0:
+                break
 
-        bugs = [x.bug_id for x in bzapi.query(query)]
-
-        while bugs:
-            query = bzapi.build_query(
-                bug_id=bugs[:250],
-                include_fields=["id", "comments"])
-
-            cur_bugs = bzapi.query(query)
-            bugs = bugs[250:]
-            for bug in cur_bugs:
+            for bug in bugs:
                 found_ids: Set[str] = set()
                 for comment in bug.comments:
                     for i, trigger_word in enumerate(trigger_words):
+                        # Only if trigger word is in comment do we use slower regex
                         if trigger_word in comment["text"]:
                             m = re.findall(regexes[i], comment["text"])
                             found_ids.update(m)

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -90,6 +90,7 @@ class Config:
             "BugzillaComponent": "kernel",
             "BugzillaTriggerWords": "",
             "BugzillaRegExes": "",
+            "BugzillaQueryLastChangeDelta": 168,
             "ProcessCommunicateTimeout": 3600,
             "KernelDebuggerPath": "/usr/bin/crash",
         }


### PR DESCRIPTION
…bugs

Set the 'limit' option to bzapi.build_query() function to ensure we
are not artificially limited to a small default number of bugs.
Note the 'limit' option is new in python-bugzilla 3.1.0.
In production we were seeing an artificial limit of 20 bugs get
queried without setting this option.  If we ever meet our defined
limit of 1000 bugs in the query this means we probably did not
query all bugs.

In addition, cut down on the number of bugs in the query by only
querying those with recent modification times.  Here we pick 7 days,
somewhat arbitrarily, but with the understanding that the cronjob
that runs bugzilla-query should be run at least once per week.  We
can look at only the recently modified bugs because we are looking
for additions of retrace-server task strings in the bug comment
text.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>