### PR TITLE
retrace-server-task: Add exception handling for SSLError

### DIFF
--- a/src/retrace-server-task
+++ b/src/retrace-server-task
@@ -707,6 +707,12 @@ if __name__ == "__main__":
             sys.exit(1)
         if req.status_code != 200:
             raise requests.exceptions.ConnectionError
+    except requests.exceptions.SSLError as ex:
+        if "debug" in ARGS:
+            LOGGER.error("SSLError: '%s'", str(ex))
+        LOGGER.error("SSL error connecting to {}: try adding '-v' to see details"
+                     " or '--no-verify' for an expired certificate.".format(ARGS["server"]))
+        sys.exit(1)
     except requests.exceptions.RequestException as ex:
         if "debug" in ARGS:
             LOGGER.error("Requests generic exception: '%s'", str(ex))


### PR DESCRIPTION
It's not uncommon in production to have a certificate expire, and when that happens we use the FAILBACK_SERVER, but this is unlikely to be what the user wants.

This patch catches the error and gives the user possible next steps to avoid the error, similar to earlier commit cf85a18c1b29.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>