### PR TITLE
retrace: Remove low value 'not an archive' message for vmcores

### DIFF
--- a/src/retrace/archive.py
+++ b/src/retrace/archive.py
@@ -238,7 +238,6 @@ def unpack_vmcore(path: Path) -> None:
         try:
             extract_into(archive, parentdir)
         except UnknownArchiveTypeError:
-            log_info(f"File {archive} is not an archive")
             break
 
         files_sizes = get_files_sizes(parentdir)


### PR DESCRIPTION
The message to log 'not an archive' is of little to no value. In our production system we see this logged for every vmcore so it just takes up log space.  Also there is no message logged for coredumps so remove this message for vmcores.