### PR TITLE
Add logic to determine if we save a stripped vmcore

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -128,6 +128,10 @@ KernelDebuginfoURL = http://kojipkgs.fedoraproject.org/packages/$BASENAME/$VERSI
 # Run makedumpfile with specified dumplevel; <= 0 or >= 32 means disabled
 VmcoreDumpLevel = 0
 
+# Percentage of space a stripped vmcore has to save for us to replace
+# the old vmcore with the new vmcore created by makedumpfile
+VmcoreDumpSavePercent = 10
+
 # EXPERIMENTAL! Use ABRT Server's storage to map build-ids
 # into debuginfo packages and resolve dependencies
 # Requires support from ABRT Server

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -71,6 +71,7 @@ class Config:
             "WgetKernelDebuginfos": False,
             "KernelDebuginfoURL": "http://kojipkgs.fedoraproject.org/packages/kernel/$VERSION/$RELEASE/$ARCH/",
             "VmcoreDumpLevel": 0,
+            "VmcoreDumpSavePercent": 10,
             "RequireGPGCheck": True,
             "UseCreaterepoUpdate": False,
             "DBFile": "stats.db",

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -2125,14 +2125,16 @@ class KernelVMcore:
             if newvmcore.is_file():
                 newvmcore.unlink()
             return 
-
-        #Calculate the % of storage space saved with the new makedumpfile core created. 
-        elif ((oldsize - newvmcore.stat().st_size) / int(oldsize) * 100 < CONFIG["VmcoreDumpSavePercent"]):
-            log_warn("makedumpfile did not strip enough pages (needed to save %{}). 
-                    Not saving new vmcore.".format(CONFIG["VmcoreDumpSavePercent"]))
-            format_number = "{:.2f}".format((int(oldsize) - int(newvmcore.stat().st_size)) / int(oldsize) * 100)
-            log_info("Percentage of space that would have been saved if we kept the stripped vmcore 
-                    is: %s" % format_number)
+        # Calculate the % of storage space saved with the new makedumpfile core created
+        if ((oldsize - newvmcore.stat().st_size) / oldsize * 100  
+            < CONFIG["VmcoreDumpSavePercent"]):
+            duration = int(time.time() - start)
+            log_warn("makedumpfile did not strip enough pages (needed to save at least "
+                     "{}%). Not saving new vmcore.".format(CONFIG["VmcoreDumpSavePercent"]))
+            saved_pct = (oldsize - newvmcore.stat().st_size) / oldsize * 100
+            log_info("makedumpfile took {} seconds. Would have saved {:.2f}% (or {}) "
+                     "if we kept the stripped vmcore.".format(duration, saved_pct,
+                     human_readable_size(oldsize - newvmcore.stat().st_size)))
         else:
             # makedumpfile did strip enough pages so save the new core
             newvmcore.rename(self._vmcore_path)
@@ -2141,7 +2143,6 @@ class KernelVMcore:
             log_info("Stripped size: %s" % human_readable_size(newsize))
             log_info("Makedumpfile took %d seconds and saved %s"
                      % (dur, human_readable_size(oldsize - newsize)))
-        return
 
 
     #

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -784,7 +784,6 @@ class RetraceWorker:
             log_info("Converted size: %s" % human_readable_size(newsize))
             log_info("Makedumpfile took %d seconds and saved %s"
                      % (dur, human_readable_size(oldsize - newsize)))
-            oldsize = newsize
 
         if custom_kernelver is not None:
             kernelver = custom_kernelver

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -994,14 +994,7 @@ class RetraceWorker:
 
         if vmcore.has_extra_pages(task):
             log_info("Executing makedumpfile to strip extra pages")
-            start = time.time()
-            # NOTE: We need to know the kernelver and vmlinux path here
             vmcore.strip_extra_pages()
-            dur = int(time.time() - start)
-            newsize = vmcore_path.stat().st_size
-            log_info("Stripped size: %s" % human_readable_size(newsize))
-            log_info("Makedumpfile took %d seconds and saved %s"
-                     % (dur, human_readable_size(oldsize - newsize)))
 
         if vmcore_path.is_file():
             st = vmcore_path.stat()


### PR DESCRIPTION
Currently we do not check to see if running makedumpfile and creating a stripped vmcore is actually worthwhile. In some situations we may see little to no benefit to stripping down a vmcore and replacing the original with the newly stripped vmcore. For those situation, this patch adds the config variable SpaceSavePercent which is meant to indicate the percentage of space a stripped vmcore will need to save for us to choose to save it in place of the original. The proposed default is 10%. This patch also adjusts the logic so that the relevant message about makedumpfile will be printed (i.e. if makedumpfile is not run or we don't use the stripped vmcore from makedumpfile we do not print how much space we saved).

Signed-off-by: Audra Mitchell <aubaker@redhat.com> #445 