### PR TITLE
manager: Prevent double submit of vmcore or coredump tasks

### DIFF
--- a/src/manager_usrcore_task_form.xhtml
+++ b/src/manager_usrcore_task_form.xhtml
@@ -1,6 +1,6 @@
 <div id="usrcore-wrapper">
     <h2>Create coredump task (userspace memory dump)</h2>
-    <form method="post" action="{create_custom_url}" id="custom">
+    <form method="post" action="{create_custom_url}" id="custom" onsubmit="createButton.disabled = true; return true;">
             <div>
                 <span class="formsubhead">Package:</span>
                 <input type="text" name="package" />
@@ -34,6 +34,6 @@
                 <input type="hidden" name="task_type" value="coredump">
             </div>
 
-            <input type="submit" value="Create coredump task" class="submit" />
+            <input type="submit" name="createButton" value="Create coredump task" class="submit" />
     </form>
 </div>

--- a/src/manager_vmcore_task_form.xhtml
+++ b/src/manager_vmcore_task_form.xhtml
@@ -1,6 +1,6 @@
 <div id="vmcore-wrapper">
     <h2>Create vmcore task (kernel memory dump)</h2>
-    <form method="post" action="{create_custom_url}" id="custom">
+    <form method="post" action="{create_custom_url}" id="custom" onsubmit="createButton.disabled = true; return true;">
             <span class="formsubhead">Kernel version:</span>
             <input type="text" name="kernelver" />
             <span>(e.g. 2.6.32-287.el6.x86_64, empty to autodetect)</span>
@@ -32,7 +32,7 @@
                 <span>(Any URL that wget can download or a local path, e.g. file:///foo/bar or just /foo/bar)</span>
                 <input type="text" name="custom_vmem_url" class="url" />
             </div>
-            <input type="submit" value="Create vmcore task" class="submit" />
+            <input type="submit" name="createButton" value="Create vmcore task" class="submit" />
     </form>
 
     <script type="text/javascript">


### PR DESCRIPTION
The POST actions on the manager page to submit a custom vmcore
or coredump should be protected from double clicks which can
cause tasks to be created but never started and end up stuck
in "available" state.  Fix this by disabling the button on
submission.

Fixes: https://github.com/abrt/retrace-server/issues/446

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>