### PR TITLE
retrace: Fix Traceback if user's home directory is unavailable

### DIFF
--- a/src/retrace/hooks/config.py
+++ b/src/retrace/hooks/config.py
@@ -42,11 +42,17 @@ def load_hook_config() -> Dict[str, str]:
     main_hook_config_file = Path(MAIN_CONFIG_PATH, MAIN_HOOK_CONFIG_FILE)
     hook_configs.append(main_hook_config_file)
 
-    if USER_HOOK_CONFIGS_PATH.exists():
-        hook_configs += get_config_files(USER_HOOK_CONFIGS_PATH)
+    try:
+        if USER_HOOK_CONFIGS_PATH.exists():
+            hook_configs += get_config_files(USER_HOOK_CONFIGS_PATH)
+    except Exception as ex:
+        log_warn(f"USER_HOOK_CONFIGS_PATH {USER_HOOK_CONFIGS_PATH} does not exist: {ex}")
 
-    if USER_CONFIG_PATH.exists():
-        hook_configs.append(USER_CONFIG_PATH)
+    try:
+        if USER_CONFIG_PATH.exists():
+            hook_configs.append(USER_CONFIG_PATH)
+    except Exception as ex:
+        log_warn(f"USER_CONFIG_PATH {USER_CONFIG_PATH} does not exist: {ex}")
 
     cfgs = load_config_files(hook_configs)
 


### PR DESCRIPTION
We had an instance in production where a user's home directory was unable
to be accessed and returned "permission denied".  This also had the effect
of a Traceback if a user tried "retrace-server-task create" or even
"retrace-server-interact", since the hooks path failed with permission
denied per below.  Fix the Traceback by wrapping pathlib.exist() checks
in try .. except clauses.

Before the patch:
$ retrace-server-interact 846035327 crash
Traceback (most recent call last):
  File "/usr/bin/retrace-server-interact", line 12, in <module>
    from retrace.retrace import (ALLOWED_FILES,
  File "/usr/lib/python3.6/site-packages/retrace/__init__.py", line 18, in <module>
    from . import retrace_worker
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 16, in <module>
    from .hooks.hooks import RetraceHook
  File "/usr/lib/python3.6/site-packages/retrace/hooks/__init__.py", line 3, in <module>
    from . import hooks
  File "/usr/lib/python3.6/site-packages/retrace/hooks/hooks.py", line 11, in <module>
    from .config import HOOK_PATH, HOOK_TIMEOUT, hooks_config
  File "/usr/lib/python3.6/site-packages/retrace/hooks/config.py", line 56, in <module>
    hooks_config = load_hook_config()
  File "/usr/lib/python3.6/site-packages/retrace/hooks/config.py", line 45, in load_hook_config
    if USER_HOOK_CONFIGS_PATH.exists():
  File "/usr/lib64/python3.6/pathlib.py", line 1336, in exists
    self.stat()
  File "/usr/lib64/python3.6/pathlib.py", line 1158, in stat
    return self._accessor.stat(self)
  File "/usr/lib64/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
PermissionError: [Errno 13] Permission denied: '/home/foo/user/.config/retrace-server/hooks'

After the patch:
$ retrace-server-interact 279216098 crash
USER_HOOK_CONFIGS_PATH /home/foo/.config/retrace-server/hooks does not exist: [Errno 13] Permission denied: '/home/foo/.config/retrace-server/hooks'
USER_CONFIG_PATH /home/foo/.config/retrace-server does not exist: [Errno 13] Permission denied: '/home/foo/.config/retrace-server'
If you want to execute the command manually, you can run
$ crash -i /cores/retrace/tasks/789215099/crashrc /cores/retrace/tasks/789215099/crash/vmcore /cores/retrace/repos/kernel/x86_64/usr/lib/debug/lib/modules/4.18.0-80.el8.x86_64/vmlinux
...

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>