### PR TITLE
retrace: Re-use ProcessCommunicateTimeout with makedumpfile

### DIFF
--- a/src/config/retrace-server.conf
+++ b/src/config/retrace-server.conf
@@ -177,7 +177,8 @@ BugzillaRegExes = retrace-server-interact\\s+([0-9]{9}), /var/spool/retrace-serv
 BugzillaQueryLastChangeDelta = 168
 
 # Timeout (in seconds) for communication with any process
-ProcessCommunicateTimeout = 3600
+# Default: 12 hours
+ProcessCommunicateTimeout = 43200
 
 # Path to the kernel (vmcore) debugger
 KernelDebuggerPath = /usr/bin/crash

--- a/src/manager.wsgi
+++ b/src/manager.wsgi
@@ -225,7 +225,7 @@ def application(environ, start_response):
         if not task.has_results(match.group(9)):
             return response(start_response, "404 Not Found", _("There is no such record"))
 
-        return response(start_response, "200 OK", task.get_results(match.group(9)).decode('utf-8','ignore'))
+        return response(start_response, "200 OK", task.get_results(match.group(9)).decode("utf-8",'ignore'))
 
     elif match.group(6) and match.group(6) == "start":
         # start

--- a/src/retrace-server-cleanup
+++ b/src/retrace-server-cleanup
@@ -60,7 +60,7 @@ def check_open_crash_file(retrace_task: RetraceTask) -> bool:
     else:
         return False
 
-    lsof = run([LSOF_BIN, "+wt", crash_path], stdout=PIPE, check=False, encoding='utf-8')
+    lsof = run([LSOF_BIN, "+wt", crash_path], stdout=PIPE, check=False, encoding="utf-8")
     pids = lsof.stdout
 
     if pids:

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -91,7 +91,7 @@ class Config:
             "BugzillaTriggerWords": "",
             "BugzillaRegExes": "",
             "BugzillaQueryLastChangeDelta": 168,
-            "ProcessCommunicateTimeout": 3600,
+            "ProcessCommunicateTimeout": 43200,
             "KernelDebuggerPath": "/usr/bin/crash",
         }
 

--- a/src/retrace/hooks/hooks.py
+++ b/src/retrace/hooks/hooks.py
@@ -97,7 +97,7 @@ class RetraceHook:
 
         try:
             child = run(cmd, shell=True, timeout=hook_timeout, cwd=hook_path,
-                        stdout=PIPE, stderr=PIPE, encoding='utf-8', check=True)
+                        stdout=PIPE, stderr=PIPE, encoding="utf-8", check=True)
         except TimeoutExpired as ex:
             if ex.stdout:
                 log_info(ex.stdout)

--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -288,7 +288,7 @@ def get_canon_arch(arch: str) -> str:
 
 
 def guess_arch(coredump_path: Path) -> Optional[str]:
