### PR TITLE
retrace-server-interact: Fix traceback for non-existent gid

### DIFF
--- a/src/retrace-server-interact
+++ b/src/retrace-server-interact
@@ -28,7 +28,13 @@ def print_cmdline(cmd_line: List[str]):
     sys.stderr.write("$ %s\n\n" % list2cmdline(cmd_line))
 
 if __name__ == "__main__":
-    groups = [grp.getgrgid(g).gr_name for g in os.getgroups()]
+    groups = []
+    for g in os.getgroups():
+        try:
+            group = grp.getgrgid(g)
+            groups.append(group.gr_name)
+        except KeyError:
+            pass
     if not CONFIG["AuthGroup"] in groups:
         sys.stderr.write("You must be a member '%s' group in order to use "
                          "interactive debugging.\n" % CONFIG["AuthGroup"])


### PR DESCRIPTION
Its possible for a user to be in a group that does not have a name.
In this case retrace-server-interact will Traceback something like
the following
 Traceback (most recent call last):
   File "/usr/bin/retrace-server-interact", line 31, in <module>
     groups = [grp.getgrgid(g).gr_name for g in os.getgroups()]
   File "/usr/bin/retrace-server-interact", line 31, in <listcomp>
     groups = [grp.getgrgid(g).gr_name for g in os.getgroups()]
 KeyError: 'getgrgid(): gid not found: 12345'

Fix this by ensuring we don't assume the group database will
have an entry for each gid, in which case getgrgid() will raise
KeyError.  If this happens, catch the exception and just skip
over the gid.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>