### PR TITLE
config: Add support for RAR archives if the unar tool is installed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,10 @@ tito = find_program('tito',
   required: false,
   disabler: true,
 )
+unar = find_program('unar',
+  required: false,
+  disabler: true,
+)
 xmlto = find_program('xmlto',
   required: get_option('docs'),
   disabler: true,

--- a/retrace-server.spec
+++ b/retrace-server.spec
@@ -86,6 +86,7 @@ Recommends: httpd
 Recommends: logrotate
 Recommends: rpm
 Suggests: podman
+Suggests: unar
 
 Obsoletes: abrt-retrace-server < 2.0.3
 Provides: abrt-retrace-server = 2.0.3

--- a/src/retrace/config.py.in
+++ b/src/retrace/config.py.in
@@ -20,6 +20,7 @@ LSOF_BIN = "@LSOF_BIN@"
 PODMAN_BIN = "@PODMAN_BIN@"
 PS_BIN = "@PS_BIN@"
 TAR_BIN = "@TAR_BIN@"
+UNAR_BIN = "@UNAR_BIN@"
 XZ_BIN = "@XZ_BIN@"
 
 Getter = Union[Callable[[str, str], int],

--- a/src/retrace/meson.build
+++ b/src/retrace/meson.build
@@ -10,6 +10,7 @@ configuration.set('LSOF_BIN', lsof.path())
 configuration.set('PODMAN_BIN', podman.path())
 configuration.set('PS_BIN', ps.path())
 configuration.set('TAR_BIN', tar.path())
+configuration.set('UNAR_BIN', unar.path())
 configuration.set('XZ_BIN', xz.path())
 
 sources = [


### PR DESCRIPTION
If 'unar' tool is installed we can extract 'rar' archives, which
is a rare, but not non-existent, archive type.

Make this an optional install for meson to prevent build failures.
If not installed, but a RAR archive is submitted, the task will
fail with something like the following in retrace_log:
 [D] File type: rar archive data, v4, os: win32
 [D] rar detected
 [W] [Errno 2] No such file or directory: 'unar': 'unar'

Resolves: https://github.com/abrt/retrace-server/issues/465
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1457434
Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>