### PR TITLE
meson: Copy spec file to build directory

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,4 +38,5 @@ jobs:
           directory: ./build
           fail_ci_if_error: true
           flags: unittests
+          root_dir: .
           verbose: true

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('retrace-server', license : 'GPL2+', meson_version : '>= 0.49.0', version : '1.24.0')
+project('retrace-server', license : 'GPL2+', meson_version : '>= 0.59.0', version : '1.24.0')
 
 bindir = get_option('bindir')
 datadir = get_option('datadir')

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,8 @@ datadir = get_option('datadir')
 mandir = get_option('mandir')
 sysconfdir = get_option('sysconfdir')
 
+spec_name = '@0@.spec'.format(meson.project_name())
+
 i18n = import('i18n')
 python = import('python')
 
@@ -48,6 +50,14 @@ subdir('man')
 subdir('po')
 subdir('src')
 subdir('test')
+
+# Copy the spec file to the build directory so that Tito can run inside it to build
+# the rpm and srpm targets (below).
+configure_file(
+  copy: true,
+  input: spec_name,
+  output: spec_name,
+)
 
 # This will, naturally, fail if the build directory is outside the git repo,
 # since Tito does not provide a way to specify the working directory or the spec

--- a/retrace-server.spec
+++ b/retrace-server.spec
@@ -23,7 +23,7 @@ BuildRequires: coreutils
 BuildRequires: gettext
 BuildRequires: gzip
 BuildRequires: lsof
-BuildRequires: meson
+BuildRequires: meson >= 0.59.0
 # /usr/bin/ps from procps-ng is used to monitor running workers.
 BuildRequires: procps-ng
 BuildRequires: python3-devel

--- a/src/retrace/meson.build
+++ b/src/retrace/meson.build
@@ -3,14 +3,14 @@ subdir('hooks')
 
 configuration = configuration_data()
 
-configuration.set('CREATEREPO_BIN', createrepo.path())
-configuration.set('DF_BIN', df.path())
-configuration.set('GZIP_BIN', gzip.path())
-configuration.set('LSOF_BIN', lsof.path())
-configuration.set('PODMAN_BIN', podman.path())
-configuration.set('PS_BIN', ps.path())
-configuration.set('TAR_BIN', tar.path())
-configuration.set('XZ_BIN', xz.path())
+configuration.set('CREATEREPO_BIN', createrepo.full_path())
+configuration.set('DF_BIN', df.full_path())
+configuration.set('GZIP_BIN', gzip.full_path())
+configuration.set('LSOF_BIN', lsof.full_path())
+configuration.set('PODMAN_BIN', podman.full_path())
+configuration.set('PS_BIN', ps.full_path())
+configuration.set('TAR_BIN', tar.full_path())
+configuration.set('XZ_BIN', xz.full_path())
 
 sources = [
   '__init__.py',

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,11 +1,5 @@
-# TODO: build_root() is deprecated since Meson 0.56.0. Port to
-# project_build_root() once the version lands in all supported
-# releases.
-build_dir = meson.build_root()
-# TODO: source_root() is deprecated since Meson 0.56.0. Port to
-# project_source_root() once the version lands in all supported
-# releases.
-source_dir = meson.source_root()
+build_dir = meson.project_build_root()
+source_dir = meson.project_source_root()
 
 test_env = environment()
 test_env.set('PYTHONPATH',


### PR DESCRIPTION
Make sure the spec file is in the build directory so that Tito can run the `rpm` and `srpm` targets.