-    output = run(["file", str(coredump_path)], stdout=PIPE, encoding='utf-8',
+    output = run(["file", str(coredump_path)], stdout=PIPE, encoding="utf-8",
                  check=False).stdout
     match = CORE_ARCH_PARSER.search(output)
     if match:
@@ -313,7 +313,7 @@ def guess_arch(coredump_path: Path) -> Optional[str]:
 
     result = None
     lines = run(["strings", str(coredump_path)],
-                stdout=PIPE, stderr=STDOUT, encoding='utf-8',
+                stdout=PIPE, stderr=STDOUT, encoding="utf-8",
                 check=False).stdout.splitlines()
     for line in lines:
         for canon_arch, derived_archs in ARCH_MAP.items():
@@ -355,7 +355,7 @@ def run_gdb(savedir: Path, repopath: str, taskid: int, image_tag: str,
     if CONFIG["RetraceEnvironment"] == "mock":
         output = run(["/usr/bin/mock", "chroot", "--configdir", savedir,
                       "--", "ls '%s'" % executable],
-                     stdout=PIPE, stderr=DEVNULL, encoding='utf-8',
+                     stdout=PIPE, stderr=DEVNULL, encoding="utf-8",
                      check=False).stdout
         if output.strip() != executable:
             raise Exception("The appropriate package set could not be installed")
@@ -741,7 +741,7 @@ def get_active_tasks() -> List[int]:
 
 
 def check_run(cmd: List[str]) -> None:
-    child = run(cmd, stdout=PIPE, stderr=STDOUT, encoding='utf-8', check=False)
+    child = run(cmd, stdout=PIPE, stderr=STDOUT, encoding="utf-8", check=False)
     stdout = child.stdout
     if child.returncode:
         raise Exception("%s exited with %d: %s" % (cmd[0], child.returncode, stdout))
@@ -1100,7 +1100,7 @@ class RetraceTask:
             return None
 
         filename = self._get_file_path(key)
-        with open(filename, "r", encoding='utf-8', errors='replace') as f:
+        with open(filename, "r", encoding="utf-8", errors='replace') as f:
             result = f.read(maxlen)
 
         return result
@@ -1367,7 +1367,7 @@ class RetraceTask:
 
         try:
             if cmd_output is not None:
-                cmd_output.decode('utf-8')
+                cmd_output.decode("utf-8")
         except UnicodeDecodeError as err:
             log_warn("crash command: '%s' triggered UnicodeDecodeError " %
                      crash_cmdline.replace('\r', '; ').replace('\n', '; '))
@@ -1466,7 +1466,7 @@ class RetraceTask:
                     continue
 
                 child = run(["wget", "-nv", "-P", str(crashdir), url],
-                            stdout=PIPE, stderr=STDOUT, encoding='utf-8', check=False)
+                            stdout=PIPE, stderr=STDOUT, encoding="utf-8", check=False)
                 stdout = child.stdout
                 if child.returncode:
                     errors.append((url, "wget exited with %d: %s" % (child.returncode, stdout)))
@@ -2057,7 +2057,7 @@ class KernelVMcore:
         log_info("Executing makedumpfile to obtain dump level")
         try:
             lines = run(cmd, stdout=PIPE, stderr=DEVNULL,
-                        encoding='utf-8', timeout=timeout,
+                        encoding="utf-8", timeout=timeout,
                         check=False).stdout.splitlines()
         except TimeoutExpired:
             log_error("Command: '{}' exceeded {} second timeout - "
@@ -2178,7 +2178,7 @@ class KernelVMcore:
         save = getsignal(SIGPIPE)
         signal(SIGPIPE, SIG_DFL)
         child = run(crash_cmd + ["--osrelease", str(core_path)],
-                    stdout=PIPE, stderr=STDOUT, encoding='utf-8', check=False)
+                    stdout=PIPE, stderr=STDOUT, encoding="utf-8", check=False)
         release = child.stdout.strip()
         ret = child.returncode
         signal(SIGPIPE, save)
@@ -2215,7 +2215,7 @@ class KernelVMcore:
                 if release:
                     release = release.group(0)
             if release:
-                release = release.decode('utf-8')
+                release = release.decode("utf-8")
 
         # Clean up the release before returning or calling KernelVer
         if release is None or release == "unknown":
@@ -2322,7 +2322,7 @@ class KernelVMcore:
         vmlinux_path = None
         debugfiles = {}
         lines = run(["rpm", "-qpl", str(debuginfo)],
-                    stdout=PIPE, stderr=DEVNULL, encoding='utf-8', check=False).stdout.splitlines()
+                    stdout=PIPE, stderr=DEVNULL, encoding="utf-8", check=False).stdout.splitlines()
         for line in lines:
             if line.endswith(pattern):
                 vmlinux_path = line
@@ -2380,7 +2380,7 @@ class KernelVMcore:
             return vmlinux
 
         modules = []
