### PR TITLE
retrace: Fix Traceback if getgrpnam() fails and fail task if chgrp fails

### DIFF
--- a/src/retrace/retrace.py
+++ b/src/retrace/retrace.py
@@ -763,11 +763,11 @@ class RetraceTask:
         return child.returncode
 
     def chgrp(self, key: Union[str, Path]) -> None:
-        gr = grp.getgrnam(CONFIG["AuthGroup"])
         try:
+            gr = grp.getgrnam(CONFIG["AuthGroup"])
             os.chown(self._get_file_path(key), -1, gr.gr_gid)
-        except OSError:
-            pass
+        except (OSError, KeyError) as ex:
+            raise ex
 
     def chmod(self, key: Union[str, Path]) -> None:
         mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH


### PR DESCRIPTION
If AuthGroup is set in the config but getgrnam() fails for some reason (such as a network or server error) the below Traceback will occur.  Fix this by catching KeyError and handling the same as with OSError in chgrp.

Also if chrgrp fails, we don't want to continue so raise an exception here which should fail the task.

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 1102, in start
    errors = task.download_remote()
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 1199, in download_remote
    self.set_md5sum("\n".join(md5sums)+"\n")
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 1439, in set_md5sum
    self.set(RetraceTask.MD5SUM_FILE, value)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 785, in set
    self.chgrp(key)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 766, in chgrp
    gr = grp.getgrnam(CONFIG["AuthGroup"])
KeyError: "getgrnam(): name not found: 'my-auth-group'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/retrace-server-worker", line 85, in <module>
    worker.start(kernelver=kernelver, arch=cmdline.arch)
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 1138, in start
    self._fail()
  File "/usr/lib/python3.6/site-packages/retrace/retrace_worker.py", line 171, in _fail
    task.set_status(STATUS_FAIL)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 932, in set_status
    self.set_atomic(RetraceTask.STATUS_FILE, "%d" % statuscode)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 806, in set_atomic
    self.chgrp(key)
  File "/usr/lib/python3.6/site-packages/retrace/retrace.py", line 766, in chgrp
    gr = grp.getgrnam(CONFIG["AuthGroup"])
KeyError: "getgrnam(): name not found: 'my-auth-group'"

Signed-off-by: Dave Wysochanski <dwysocha@redhat.com>