### PR TITLE
stats: Fix Releases counting by using wildcard at end and add el9

### DIFF
--- a/src/plugins/centos.py
+++ b/src/plugins/centos.py
@@ -15,5 +15,6 @@ versionlist = [
     "el6",
     "el7",
     "el8",
+    "el9",
 ]
 repos: List[List[str]] = [[]]

--- a/src/plugins/rhel.py
+++ b/src/plugins/rhel.py
@@ -21,5 +21,6 @@ versionlist = [
     "el6",
     "el7",
     "el8",
+    "el9",
 ]
 repos: List[List[str]] = [[]]

--- a/src/stats.wsgi
+++ b/src/stats.wsgi
@@ -111,7 +111,7 @@ def application(environ, start_response):
     tablerows = []
     i = 1
     for key in versions.keys():
-        query.execute("SELECT COUNT(*) FROM tasks WHERE version LIKE '%"+key+"'")
+        query.execute("SELECT COUNT(*) FROM tasks WHERE version LIKE '%"+key+"%'")
         row = query.fetchone()
         retstr = str(versions[key]) + " " + str(key[2:])
 


### PR DESCRIPTION
The stats database has a 'version' field which records the version of the package.  The value of this field though may not end in the any of the strings listed in the plugins though.  For the kernel, the 'arch' value is included at the end of the value.  Also, for any z-stream package versions include the minor (Y) version after the major (X) version (for example, "el8_2" for a 8.2.0.z package). Fix these issues by using a wildcard at the end of the database query string.

In addition, add 'el9' to the 'rhel' and 'centos' plugins.

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>