-        for line in stdout.decode('utf-8').splitlines():
+        for line in stdout.decode("utf-8").splitlines():
             # skip header
             if "NAME" in line:
                 continue

--- a/src/retrace/retrace_worker.py
+++ b/src/retrace/retrace_worker.py
@@ -189,7 +189,7 @@ class RetraceWorker:
     def _retrace_run(self, errorcode: int, cmd: List[str]) -> str:
         "Runs cmd using subprocess.Popen and kills script with errorcode on failure"
         try:
-            child = run(cmd, stdout=PIPE, stderr=STDOUT, encoding='utf-8', check=False)
+            child = run(cmd, stdout=PIPE, stderr=STDOUT, encoding="utf-8", check=False)
             output = child.stdout
         except Exception as ex:
             child = None
@@ -356,7 +356,7 @@ class RetraceWorker:
                              f"--repos={repoid}",
                              f"--config={dnfcfgpath}",
                              "--log=%s" % (self.task.get_savedir() / "c2p_log")],
-                            stdout=PIPE, stderr=PIPE, encoding='utf-8', check=False)
+                            stdout=PIPE, stderr=PIPE, encoding="utf-8", check=False)
                 section = 0
                 lines = child.stdout.split("\n")
                 libdb = False
@@ -505,7 +505,7 @@ class RetraceWorker:
                 log_debug("Using FAF repository")
                 build_call.append("--volume={0}:{0}:ro".format(CONFIG["FafLinkDir"]))
 
-            child = run(build_call, stdout=sys.stderr, stderr=PIPE, encoding='utf-8',
+            child = run(build_call, stdout=sys.stderr, stderr=PIPE, encoding="utf-8",
                         check=False)
 
             if child.returncode:
@@ -877,7 +877,7 @@ class RetraceWorker:
                 os.umask(old_umask)
 
             child = run(["/usr/bin/mock", "--configdir", str(cfgdir), "init"],
-                        stdout=PIPE, stderr=PIPE, encoding='utf-8', check=False)
+                        stdout=PIPE, stderr=PIPE, encoding="utf-8", check=False)
             stderr = child.stderr
             if child.returncode:
                 raise Exception("mock exited with %d:\n%s" % (child.returncode, stderr))

--- a/src/retrace/util.py
+++ b/src/retrace/util.py
@@ -232,7 +232,7 @@ def unpack(archive: str, mime: str, targetdir: Optional[str] = None) -> int:
 
 def unpacked_size(archive: str, mime: str) -> Optional[int]:
     command, parser = HANDLE_ARCHIVE[mime]["size"]
-    lines = run(command + [archive], stdout=PIPE, encoding='utf-8', check=False).stdout.split("\n")
+    lines = run(command + [archive], stdout=PIPE, encoding="utf-8", check=False).stdout.split("\n")
     for line in lines:
         match = parser.match(line)
         if match:


### PR DESCRIPTION
As https://bugzilla.redhat.com/show_bug.cgi?id=2049284 explains,
makedumpfile can infinite loop similar to what has previously
happened with crash.  With makedumpfile, such a loop can have
impacts beyond just CPU usage, and as was seen in the above bug,
all free disk space may fill up and thus have larger impacts.

To resolve this issue, first, re-use the same config setting,
CONFIG["ProcessCommunicateTimeout"], for makedumpfile as we
did for crash in commit becb40663a003.  Second, increase the
default value of CONFIG["ProcessCommunicateTimeout"] to reflect
a more realistic "worst case" valid runtime.  In production we
have seen makedumpfile may run up to 6 hours on some larger
vmcores.  Given various filesystems performance characteristics
and to add some margin, set the default of
CONFIG["ProcessCommunicateTimeout"] to 43200 seconds (12 hours).
Finally, improve logging to reflect both when makedumpfile
starts running as well as if a timeout occurs.

Resolves: https://github.com/abrt/retrace-server/issues/455
Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>